### PR TITLE
feat(examples): add Agno-based medical chatbot agent

### DIFF
--- a/examples/medical_agent/.env.example
+++ b/examples/medical_agent/.env.example
@@ -1,0 +1,2 @@
+OPENROUTER_API_KEY=your_api_key_here
+BINDU_ID=your_agent_did_here

--- a/examples/medical_agent/.env.example
+++ b/examples/medical_agent/.env.example
@@ -1,2 +1,1 @@
 OPENROUTER_API_KEY=your_api_key_here
-BINDU_ID=your_agent_did_here

--- a/examples/medical_agent/agent.py
+++ b/examples/medical_agent/agent.py
@@ -34,9 +34,10 @@ agent_config = {
     "description": "A medical guidance agent built with Agno and Bindu",
     "version": "1.0.0",
     "deployment": {
-        "url": "http://localhost:3773",
-        "expose": True
-    }
+            "url": "http://localhost:3773",
+            "expose": True,
+            "cors_origins": ["http://localhost:5173"]
+        },
 }
 
 # Bindufy and Launch

--- a/examples/medical_agent/agent.py
+++ b/examples/medical_agent/agent.py
@@ -1,0 +1,45 @@
+import os
+from dotenv import load_dotenv
+from agno.agent import Agent
+from agno.models.openrouter import OpenRouter
+from bindu.penguin.bindufy import bindufy
+
+load_dotenv()
+
+# Initialize the Agno Agent
+medical_agent = Agent(
+    model=OpenRouter(id="google/gemini-2.0-flash-001"),
+    instructions=[
+        "You are a helpful Medical Assistant.",
+        "Provide general health information and wellness advice.",
+        "Always include a disclaimer that you are an AI, not a doctor.",
+    ],
+    markdown=True
+)
+
+# Define the Handler (The "Brain" Bindu calls)
+def medical_handler(messages: list[dict[str, str]]) -> str:
+    """
+    Bindu passes a list of messages. 
+    We pass the latest message to Agno and return the string response.
+    """
+    user_query = messages[-1]["content"] if messages else ""
+    response = medical_agent.run(user_query)
+    return response.content
+
+# Define the Bindu Configuration
+agent_config = {
+    "author": "your-email@example.com", # Required by the source code you found
+    "name": "Medical-Chatbot-Agent",
+    "description": "A medical guidance agent built with Agno and Bindu",
+    "version": "1.0.0",
+    "deployment": {
+        "url": "http://localhost:3773",
+        "expose": True
+    }
+}
+
+# Bindufy and Launch
+if __name__ == "__main__":
+    # This will start the server automatically because run_server=True by default
+    bindufy(config=agent_config, handler=medical_handler)


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: The proposed medical chatbot example was acting as a simple LLM handler rather than utilizing a true agent framework, missing the opportunity to showcase Bindu's full capabilities.
- **Why it matters**: As requested by maintainers, examples should demonstrate real agentic behavior (tool use, multi-step reasoning) by integrating with frameworks like Agno.
- **What changed**: Added a new `medical_agent` example in the `examples/` directory that uses the Agno `Agent` class (powered by OpenRouter) and securely wraps it using the `bindufy()` function. Added an `.env.example` file.
- **What did NOT change** (scope boundary): Core Bindu framework logic, existing tests, and other examples remain untouched.

## Change Type (select all that apply)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Server / API endpoints
- [ ] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [ ] CLI / utilities
- [ ] Tests
- [x] Documentation
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #105

## User-Visible / Behavior Changes

Adds a new, ready-to-run example in `examples/medical_agent/` that demonstrates how to build and expose an Agno-based agent as a microservice using Bindu.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/credentials handling changed? `No`
- New/changed network calls? `No` (Only the agent itself making standard LLM API calls).
- Database schema/migration changes? `No`
- Authentication/authorization changes? `No`
- **If any `Yes`, explain risk + mitigation**: N/A

## Verification

### Environment

- OS: Linux (GitHub Codespaces)
- Python version: 3.12+ (via `uv`)
- Storage backend: Memory
- Scheduler backend: Memory

### Steps to Test

1. Navigate to the example: `cd examples/medical_agent`
2. Install dependencies: `uv pip install agno python-dotenv openai uvicorn`
3. Run the agent: `uv run python agent.py`
4. Visit `http://localhost:3773/.well-known/agent.json` to verify the DID and manifest creation.

### Expected Behavior

- The Bindu server starts successfully.
- The `bindufy` function assigns a unique DID to the agent.
- The agent manifest is exposed correctly via the `.well-known` endpoint.

### Actual Behavior

- Server started, sunflower logo displayed, and the agent manifest (JSON) was successfully served and verified in the browser.

## Evidence (attach at least one)

- [ ] Failing test before + passing after
- [x] Test output / logs
- [x] Screenshot / recording (Attached screenshot of the successfully generated `.well-known/agent.json` manifest).
<img width="1919" height="950" alt="Screenshot 2026-02-24 152152" src="https://github.com/user-attachments/assets/918f2179-29e6-411d-b5f9-33dfa2dc1fc7" />

- [ ] Performance metrics (if relevant)

## Human Verification (required)

What you personally verified (not just CI):

- **Verified scenarios**: Agent initialization, proper routing of the Agno agent through `bindufy`, and Uvicorn server startup.
- **Edge cases checked**: Verified that the script handles missing `.env` variables gracefully without crashing the Bindu initialization phase.
- **What you did NOT verify**: Multi-agent interaction protocols with this specific agent.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`
- **If yes, exact upgrade steps**: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Delete the `examples/medical_agent/` directory.
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: N/A

## Risks and Mitigations

List only real risks for this PR. If none, write `None`.

- **Risk**: None
  - **Mitigation**: N/A

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [x] Documentation updated (if needed)
- [x] Security impact assessed
- [x] Human verification completed
- [x] Backward compatibility considered