### PR TITLE
fix(tests): add Windows compatibility to file permission validation

### DIFF
--- a/tests/unit/test_did_extension.py
+++ b/tests/unit/test_did_extension.py
@@ -292,11 +292,19 @@ class TestDIDAgentExtension:
 
     def test_file_permissions(self, did_extension):
         """Test that private key has correct file permissions."""
-        did_extension.generate_and_save_key_pair()
-
-        # Check private key permissions (should be 0o600)
+        import platform
         import stat
 
+        did_extension.generate_and_save_key_pair()
+
+        # Skip permission checks on Windows - they don't apply
+        if platform.system() == "Windows":
+            # On Windows, just verify files exist and are readable
+            assert did_extension.private_key_path.exists()
+            assert did_extension.public_key_path.exists()
+            return
+
+        # On Unix-like systems, check permissions
         private_key_stat = did_extension.private_key_path.stat()
         private_key_mode = stat.S_IMODE(private_key_stat.st_mode)
         assert private_key_mode == 0o600


### PR DESCRIPTION
fix(tests): add Windows compatibility to file permission validation

## Summary
Make the test_file_permissions test work correctly on both Windows and Unix systems by adding platform-specific handling.

## Problem
The test was failing on Windows because it was checking for Unix-style file permissions (0o600), but Windows uses a different permission system (ACLs).

## Solution
- **Windows**: Skip permission mode checks (just verify files exist)
- **Unix**: Continue checking for secure permissions (0o600 for private key, 0o644 for public key)

## Changes
**Modified**: `tests/unit/test_did_extension.py`

## Testing
- All 507 tests pass
- Test now works on both Windows and Unix
- Maintains security verification for Unix deployments