### PR TITLE
fix: move __future__ import to top of did_agent_extension.py

### DIFF
--- a/bindu/extensions/did/did_agent_extension.py
+++ b/bindu/extensions/did/did_agent_extension.py
@@ -24,9 +24,11 @@ By implementing DID as an extension (https://a2a-protocol.org/v0.3.0/topics/exte
 This extension provides cryptographic identity management using Ed25519 keys and W3C-compliant
 DID documents, enabling agents to establish trust in a decentralized network.
 """
+
+from __future__ import annotations
+
 import os
 import platform
-from __future__ import annotations
 
 from datetime import datetime, timezone
 from functools import cached_property
@@ -222,13 +224,17 @@ class DIDAgentExtension:
             self.public_key_path.write_bytes(public_pem)
         else:
             # POSIX: use os.open to set permissions atomically on creation
-            fd = os.open(str(self.private_key_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            fd = os.open(
+                str(self.private_key_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+            )
             with os.fdopen(fd, "wb") as f:
                 f.write(private_pem)
 
-            fd = os.open(str(self.public_key_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+            fd = os.open(
+                str(self.public_key_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644
+            )
             with os.fdopen(fd, "wb") as f:
-                f.write(public_pem)    
+                f.write(public_pem)
 
         return {
             "private_key_path": str(self.private_key_path),


### PR DESCRIPTION
## Summary
- **Problem**: `from __future__ import annotations` was placed after `import os` and `import platform` in `bindu/extensions/did/did_agent_extension.py`
- **Why it matters**: Python requires future statements to appear before any other imports. This causes a `SyntaxError` at parse time when the module is imported
- **What changed**: Moved `from __future__ import annotations` to immediately after the module docstring, before all other imports
- **What did NOT change**: No logic, behaviour, or functionality was modified — this is purely an import order fix

## Change Type (select all that apply)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Extensions (DID, x402, etc.)

## Linked Issue/PR
- Closes #436 

## User-Visible / Behavior Changes
None.

## Security Impact (required)
- New permissions/capabilities? `No`
- Secrets/credentials handling changed? `No`
- New/changed network calls? `No`
- Database schema/migration changes? `No`
- Authentication/authorization changes? `No`

## Verification
### Environment
- OS: Linux (Ubuntu)
- Python version: 3.12.9
- Storage backend: InMemory (default)
- Scheduler backend: InMemory (default)

### Steps to Test
1. Clone the repo and set up environment: `uv venv --python 3.12.9 && source .venv/bin/activate && uv sync --dev`
2. Before fix: `python -c "from bindu.extensions.did.did_agent_extension import DIDAgentExtension"` → raises `SyntaxError`
3. After fix: same command runs with no errors

### Expected Behavior
- Module imports without any `SyntaxError`

### Actual Behavior
- Module imports cleanly with no errors

## Evidence (attach at least one)
- [x] Failing test before + passing after
- [x] Test output / logs

Before fix:
```
File "bindu/extensions/did/did_agent_extension.py", line 29
    from __future__ import annotations
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: from __future__ imports must occur at the beginning of the file
```

After fix:
```
781 passed, 4 skipped in 44.56s
```

## Human Verification (required)
- **Verified scenarios**: Confirmed `SyntaxError` is raised before fix and gone after fix. All 781 unit tests pass.
- **Edge cases checked**: Verified no other `__future__` imports exist in the file that could be affected
- **What you did NOT verify**: Production deployment with PostgreSQL/Redis backends

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: `git revert` the commit
- Files/config to restore: `bindu/extensions/did/did_agent_extension.py`
- Known bad symptoms: `SyntaxError` on import of DID extension

## Risks and Mitigations
None.

## Checklist
- [x] Tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [x] Documentation updated (if needed)
- [x] Security impact assessed
- [x] Human verification completed
- [x] Backward compatibility considered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code formatting and organization improvements for maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->