### PR TITLE
chore: simplify None-value filtering in config settings helpers

### DIFF
--- a/bindu/utils/config/settings.py
+++ b/bindu/utils/config/settings.py
@@ -11,6 +11,11 @@ from bindu.utils.logging import get_logger
 logger = get_logger("bindu.utils.config.settings")
 
 
+def _remove_none_values(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of the dictionary without None-valued entries."""
+    return {key: value for key, value in data.items() if value is not None}
+
+
 def prepare_auth_settings(auth_config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Prepare auth settings from configuration.
 
@@ -49,10 +54,7 @@ def prepare_auth_settings(auth_config: Dict[str, Any]) -> Optional[Dict[str, Any
             "auto_register_agents": auth_config.get("auto_register_agents"),
             "agent_client_prefix": auth_config.get("agent_client_prefix"),
         }
-        # Remove None values
-        settings_to_apply["hydra"] = {
-            k: v for k, v in settings_to_apply["hydra"].items() if v is not None
-        }
+        settings_to_apply["hydra"] = _remove_none_values(settings_to_apply["hydra"])
     else:
         logger.warning(f"Unknown authentication provider: {provider}")
 
@@ -82,10 +84,7 @@ def prepare_vault_settings(vault_config: Dict[str, Any]) -> Optional[Dict[str, A
         }
     }
 
-    # Remove None values
-    settings_to_apply["vault"] = {
-        k: v for k, v in settings_to_apply["vault"].items() if v is not None
-    }
+    settings_to_apply["vault"] = _remove_none_values(settings_to_apply["vault"])
 
     if settings_to_apply["vault"].get("enabled"):
         logger.info(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: `bindu/utils/config/settings.py` repeated the same None-value filtering logic in multiple places.
- **Why it matters**: Repeated cleanup logic makes the file slightly harder to maintain and update consistently.
- **What changed**: Extracted the repeated dict filtering into a private helper and reused it in auth and vault settings preparation.
- **What did NOT change** (scope boundary): No behavior changes, no config schema changes, no auth flow changes, and no new functionality.

## Change Type (select all that apply)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] Tests
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Server / API endpoints
- [ ] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [x] CLI / utilities
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #261

## User-Visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/credentials handling changed? (`No`)
- New/changed network calls? (`No`)
- Database schema/migration changes? (`No`)
- Authentication/authorization changes? (`No`)
- **If any `Yes`, explain risk + mitigation**:

## Verification

### Environment

- OS: Windows
- Python version: 3.12.9
- Storage backend: N/A
- Scheduler backend: N/A

### Steps to Test

1. Review `prepare_auth_settings()` before and after the change.
2. Review `prepare_vault_settings()` before and after the change.
3. Confirm the helper only replaces duplicated None-value filtering logic.

### Expected Behavior

- Auth and vault settings preparation return the same outputs as before.
- Only duplicated internal cleanup logic is reduced.

### Actual Behavior

- The helper replaces repeated dict filtering without changing the surrounding logic.

## Evidence (attach at least one)

- [ ] Failing test before + passing after
- [ ] Test output / logs
- [ ] Screenshot / recording
- [ ] Performance metrics (if relevant)

## Human Verification (required)

What you personally verified (not just CI):

- **Verified scenarios**: Reviewed both auth and vault settings preparation paths to confirm the helper preserves the same None-filtering behavior.
- **Edge cases checked**: Confirmed the helper only removes `None` values and does not change keys with valid falsy values.
- **What you did NOT verify**: Full repo-wide automated hooks/tests are currently blocked by unrelated existing repo issues, including the known DID `__future__` import syntax problem.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- **If yes, exact upgrade steps**:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR/commit.
- Files/config to restore: `bindu/utils/config/settings.py`
- Known bad symptoms reviewers should watch for: Unexpected missing config keys in prepared auth or vault settings.

## Risks and Mitigations

List only real risks for this PR. If none, write `None`.

- **Risk**: A helper refactor could accidentally alter filtering behavior if implemented incorrectly.
  - **Mitigation**: The helper uses the same `is not None` filtering logic that was already present in both locations.

## Checklist

- [ ] Tests pass (`uv run pytest`)
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [ ] Documentation updated (if needed)
- [x] Security impact assessed
- [x] Human verification completed
- [x] Backward compatibility considered



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for configuration settings handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->