### PR TITLE
Fix DID import order and Windows README decoding

### DIFF
--- a/bindu/extensions/did/did_agent_extension.py
+++ b/bindu/extensions/did/did_agent_extension.py
@@ -24,9 +24,13 @@ By implementing DID as an extension (https://a2a-protocol.org/v0.3.0/topics/exte
 This extension provides cryptographic identity management using Ed25519 keys and W3C-compliant
 DID documents, enabling agents to establish trust in a decentralized network.
 """
+
+from __future__ import annotations
+
+
 import os
 import platform
-from __future__ import annotations
+
 
 from datetime import datetime, timezone
 from functools import cached_property
@@ -222,13 +226,17 @@ class DIDAgentExtension:
             self.public_key_path.write_bytes(public_pem)
         else:
             # POSIX: use os.open to set permissions atomically on creation
-            fd = os.open(str(self.private_key_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            fd = os.open(
+                str(self.private_key_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+            )
             with os.fdopen(fd, "wb") as f:
                 f.write(private_pem)
 
-            fd = os.open(str(self.public_key_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+            fd = os.open(
+                str(self.public_key_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644
+            )
             with os.fdopen(fd, "wb") as f:
-                f.write(public_pem)    
+                f.write(public_pem)
 
         return {
             "private_key_path": str(self.private_key_path),

--- a/tests/unit/test_minimax_example.py
+++ b/tests/unit/test_minimax_example.py
@@ -11,8 +11,12 @@ from pathlib import Path
 import pytest
 
 # Path to the example file
-EXAMPLE_PATH = Path(__file__).parent.parent.parent / "examples" / "beginner" / "minimax_example.py"
-ENV_EXAMPLE_PATH = Path(__file__).parent.parent.parent / "examples" / "beginner" / ".env.example"
+EXAMPLE_PATH = (
+    Path(__file__).parent.parent.parent / "examples" / "beginner" / "minimax_example.py"
+)
+ENV_EXAMPLE_PATH = (
+    Path(__file__).parent.parent.parent / "examples" / "beginner" / ".env.example"
+)
 
 
 class TestMiniMaxExampleFile:
@@ -59,7 +63,7 @@ class TestMiniMaxExampleFile:
     def test_example_reads_api_key_from_env(self):
         """Verify the example reads MINIMAX_API_KEY from env."""
         source = EXAMPLE_PATH.read_text()
-        assert 'MINIMAX_API_KEY' in source
+        assert "MINIMAX_API_KEY" in source
         assert 'os.getenv("MINIMAX_API_KEY")' in source
 
     def test_example_has_config_dict(self):
@@ -152,22 +156,30 @@ class TestReadmeUpdates:
 
     def test_main_readme_mentions_minimax(self):
         """Verify main README mentions MiniMax."""
-        readme = (Path(__file__).parent.parent.parent / "README.md").read_text()
+        readme = (Path(__file__).parent.parent.parent / "README.md").read_text(
+            encoding="utf-8"
+        )
         assert "MiniMax" in readme
 
     def test_main_readme_has_minimax_api_key(self):
         """Verify main README mentions MINIMAX_API_KEY."""
-        readme = (Path(__file__).parent.parent.parent / "README.md").read_text()
+        readme = (Path(__file__).parent.parent.parent / "README.md").read_text(
+            encoding="utf-8"
+        )
         assert "MINIMAX_API_KEY" in readme
 
     def test_examples_readme_mentions_minimax(self):
         """Verify examples README lists the MiniMax example."""
-        readme = (Path(__file__).parent.parent.parent / "examples" / "README.md").read_text()
+        readme = (
+            Path(__file__).parent.parent.parent / "examples" / "README.md"
+        ).read_text(encoding="utf-8")
         assert "minimax_example.py" in readme
 
     def test_examples_readme_mentions_minimax_env(self):
         """Verify examples README mentions MINIMAX_API_KEY in env vars."""
-        readme = (Path(__file__).parent.parent.parent / "examples" / "README.md").read_text()
+        readme = (
+            Path(__file__).parent.parent.parent / "examples" / "README.md"
+        ).read_text(encoding="utf-8")
         assert "MINIMAX_API_KEY" in readme
 
 
@@ -184,6 +196,7 @@ class TestMiniMaxIntegration:
     def test_minimax_api_connection(self, api_key):
         """Test that MiniMax API is reachable with valid key."""
         import httpx
+
         resp = httpx.post(
             "https://api.minimax.io/v1/chat/completions",
             headers={
@@ -202,6 +215,7 @@ class TestMiniMaxIntegration:
     def test_minimax_chat_completion(self, api_key):
         """Test a simple chat completion via MiniMax API."""
         import httpx
+
         resp = httpx.post(
             "https://api.minimax.io/v1/chat/completions",
             headers={
@@ -223,6 +237,7 @@ class TestMiniMaxIntegration:
     def test_minimax_m27_highspeed_model(self, api_key):
         """Test that M2.7-highspeed model is also accessible."""
         import httpx
+
         resp = httpx.post(
             "https://api.minimax.io/v1/chat/completions",
             headers={


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: Two cross-platform issues were affecting test reliability: `bindu/extensions/did/did_agent_extension.py` had an invalid `from __future__ import annotations` placement, and MiniMax README tests read README files using the platform default encoding on Windows.
- **Why it matters**: The misplaced future import causes Python import failure, and default-encoding README reads can raise `UnicodeDecodeError` on Windows. Together, these issues break otherwise unrelated test runs.
- **What changed**: Moved `from __future__ import annotations` to a valid location in the DID extension module and updated MiniMax README tests to read files with `encoding="utf-8"`.
- **What did NOT change** (scope boundary): No functional DID behavior, auth logic, storage behavior, or README content was changed beyond test-read compatibility and import correctness.

## Change Type (select all that apply)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [x] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Server / API endpoints
- [x] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [ ] CLI / utilities
- [x] Tests
- [ ] Documentation
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-Visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/credentials handling changed? (`No`)
- New/changed network calls? (`No`)
- Database schema/migration changes? (`No`)
- Authentication/authorization changes? (`No`)
- **If any `Yes`, explain risk + mitigation**: None

## Verification

### Environment

- OS: Windows
- Python version: Python 3.12.9 (`F:\Bindu\.venv\Scripts\python.exe`)
- Storage backend: Not changed
- Scheduler backend: Not changed

### Steps to Test

1. Fix the import order in `bindu/extensions/did/did_agent_extension.py`
2. Update `tests/unit/test_minimax_example.py` to read README files with `encoding="utf-8"`
3. Run `uv run pytest tests/unit/test_minimax_example.py -v`

### Expected Behavior

- The DID extension imports cleanly
- MiniMax README tests pass on Windows without `UnicodeDecodeError`

### Actual Behavior

- `uv run pytest tests/unit/test_minimax_example.py -v` passed after the changes

## Evidence (attach at least one)

- [x] Failing test before + passing after
- [x] Test output / logs
- [ ] Screenshot / recording
- [ ] Performance metrics (if relevant)

## Human Verification (required)

What you personally verified (not just CI):

- **Verified scenarios**: Verified the DID extension no longer fails import due to future import placement and MiniMax README tests pass on Windows
- **Edge cases checked**: Verified UTF-8 file reads for both root `README.md` and `examples/README.md` paths used in the MiniMax tests
- **What you did NOT verify**: Did not resolve the remaining unrelated Windows permission test in `tests/unit/auth/test_hydra_registration.py`

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- **If yes, exact upgrade steps**: None

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two-file change set in this PR
- Files/config to restore:
  - `bindu/extensions/did/did_agent_extension.py`
  - `tests/unit/test_minimax_example.py`
- Known bad symptoms reviewers should watch for:
  - syntax/import failure in DID extension if future import placement regresses
  - Windows README decode failures if explicit UTF-8 reads are removed

## Risks and Mitigations

- **Risk**: Minimal risk of unintended formatting-only churn in the DID extension file
  - **Mitigation**: Scope is limited to import correctness plus test file encoding reads

## Checklist

- [ ] Tests pass (`uv run pytest`)
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [ ] Documentation updated (if needed)
- [x] Security impact assessed
- [x] Human verification completed
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file encoding handling for consistent text decoding across operations.

* **Refactor**
  * Code formatting and organization improvements including import placement and multi-line expression restructuring.

* **Style**
  * Corrected whitespace and string literal formatting across codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->