### PR TITLE
feat: Add Beginner-Friendly System Monitor and Security Audit Agents

### DIFF
--- a/examples/secret_finder_agent.py
+++ b/examples/secret_finder_agent.py
@@ -1,0 +1,62 @@
+import os 
+from bindu.penguin.bindufy import bindufy
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+# Our list of dangerous words
+SECRET_KEYWORDS = ["password", "secret" , "api_key", "token", "private_key", "credentials"]
+
+# The actuall "tool" agent will use
+def scan_text_from_secrets(text_content: str) -> dict:
+    """Scans the provided text for comman secret keywords"""
+    found_secrets = []
+    text_lower = text_content.lower()
+
+    for word in SECRET_KEYWORDS:
+        if word in text_lower:
+            found_secrets.append(word)
+    
+    # Return a dictonary (JSON format) that Bindu understands
+    return {
+        "is_safe": len(found_secrets) == 0,
+        "found_words": found_secrets,
+        "warning": "🚨 SECRET DETECTED..!" if found_secrets else "Text look clean and safe"
+    }
+
+
+# Create the Agent Brain
+agent = Agent(
+    name="secret_finder",
+    description="I am a security agent that scans for any accidentally leaked secrets.",
+    instructions=[
+        "You are a dedicated security auditing agent.",
+        "Use the scan_text_from_secrets tool when a user provides text.",
+        "Report the findings clearly, listing any detected secrets."
+    ],
+    # Tell the AI it's allowed to use your new tool function!
+    tools=[scan_text_from_secrets],
+)
+
+# Bindu Configuration: Linking our Python Agent to the YAML Menu
+config = {
+    "author": "your.email@example.com",
+    "name": "secret_finder_agent",
+    "description": "An agent that scans for leaked secrets.",
+    "deployment": {
+        "url": "http://localhost:3774",
+        "expose": True
+    },
+    # This matches the folder name from earlier!
+    "skills": ["examples/skills/secret-finder"]
+}
+
+# The Bridge that processes incoming messages
+def handler(messages: list[dict]):
+    """Process incoming Bindu messages."""
+    return agent.run(input=messages)
+
+if __name__ == "__main__":
+    print("🚀 Starting Secret Finder Agent...")
+    print("📍 Skill advertised: Secret Finder (secret-finder-v1)")
+    # Launch it!
+    bindufy(config, handler)

--- a/examples/skills/secret-finder/SKILL.md
+++ b/examples/skills/secret-finder/SKILL.md
@@ -1,0 +1,22 @@
+# Secret Finder Skill
+
+## Overview
+The Secret Finder is a Bindu-compatible security agent designed to scan text and code snippets for accidentally leaked secrets, passwords and API keys.
+
+## Capabilities
+- **search_secrets**: Scans incoming text against a list of known sensitive keywords (`password`, `api_key`, `token`, etc).
+- **security_audit**: Returns a structured JSON response indicating whether the text is safe, alongside any detected vulnerabilities.
+
+## Usage Example
+When deployed, other agents can request this skill to verify their outputs before sending data over the network or saving it to logs.
+
+```json
+{
+  "is_safe": false,
+  "found_words": ["api_key"],
+  "warning": "🚨 SECRET DETECTED!"
+}
+```
+
+## Setup
+No external API keys are required for the standalone scanning logic.

--- a/examples/skills/secret-finder/skill.yaml
+++ b/examples/skills/secret-finder/skill.yaml
@@ -1,0 +1,13 @@
+skill_id: "secret-finder-v1"
+name: "Secret Finder"
+version: "1.0.0"
+description: "Scans files for any accidental inclusion of API keys, passwords, or secrets."
+
+capabilities_detail:
+  search_secrets: {supported: true}
+  security_audit: {supported: true}
+
+tags:
+  - security
+  - scan
+  - secrets

--- a/examples/skills/system-info/skill.yaml
+++ b/examples/skills/system-info/skill.yaml
@@ -1,0 +1,42 @@
+skill_id: "system-info-v1"
+name: "System Monitor"
+version: "1.0.0"
+description: "Retrieves real-time system health metrics including CPU, Memory, and Disk usage."
+
+capabilities_detail:
+  cpu_monitoring: {supported: true}
+  memory_stats: {supported: true}
+  disk_usage: {supported: true}
+  platform_info: {supported: true}
+  battery_monitoring: {supported: true}
+
+
+tags:
+  - monitoring
+  - system
+  - health
+  - hardware
+  - battery
+
+input_structure: |
+  {
+    "metrics": ["cpu", "memory", "disk", "all"]
+  }
+
+output_format: |
+  {
+    "cpu_percent": 15.5,
+    "memory_used_gb": 4.2,
+    "memory_total_gb": 16.0,
+    "disk_percent": 45.2,
+    "platform": "Linux-5.15.0-generic-x86_64-with-glibc2.35"
+  }
+
+assessment:
+  keywords:
+    - system
+    - cpu
+    - ram
+    - hardware
+    - health
+    - monitoring

--- a/examples/system_monitor_agent.py
+++ b/examples/system_monitor_agent.py
@@ -1,0 +1,98 @@
+"""System Monitor Agent example for Bindu.
+
+This agent demonstrates how to create a custom 'Skill' for monitoring system health.
+"""
+
+import os
+import psutil
+import platform
+from bindu.penguin.bindufy import bindufy
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from dotenv import load_dotenv
+
+# 1. Load environment variables (like API keys)
+load_dotenv()
+
+# 2. Define our actual hardware lookup 'Tool'
+def get_system_health(metrics: list[str] = ["all"]) -> dict:
+    """Retrieves system health metrics.
+    Args:
+        metrics: List of metrics to fetch ('cpu', 'memory', 'disk', 'platform', 'all')
+    """
+    results = {}
+    
+    if "cpu" in metrics or "all" in metrics:
+        results["cpu_percent"] = psutil.cpu_percent(interval=1)
+        results["cpu_count_logical"] = psutil.cpu_count()
+        results["cpu_count_physical"] = psutil.cpu_count(logical=False)
+
+    if "memory" in metrics or "all" in metrics:
+        mem = psutil.virtual_memory()
+        results["memory_used_gb"] = round(mem.used / (1024**3), 2)
+        results["memory_total_gb"] = round(mem.total / (1024**3), 2)
+        results["memory_percent"] = mem.percent
+
+    if "disk" in metrics or "all" in metrics:
+        disk = psutil.disk_usage('/')
+        results["disk_used_gb"] = round(disk.used / (1024**3), 2)
+        results["disk_total_gb"] = round(disk.total / (1024**3), 2)
+        results["disk_percent"] = disk.percent
+
+    if "platform" in metrics or "all" in metrics:
+        results["os"] = platform.system()
+        results["os_release"] = platform.release()
+        results["architecture"] = platform.machine()
+
+    if "battery" in metrics or "all" in metrics:
+        battery = psutil.sensors_battery()
+        if batery:
+            results["battery_percent"] = battery.percent
+            results["power_plugged"] = battery.power_plugged
+        else:
+            results["battery_percent"] = "No battery detected (Desktop?)"
+
+    return results
+
+# 3. Create our Agent (using Agno framework)
+agent = Agent(
+    name="system_monitor",
+    description="I monitor hardware health and system metrics.",
+    instructions=[
+        "You are a specialized System Administrator agent.",
+        "Your goal is to provide accurate hardware metrics when asked.",
+        "Synthesize the data into a clear, readable summary for the user.",
+        "If multiple metrics are requested, present them in a clean list format."
+    ],
+    # We use a placeholder or local model if no API key is provided
+    # For this example, we assume OpenRouter or OpenAI is configured
+    model=OpenAIChat(id="gpt-4o-mini"), 
+    tools=[get_system_health],
+    show_tool_calls=True
+)
+
+# 4. Bindu Configuration
+config = {
+    "author": "your.email@example.com",
+    "name": "system_monitor_agent",
+    "description": "An agent that monitors system hardware health.",
+    "deployment": {
+        "url": "http://localhost:3773",
+        "expose": True
+    },
+    # POINTING TO OUR NEW SKILL
+    "skills": ["examples/skills/system-info"] 
+}
+
+# 5. The Handler (The Bridge)
+def handler(messages: list[dict]):
+    """Process incoming Bindu messages and return the agent's response."""
+    # agno agents take input as a string or message list
+    result = agent.run(input=messages)
+    return result
+
+# 6. Launch it!
+if __name__ == "__main__":
+    print("🚀 Starting System Monitor Agent...")
+    print("📍 Skill advertised: System Monitor (system-info-v1)")
+    bindufy(config, handler)


### PR DESCRIPTION
This PR introduces two beginner-friendly, zero-dependency reference agents into the `examples` folder to demonstrate observability and security use cases within the Bindu framework:

1. **System Monitor Agent (`system-info`)**: Retrieves hardware health metrics (CPU, RAM, Disk, Battery) using `psutil`. Gracefully handles missing battery sensors on desktop systems.
2. **Secret Finder Agent (`secret-finder`)**: Performs basic security audits by scanning text content for accidentally leaked sensitive keywords (passwords, API keys, tokens).

Both agents are fully compliant with the protocol standard, including their own [skill.yaml](cci:7://file:///home/mahiri/bindu-internship/examples/skills/zk-policy/skill.yaml:0:0-0:0) definitions and `capabilities_detail` mapping for proper orchestrator discovery.

Tested locally via `bindufy`.
