### PR TITLE
feat(examples): add notte-browser-agent example

### DIFF
--- a/examples/notte-browser-agent/.env.example
+++ b/examples/notte-browser-agent/.env.example
@@ -1,0 +1,11 @@
+# Notte API key — get one at https://console.notte.cc
+NOTTE_API_KEY=
+
+# Optional tuning
+# NOTTE_REASONING_MODEL=gemini/gemini-2.5-flash
+# NOTTE_MAX_STEPS=15
+# NOTTE_SOLVE_CAPTCHAS=false
+# NOTTE_USE_PROXIES=false
+
+# Optional Bindu deployment override
+# BINDU_DEPLOYMENT_URL=http://localhost:3773

--- a/examples/notte-browser-agent/README.md
+++ b/examples/notte-browser-agent/README.md
@@ -1,0 +1,132 @@
+# Notte Browser Agent
+
+A Bindu agent that uses [Notte](https://notte.cc) for real-browser automation — navigates JavaScript-rendered pages, fills forms, handles authenticated sessions, solves captchas, and returns Pydantic-validated structured output.
+
+Notte is unusual among agent building blocks in that it ships both the runtime (a cloud/local Chromium browser with stealth, proxies, and Vault-backed auth) **and** the agent loop. This example wraps that combined runtime as a Bindu microservice with one call to `bindufy(...)`.
+
+## 🌐 Features
+
+### Core Capabilities
+- **Real browser**: Cloud Chromium/Firefox session per request — JavaScript renders, forms submit, cookies persist. Not HTTP scraping.
+- **Structured output**: Pass a Pydantic `BaseModel` as `response_format` and get schema-validated JSON back.
+- **Authenticated flows**: `client.Vault()` for safe credential handling; `session.set_cookies(...)` for pre-auth sessions. Credentials never enter the task string.
+- **Captcha solving**: `solve_captchas=True` on the Session handles captchas automatically.
+- **Proxies**: Built-in proxy support, including geolocated proxies via `NotteProxy.from_country(...)`.
+- **Multi-step workflows**: Natural-language task routed through a configurable agent loop (`max_steps`, `reasoning_model`).
+
+### 🔧 Technical Features
+- **Runtime**: Notte hosted cloud (default) or local Chromium via `patchright`.
+- **Agent loop**: Built into the Notte SDK — no external framework required.
+- **Reasoning model**: Any LiteLLM-style string. Default `gemini/gemini-2.5-flash`; escalate to `anthropic/claude-sonnet-4-5` or `openai/gpt-4.1` for harder flows.
+- **Bindu integration**: `bindufy(...)` wraps the handler with A2A protocol, DID identity, and skill routing.
+- **Skill**: [`skills/notte-browser-skill`](./skills/notte-browser-skill/skill.yaml) advertises browser-automation capability so other agents can discover and delegate to this one.
+
+## 🚀 Quick Start
+
+### Prerequisites
+- Python 3.12+
+- Notte API key ([get one at console.notte.cc](https://console.notte.cc))
+- UV package manager
+
+### Installation & Setup
+
+1. **Navigate to Bindu root**:
+   ```bash
+   cd /path/to/bindu
+   ```
+
+2. **Install Notte alongside Bindu**:
+   ```bash
+   uv add notte
+   # or, inside a project venv:
+   # pip install notte
+   ```
+
+3. **Configure environment**:
+   ```bash
+   cp examples/notte-browser-agent/.env.example examples/notte-browser-agent/.env
+   # Edit examples/notte-browser-agent/.env and set NOTTE_API_KEY
+   ```
+
+4. **Run the agent**:
+   ```bash
+   uv run python examples/notte-browser-agent/notte_browser_agent.py
+   ```
+
+   The Bindu service starts on `http://localhost:3773` by default. Set `BINDU_DEPLOYMENT_URL` or `BINDU_PORT` to override.
+
+## 📡 Usage Examples
+
+### Direct invocation
+```python
+messages = [
+    {
+        "role": "user",
+        "content": (
+            "Go to news.ycombinator.com and return the top 5 posts as JSON "
+            "with title, url, points, and author."
+        ),
+    }
+]
+```
+
+### Supported query types
+- **Data extraction from dynamic pages**: "Extract product listings from [URL]" — pages that won't respond to `curl` or `requests`.
+- **Authenticated flows**: "Log in to [URL] and download the latest invoice." Pair with `client.Vault()` for real credentials.
+- **Multi-step workflows**: "Search [query] on [site], apply [filter], and return the top result as JSON."
+- **Captcha / proxy-gated sites**: Set `NOTTE_SOLVE_CAPTCHAS=true` or `NOTTE_USE_PROXIES=true` in `.env`.
+- **E-commerce**: "Find [product] on [shop], select the right variant, and return the final price."
+
+## ⚙️ Configuration
+
+All runtime options are read from `.env`:
+
+| Variable | Default | What it does |
+|---|---|---|
+| `NOTTE_API_KEY` | *(required)* | Hosted-mode API key from console.notte.cc |
+| `NOTTE_REASONING_MODEL` | `gemini/gemini-2.5-flash` | LiteLLM-style model string used by the Notte agent |
+| `NOTTE_MAX_STEPS` | `15` | Hard cap on agent iterations per task |
+| `NOTTE_SOLVE_CAPTCHAS` | `false` | Enable automatic captcha solving on the Session |
+| `NOTTE_USE_PROXIES` | `false` | Route traffic through Notte's managed proxies |
+| `BINDU_DEPLOYMENT_URL` | `http://localhost:3773` | Where the Bindu service binds |
+
+## 🗂️ Project Structure
+
+```
+notte-browser-agent/
+├── notte_browser_agent.py      # Main agent implementation
+├── .env                        # Environment variables (API keys)
+├── .env.example                # Environment variables template
+├── skills/
+│   └── notte-browser-skill/
+│       └── skill.yaml          # Skill metadata — browser automation capability
+└── README.md                   # This file
+```
+
+## 🔍 Troubleshooting
+
+#### `NOTTE_API_KEY not set`
+Ensure `.env` exists in `examples/notte-browser-agent/` with a real key from https://console.notte.cc. `load_dotenv()` reads the local `.env`.
+
+#### `ModuleNotFoundError: No module named 'notte_sdk'`
+Run `uv add notte` (or `pip install notte` inside your venv).
+
+#### Agent returns no answer / "ran out of steps"
+Raise `NOTTE_MAX_STEPS` in `.env`, or switch `NOTTE_REASONING_MODEL` to a stronger model (e.g. `anthropic/claude-sonnet-4-5`). Don't just retry with the same config — it will fail identically.
+
+#### Captcha / bot-detection blocks the run
+Set `NOTTE_SOLVE_CAPTCHAS=true` and optionally `NOTTE_USE_PROXIES=true` in `.env`.
+
+#### Credentials in logs
+Never paste raw credentials into the task string — route them through `client.Vault()` instead. See the [Notte auth docs](https://docs.notte.cc) and the hosted skill at [`agent-skill-notte`](https://github.com/nottelabs/agent-skill-notte).
+
+## 🔗 References
+
+- **Notte SDK source**: https://github.com/nottelabs/notte
+- **Notte docs**: https://docs.notte.cc
+- **Notte console (API keys)**: https://console.notte.cc
+- **Notte Agent Skill (Claude Code / Cursor / Goose / 30+ clients)**: https://github.com/nottelabs/agent-skill-notte
+
+---
+
+**Built with ❤️ using the Bindu Agent Framework + Notte**

--- a/examples/notte-browser-agent/README.md
+++ b/examples/notte-browser-agent/README.md
@@ -8,11 +8,11 @@ Notte is unusual among agent building blocks in that it ships both the runtime (
 
 ### Core Capabilities
 - **Real browser**: Cloud Chromium/Firefox session per request — JavaScript renders, forms submit, cookies persist. Not HTTP scraping.
-- **Structured output**: Pass a Pydantic `BaseModel` as `response_format` and get schema-validated JSON back.
-- **Authenticated flows**: `client.Vault()` for safe credential handling; `session.set_cookies(...)` for pre-auth sessions. Credentials never enter the task string.
-- **Captcha solving**: `solve_captchas=True` on the Session handles captchas automatically.
-- **Proxies**: Built-in proxy support, including geolocated proxies via `NotteProxy.from_country(...)`.
+- **Captcha solving**: Set `NOTTE_SOLVE_CAPTCHAS=true` to enable automatic captcha solving on the Session.
+- **Proxies**: Set `NOTTE_USE_PROXIES=true` to route traffic through Notte's managed proxies.
 - **Multi-step workflows**: Natural-language task routed through a configurable agent loop (`max_steps`, `reasoning_model`).
+
+> The Notte SDK also supports `response_format` for Pydantic-validated structured output, `client.Vault()` for credentialed flows, `session.execute(...)` for deterministic scripting, and `client.scrape(...)` for one-shot extraction. This example's handler intentionally wires only the minimal agent path — extend it as needed for those advanced flows.
 
 ### 🔧 Technical Features
 - **Runtime**: Notte hosted cloud (default) or local Chromium via `patchright`.
@@ -74,7 +74,7 @@ messages = [
 
 ### Supported query types
 - **Data extraction from dynamic pages**: "Extract product listings from [URL]" — pages that won't respond to `curl` or `requests`.
-- **Authenticated flows**: "Log in to [URL] and download the latest invoice." Pair with `client.Vault()` for real credentials.
+- **Authenticated flows** (requires extending the handler): pair a task like "Log in and download the latest invoice" with `client.Vault()` credential retrieval — do not pass raw credentials in the task string.
 - **Multi-step workflows**: "Search [query] on [site], apply [filter], and return the top result as JSON."
 - **Captcha / proxy-gated sites**: Set `NOTTE_SOLVE_CAPTCHAS=true` or `NOTTE_USE_PROXIES=true` in `.env`.
 - **E-commerce**: "Find [product] on [shop], select the right variant, and return the final price."
@@ -94,7 +94,7 @@ All runtime options are read from `.env`:
 
 ## 🗂️ Project Structure
 
-```
+```text
 notte-browser-agent/
 ├── notte_browser_agent.py      # Main agent implementation
 ├── .env                        # Environment variables (API keys)
@@ -107,22 +107,22 @@ notte-browser-agent/
 
 ## 🔍 Troubleshooting
 
-#### `NOTTE_API_KEY not set`
+### `NOTTE_API_KEY not set`
 Ensure `.env` exists in `examples/notte-browser-agent/` with a real key from https://console.notte.cc. `load_dotenv()` reads the local `.env`.
 
-#### `ModuleNotFoundError: No module named 'notte_sdk'`
+### `ModuleNotFoundError: No module named 'notte_sdk'`
 Run `uv pip install 'notte>=1.8.12'` (or `pip install 'notte>=1.8.12'` inside your venv).
 
-#### `pydantic_core._pydantic_core.ValidationError: ... extra_forbidden`
+### `pydantic_core._pydantic_core.ValidationError: ... extra_forbidden`
 Your resolved `notte` version is too old. Upgrade with `uv pip install 'notte>=1.8.12'`.
 
-#### Agent returns no answer / "ran out of steps"
+### Agent returns no answer / "ran out of steps"
 Raise `NOTTE_MAX_STEPS` in `.env`, or switch `NOTTE_REASONING_MODEL` to a stronger model (e.g. `anthropic/claude-sonnet-4-5`). Don't just retry with the same config — it will fail identically.
 
-#### Captcha / bot-detection blocks the run
+### Captcha / bot-detection blocks the run
 Set `NOTTE_SOLVE_CAPTCHAS=true` and optionally `NOTTE_USE_PROXIES=true` in `.env`.
 
-#### Credentials in logs
+### Credentials in logs
 Never paste raw credentials into the task string — route them through `client.Vault()` instead. See the [Notte auth docs](https://docs.notte.cc) and the hosted skill at [`agent-skill-notte`](https://github.com/nottelabs/agent-skill-notte).
 
 ## 🔗 References

--- a/examples/notte-browser-agent/README.md
+++ b/examples/notte-browser-agent/README.md
@@ -35,12 +35,14 @@ Notte is unusual among agent building blocks in that it ships both the runtime (
    cd /path/to/bindu
    ```
 
-2. **Install Notte alongside Bindu**:
+2. **Install Notte alongside Bindu** (version pin matters):
    ```bash
-   uv add notte
+   uv pip install 'notte>=1.8.12'
    # or, inside a project venv:
-   # pip install notte
+   # pip install 'notte>=1.8.12'
    ```
+
+   > ⚠️ **Pin to `>=1.8.12`.** Older versions (1.6.x) on PyPI ship a stricter `pydantic` session model that rejects fields returned by the current Notte API, producing `extra_forbidden` validation errors. `uv add notte` may resolve to an older version depending on your dep graph — use `uv pip install 'notte>=1.8.12'` to be explicit.
 
 3. **Configure environment**:
    ```bash
@@ -109,7 +111,10 @@ notte-browser-agent/
 Ensure `.env` exists in `examples/notte-browser-agent/` with a real key from https://console.notte.cc. `load_dotenv()` reads the local `.env`.
 
 #### `ModuleNotFoundError: No module named 'notte_sdk'`
-Run `uv add notte` (or `pip install notte` inside your venv).
+Run `uv pip install 'notte>=1.8.12'` (or `pip install 'notte>=1.8.12'` inside your venv).
+
+#### `pydantic_core._pydantic_core.ValidationError: ... extra_forbidden`
+Your resolved `notte` version is too old. Upgrade with `uv pip install 'notte>=1.8.12'`.
 
 #### Agent returns no answer / "ran out of steps"
 Raise `NOTTE_MAX_STEPS` in `.env`, or switch `NOTTE_REASONING_MODEL` to a stronger model (e.g. `anthropic/claude-sonnet-4-5`). Don't just retry with the same config — it will fail identically.

--- a/examples/notte-browser-agent/notte_browser_agent.py
+++ b/examples/notte-browser-agent/notte_browser_agent.py
@@ -1,0 +1,102 @@
+"""Notte Browser Agent (Bindu example).
+
+Wraps the Notte SDK's built-in Agent + Session as a Bindu microservice.
+Notte provides the browser runtime (cloud Chromium, stealth, captcha solving,
+proxies, Vault-backed auth) and the agent loop that turns a natural-language
+task into structured Pydantic output. `bindufy(...)` exposes that as a
+Bindu-native agent with DID identity, A2A protocol, and skill routing.
+
+Unlike most Bindu examples, there is no separate "LLM + tools" layer here —
+Notte IS the agent. The handler simply forwards the user message to
+`client.Agent(...).run(task=...)`.
+
+Usage:
+    python notte_browser_agent.py
+
+Environment:
+    Requires NOTTE_API_KEY in .env (https://console.notte.cc to obtain one).
+
+Docs:
+    - Notte SDK:            https://github.com/nottelabs/notte
+    - Notte docs:           https://docs.notte.cc
+    - Agent Skill (Claude): https://github.com/nottelabs/agent-skill-notte
+"""
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from bindu.penguin.bindufy import bindufy
+from notte_sdk import NotteClient
+
+# A single, long-lived Notte client. Session lifetime is scoped per request
+# inside the handler so every A2A call gets an isolated browser context.
+client = NotteClient()
+
+# Sensible default model. Escalate to anthropic/claude-sonnet-4-5 or
+# openai/gpt-4.1 for harder multi-step flows via NOTTE_REASONING_MODEL.
+REASONING_MODEL = os.getenv("NOTTE_REASONING_MODEL", "gemini/gemini-2.5-flash")
+MAX_STEPS = int(os.getenv("NOTTE_MAX_STEPS", "15"))
+SOLVE_CAPTCHAS = os.getenv("NOTTE_SOLVE_CAPTCHAS", "false").lower() == "true"
+USE_PROXIES = os.getenv("NOTTE_USE_PROXIES", "false").lower() == "true"
+
+# Bindu agent configuration
+config = {
+    "author": "bindu.builder@getbindu.com",
+    "name": "notte_browser_agent",
+    "description": (
+        "Real-browser web automation agent powered by Notte. Navigates JS-rendered "
+        "pages, fills forms, handles auth, solves captchas, and returns Pydantic-"
+        "validated structured output."
+    ),
+    "deployment": {
+        "url": os.getenv("BINDU_DEPLOYMENT_URL", "http://localhost:3773"),
+        "expose": True,
+        "cors_origins": ["http://localhost:5173"],
+    },
+    "skills": ["skills/notte-browser-skill"],
+}
+
+
+def handler(messages: list[dict[str, str]]) -> str:
+    """Run the latest user message as a Notte browser task.
+
+    Args:
+        messages: A2A message history; we use the latest user turn as the task.
+
+    Returns:
+        The agent's final answer as a string (JSON if the caller asked for
+        structured output, free text otherwise).
+    """
+    if not messages:
+        return (
+            "Please provide a browser task. Example: 'Go to news.ycombinator.com "
+            "and return the top 5 posts as JSON with title, url, and points.'"
+        )
+
+    latest = messages[-1]
+    task = latest.get("content", "") if isinstance(latest, dict) else str(latest)
+    if not task.strip():
+        return "Empty task — please describe the browser action you want."
+
+    with client.Session(
+        solve_captchas=SOLVE_CAPTCHAS,
+        proxies=USE_PROXIES,
+    ) as session:
+        agent = client.Agent(
+            session=session,
+            reasoning_model=REASONING_MODEL,
+            max_steps=MAX_STEPS,
+        )
+        response = agent.run(task=task)
+
+    answer = getattr(response, "answer", None)
+    if answer is None:
+        return "Notte agent returned no answer — try raising NOTTE_MAX_STEPS or a stronger NOTTE_REASONING_MODEL."
+    return answer
+
+
+if __name__ == "__main__":
+    bindufy(config, handler)

--- a/examples/notte-browser-agent/notte_browser_agent.py
+++ b/examples/notte-browser-agent/notte_browser_agent.py
@@ -76,9 +76,18 @@ def handler(messages: list[dict[str, str]]) -> str:
             "and return the top 5 posts as JSON with title, url, and points.'"
         )
 
-    latest = messages[-1]
-    task = latest.get("content", "") if isinstance(latest, dict) else str(latest)
-    if not task.strip():
+    latest_user = next(
+        (
+            m
+            for m in reversed(messages)
+            if isinstance(m, dict) and m.get("role") == "user"
+        ),
+        None,
+    )
+    if latest_user is None:
+        return "No user message found — please send a task as a user-role message."
+    task = latest_user.get("content", "")
+    if not isinstance(task, str) or not task.strip():
         return "Empty task — please describe the browser action you want."
 
     with client.Session(

--- a/examples/notte-browser-agent/skills/notte-browser-skill/skill.yaml
+++ b/examples/notte-browser-agent/skills/notte-browser-skill/skill.yaml
@@ -1,0 +1,99 @@
+id: notte-browser-skill
+name: notte-browser-skill
+version: 1.0.0
+author: bindu.builder@getbindu.com
+description: |
+  Real-browser automation skill powered by Notte. Navigates JavaScript-rendered
+  pages, fills forms, clicks through multi-step flows, handles authenticated
+  sessions, solves captchas, routes through proxies, and returns strongly-typed
+  Pydantic output. Use whenever the task needs a real browser (not just HTTP)
+  — dynamic pages, logins, e-commerce checkouts, dashboards behind auth, or
+  structured extraction from pages that won't respond to `requests` / `curl`.
+
+tags:
+  - browser-automation
+  - web-agent
+  - web-scraping
+  - form-filling
+  - authenticated-session
+  - captcha
+  - proxies
+  - structured-extraction
+  - pydantic
+
+input_modes:
+  - application/json
+
+output_modes:
+  - application/json
+
+examples:
+  - "Go to news.ycombinator.com and return the top 5 posts as JSON with title, url, points, author"
+  - "Log in to https://app.example.com with these credentials and download the latest invoice PDF"
+  - "Search 'air force 1' on nike.com, solve any captcha, and return the current price and availability"
+  - "Open my dashboard at https://portal.example.com, navigate to Billing, and extract the current balance"
+  - "Fill the contact form at https://example.com/contact with name=Jane, email=jane@ex.com, submit, and confirm the success state"
+
+capabilities_detail:
+  real_browser:
+    supported: true
+    description: "Runs a full Chromium/Firefox session (cloud or local) — JavaScript renders, forms submit, cookies persist"
+  structured_extraction:
+    supported: true
+    description: "Pass a Pydantic BaseModel as `response_format`; the agent returns schema-validated output"
+  multi_step_workflows:
+    supported: true
+    description: "Natural-language task routed through a Notte agent with configurable max_steps and reasoning_model"
+  authenticated_sessions:
+    supported: true
+    description: "Vault-backed credential handling and cookie injection — credentials never enter the task string or logs"
+  captcha_solving:
+    supported: true
+    description: "Set `solve_captchas=True` on Session for automatic captcha resolution"
+  proxies:
+    supported: true
+    description: "Built-in proxy support including geolocated proxies via `NotteProxy.from_country(...)`"
+  hybrid_scripting:
+    supported: true
+    description: "Mix deterministic `session.execute(...)` calls with agent reasoning for cost and reliability wins"
+  one_shot_scrape:
+    supported: true
+    description: "`client.scrape(url=..., response_format=...)` for pure extraction without agent overhead (5–10x cheaper)"
+
+assessment:
+  keywords:
+    - browser
+    - navigate
+    - click
+    - fill
+    - form
+    - login
+    - authenticated
+    - dashboard
+    - captcha
+    - proxy
+    - dynamic
+    - javascript
+    - spa
+    - multi-step
+    - checkout
+    - booking
+    - pydantic
+    - structured
+
+  specializations:
+    - domain: authenticated_web_flows
+      confidence_boost: 0.35
+    - domain: dynamic_page_extraction
+      confidence_boost: 0.3
+    - domain: multi_step_web_workflows
+      confidence_boost: 0.3
+    - domain: e_commerce_checkout
+      confidence_boost: 0.25
+
+  anti_patterns:
+    - "static html fetch"
+    - "public json api"
+    - "offline file processing"
+    - "pdf text extraction without a browser"
+    - "database query"

--- a/examples/notte-browser-agent/skills/notte-browser-skill/skill.yaml
+++ b/examples/notte-browser-agent/skills/notte-browser-skill/skill.yaml
@@ -32,7 +32,7 @@ examples:
 capabilities_detail:
   real_browser:
     supported: true
-    description: "Runs a full Chromium/Firefox session (cloud or local) — JavaScript renders, forms submit, cookies persist"
+    description: "Runs a Chromium-based Notte cloud session — JavaScript renders, forms submit, cookies persist. Local or alternate-browser runtimes require passing cdp_url / extra params to client.Session()."
   multi_step_workflows:
     supported: true
     description: "Natural-language task routed through a Notte agent with configurable max_steps and reasoning_model"

--- a/examples/notte-browser-agent/skills/notte-browser-skill/skill.yaml
+++ b/examples/notte-browser-agent/skills/notte-browser-skill/skill.yaml
@@ -4,61 +4,44 @@ version: 1.0.0
 author: bindu.builder@getbindu.com
 description: |
   Real-browser automation skill powered by Notte. Navigates JavaScript-rendered
-  pages, fills forms, clicks through multi-step flows, handles authenticated
-  sessions, solves captchas, routes through proxies, and returns strongly-typed
-  Pydantic output. Use whenever the task needs a real browser (not just HTTP)
-  — dynamic pages, logins, e-commerce checkouts, dashboards behind auth, or
-  structured extraction from pages that won't respond to `requests` / `curl`.
+  pages, fills forms, clicks through multi-step flows, solves captchas, and
+  routes through proxies. Use whenever the task needs a real browser (not just
+  HTTP) — dynamic pages, e-commerce flows, or extraction from pages that won't
+  respond to `requests` / `curl`.
 
 tags:
   - browser-automation
   - web-agent
   - web-scraping
   - form-filling
-  - authenticated-session
   - captcha
   - proxies
-  - structured-extraction
-  - pydantic
 
 input_modes:
   - application/json
 
 output_modes:
   - application/json
+  - text/plain
 
 examples:
   - "Go to news.ycombinator.com and return the top 5 posts as JSON with title, url, points, author"
-  - "Log in to https://app.example.com with these credentials and download the latest invoice PDF"
   - "Search 'air force 1' on nike.com, solve any captcha, and return the current price and availability"
-  - "Open my dashboard at https://portal.example.com, navigate to Billing, and extract the current balance"
   - "Fill the contact form at https://example.com/contact with name=Jane, email=jane@ex.com, submit, and confirm the success state"
 
 capabilities_detail:
   real_browser:
     supported: true
     description: "Runs a full Chromium/Firefox session (cloud or local) — JavaScript renders, forms submit, cookies persist"
-  structured_extraction:
-    supported: true
-    description: "Pass a Pydantic BaseModel as `response_format`; the agent returns schema-validated output"
   multi_step_workflows:
     supported: true
     description: "Natural-language task routed through a Notte agent with configurable max_steps and reasoning_model"
-  authenticated_sessions:
-    supported: true
-    description: "Vault-backed credential handling and cookie injection — credentials never enter the task string or logs"
   captcha_solving:
     supported: true
-    description: "Set `solve_captchas=True` on Session for automatic captcha resolution"
+    description: "Set NOTTE_SOLVE_CAPTCHAS=true to enable automatic captcha resolution on the Session"
   proxies:
     supported: true
-    description: "Built-in proxy support including geolocated proxies via `NotteProxy.from_country(...)`"
-  hybrid_scripting:
-    supported: true
-    description: "Mix deterministic `session.execute(...)` calls with agent reasoning for cost and reliability wins"
-  one_shot_scrape:
-    supported: true
-    description: "`client.scrape(url=..., response_format=...)` for pure extraction without agent overhead (5–10x cheaper)"
+    description: "Set NOTTE_USE_PROXIES=true to route traffic through Notte's managed proxies"
 
 assessment:
   keywords:
@@ -68,8 +51,6 @@ assessment:
     - fill
     - form
     - login
-    - authenticated
-    - dashboard
     - captcha
     - proxy
     - dynamic
@@ -78,12 +59,8 @@ assessment:
     - multi-step
     - checkout
     - booking
-    - pydantic
-    - structured
 
   specializations:
-    - domain: authenticated_web_flows
-      confidence_boost: 0.35
     - domain: dynamic_page_extraction
       confidence_boost: 0.3
     - domain: multi_step_web_workflows


### PR DESCRIPTION
## Summary

- **Problem**: Bindu's `examples/` directory has no reference for wrapping a built-in agent runtime (one that provides both the model loop AND its own tools) as a Bindu microservice. Every existing example pairs a framework (agno, LangChain) with external tools.
- **Why it matters**: It leaves a gap in the "any framework, any agent" story. [Notte](https://notte.cc) is a good concrete example because it ships both a real-browser runtime (cloud Chromium, stealth, proxies, captcha solving, Vault-backed auth) and its own agent loop — so the Bindu handler is just `client.Agent(...).run(task=...)`, with no intermediate framework. That's a clean demo of Bindu's framework-agnosticism.
- **What changed**: Adds `examples/notte-browser-agent/` — mirrors the structure of `examples/web-scraping-agent/` (runnable `.py` + `skills/<name>/skill.yaml` + `.env.example` + `README.md`).
- **What did NOT change** (scope boundary): No edits to `bindu/` core, no new dependencies in `pyproject.toml`, no changes to existing examples, no CI changes. Notte is installed by the user via `uv pip install 'notte>=1.8.12'` as documented in the example README.

## Change Type (select all that apply)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Server / API endpoints
- [ ] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [ ] CLI / utilities
- [ ] Tests
- [x] Documentation
- [ ] CI/CD / infra

(New content lives entirely under `examples/` — the closest tag is Documentation since Bindu treats examples as documentation surface.)

## Linked Issue/PR

- Closes #
- Related #

None — first-time contributor PR. Happy to open a tracking issue if the maintainers would prefer.

## User-Visible / Behavior Changes

A new self-contained example at `examples/notte-browser-agent/`. No changes to existing examples, core, or defaults. Users who don't run this example see no difference.

## Security Impact (required)

- New permissions/capabilities: **No** (no changes to Bindu core)
- Secrets/credentials handling changed: **No** — example reads `NOTTE_API_KEY` from its own local `.env` via `python-dotenv`, identical to the pattern already used by `examples/web-scraping-agent/` and others.
- New/changed network calls: **No** (in Bindu itself). The example, when run, calls `api.notte.cc` over HTTPS — scoped to the user who configures `NOTTE_API_KEY`.
- Database schema/migration changes: **No**
- Authentication/authorization changes: **No**
- **If any `Yes`, explain risk + mitigation**: N/A

## Verification

### Environment

- OS: macOS 14 (Darwin 23.6.0)
- Python version: 3.12
- Storage backend: N/A (example does not touch Bindu storage)
- Scheduler backend: N/A (example does not touch Bindu scheduler)

### Steps to Test

1. `cd /path/to/bindu && uv sync --dev`
2. `uv pip install 'notte>=1.8.12'` (example dependency, not added to Bindu's `pyproject.toml` — see note under "Actual Behavior" on why the pin matters)
3. `cp examples/notte-browser-agent/.env.example examples/notte-browser-agent/.env` and set `NOTTE_API_KEY` (free tier available at https://console.notte.cc)
4. `uv run python examples/notte-browser-agent/notte_browser_agent.py`
5. Send an A2A request to `http://localhost:3773` with a message like: *"Go to news.ycombinator.com and return the top 3 posts as JSON with title, url, points."*

### Expected Behavior

- `bindufy(config, handler)` starts a Bindu service on `http://localhost:3773`.
- Incoming A2A message routes to the handler.
- Notte spins up a Chromium session, runs the task, returns the agent's `response.answer`.
- Session context-manager cleanly closes the browser between calls.

### Actual Behavior

- Local syntax + schema checks pass:
  - `python3 -c "import ast; ast.parse(open('.../notte_browser_agent.py').read())"` → ok
  - `python3 -c "import yaml; yaml.safe_load(open('.../skill.yaml'))"` → ok
- **Live end-to-end run against `api.notte.cc` succeeded** with a real `NOTTE_API_KEY`:
  - Task: *"Go to https://example.com and return the exact H1 heading as plain text."*
  - Result: `'Example Domain'` (correct)
  - 2 agent steps, session cleanly started and stopped.
- **Finding from the live run (now fixed in a follow-up commit)**: `uv add notte` on Bindu's current dep graph resolved to `notte==1.6.4`, which ships a stricter pydantic session model that rejects fields returned by the current Notte API (`extra_forbidden`). The README now pins `uv pip install 'notte>=1.8.12'` and a matching troubleshooting entry is included.

## Evidence (attach at least one)

- [ ] Failing test before + passing after
- [ ] Test output / logs
- [ ] Screenshot / recording
- [ ] Performance metrics (if relevant)

None attached for v1 — this PR adds only example files (no test surface exists for examples in the Bindu repo, matching the pattern of `web-scraping-agent` and peers). Happy to record a terminal/asciinema of an end-to-end run on request.

## Human Verification (required)

- **Verified scenarios**:
  - Directory layout mirrors `examples/web-scraping-agent/` 1:1 (runnable `.py`, `skills/<name>/skill.yaml`, `.env.example`, `README.md`).
  - `skill.yaml` parses and follows the same field conventions as `examples/web-scraping-agent/skills/web-scraping-skill/skill.yaml` (`id`, `name`, `version`, `author`, `description`, `tags`, `input_modes`, `output_modes`, `examples`, `capabilities_detail`, `assessment.{keywords, specializations, anti_patterns}`).
  - `notte_browser_agent.py` parses under Python 3.12 and imports match Notte's documented hosted-SDK pattern (`from notte_sdk import NotteClient`).
  - `pre-commit` excludes already cover `^examples/` for `ruff`, `ruff-format`, `ty`, and `bandit`, so no lint regressions possible from this PR.
- **Edge cases checked**:
  - Empty or whitespace-only `messages[-1].content` → handler returns a friendly prompt instead of crashing.
  - Missing `response.answer` → handler returns a troubleshooting hint (suggesting `NOTTE_MAX_STEPS` / stronger `NOTTE_REASONING_MODEL`) rather than silently returning `None`.
  - All runtime knobs (`NOTTE_REASONING_MODEL`, `NOTTE_MAX_STEPS`, `NOTTE_SOLVE_CAPTCHAS`, `NOTTE_USE_PROXIES`) are env-driven with safe defaults matching Notte's own documented defaults.
- **Also verified (live)**:
  - End-to-end agent run against `api.notte.cc` with a real API key — session created, agent loop ran 2 steps, Notte returned the correct H1 extraction, session stopped cleanly.
  - Version-pin correctness: confirmed `notte==1.6.4` reproduces the pydantic `extra_forbidden` error; confirmed `notte>=1.8.12` resolves it.
- **What was NOT verified**:
  - Full `bindufy(...)` HTTP service path (posting an A2A request to the running service on `:3773`). The handler was exercised directly, which covers the Notte code path; the Bindu wrapper is standard across all examples and is not modified here.
  - Interop with Bindu's agent-to-agent delegation from a second bindufied agent (should "just work" via the skill, but not bench-tested here).

## Compatibility / Migration

- Backward compatible: **Yes**
- Config/env changes: **No** (example-local `.env.example` only; no global env read)
- Database migration needed: **No**
- **If yes, exact upgrade steps**: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <this-commit>`. Deleting the `examples/notte-browser-agent/` directory has zero impact on Bindu core or on any other example.
- Files/config to restore: None — the PR adds 4 new files and modifies nothing existing.
- Known bad symptoms reviewers should watch for: This example cannot affect other code paths. The only surface is `uv run python examples/notte-browser-agent/notte_browser_agent.py`; if that errors, the fix is scoped to that file.

## Risks and Mitigations

- **Risk**: `notte` is not in Bindu's `pyproject.toml` — users running this example need to `uv pip install 'notte>=1.8.12'`.
  - **Mitigation**: Documented explicitly in `examples/notte-browser-agent/README.md` with a version pin and a troubleshooting entry. Matches the pattern of `web-scraping-agent` which relies on `uv sync --extra agents` for its own deps.
- **Risk**: Older PyPI `notte` versions (1.6.x) fail with pydantic `extra_forbidden`. Discovered during the live run.
  - **Mitigation**: README pins `>=1.8.12` and includes a named troubleshooting entry that maps the pydantic error to the fix.
- **Risk**: Example requires a third-party API key (`NOTTE_API_KEY`), so it cannot run offline.
  - **Mitigation**: `.env.example` clearly flags the required key + console URL; Notte offers a free tier; local-only Notte (no API key, runs Chromium locally) is documented in the README as an alternative.

## Checklist

- [x] Tests pass (`uv run pytest`) — no test changes; existing test suite unaffected (pre-commit excludes `examples/` for ruff/ty/bandit).
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`) — not executed in contributor environment; will run on CI. New files are covered by `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files` only (all expected to pass).
- [x] Documentation updated (if needed) — new example ships with its own README.
- [x] Security impact assessed — see Security Impact section.
- [x] Human verification completed — see Human Verification section.
- [x] Backward compatibility considered — additive-only, zero impact on existing code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser automation microservice example for real-browser navigation, multi-step agent workflows, form filling, authenticated flows, optional CAPTCHA solving, and proxy routing.

* **Documentation**
  * Added a quick-start guide, environment configuration template, usage examples, supported query types, troubleshooting tips, and a skill manifest describing inputs/outputs and capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->