### PR TITLE
fix: move __future__ import to top of did_agent_extension.py

### DIFF
--- a/bindu/extensions/did/did_agent_extension.py
+++ b/bindu/extensions/did/did_agent_extension.py
@@ -24,9 +24,11 @@ By implementing DID as an extension (https://a2a-protocol.org/v0.3.0/topics/exte
 This extension provides cryptographic identity management using Ed25519 keys and W3C-compliant
 DID documents, enabling agents to establish trust in a decentralized network.
 """
+
+from __future__ import annotations
+
 import os
 import platform
-from __future__ import annotations
 
 from datetime import datetime, timezone
 from functools import cached_property


### PR DESCRIPTION
## Summary

- Fixes SyntaxError: `from __future__ imports must occur at the beginning of the file`
- Moves `from __future__ import annotations` to the correct position (after docstring, before other imports)

## Changes

- `bindu/extensions/did/did_agent_extension.py`: Moved `from __future__ import annotations` from line 28 to after docstring

## Test plan

- [x] File compiles successfully with `python -m py_compile`
- [x] Module can be imported without SyntaxError

Closes #436

---
🤖 Generated with [OpenClaude](https://github.com/anthropics/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code organization through import reordering to align with project standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->