### PR TITLE
Add ScopeBlind authorization receipts extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 ---
 
-**Bindu** (read: _binduu_) turns any AI agent into a production microservice. Build your agent in any framework — Agno, LangChain, OpenAI SDK, even plain TypeScript — call `bindufy()`, and get a service with DID identity, A2A protocol, OAuth2 auth, and crypto payments. No infrastructure code. No rewriting.
+**Bindu** (read: _binduu_) turns any AI agent into a production microservice. Build your agent in any framework — Agno, LangChain, OpenAI SDK, even plain TypeScript — call `bindufy()`, and get a service with DID identity, A2A protocol, OAuth2 auth, crypto payments, and verifiable authorization receipts. No infrastructure code. No rewriting.
 
 Works with Python, TypeScript, and Kotlin. Built on open protocols: **A2A**, **AP2**, and **X402**.
 
@@ -472,6 +472,7 @@ Output:
 | 📊 **Observability & Monitoring** | Track performance and debug issues with OpenTelemetry and Sentry | [Guide →](docs/OBSERVABILITY.md) |
 | 🔄 **Retry Mechanism** | Automatic retry with exponential backoff for resilient agents | [Guide →](https://docs.getbindu.com/bindu/learn/retry/overview) |
 | 🔑 **Decentralized Identifiers (DIDs)** | Cryptographic identity for verifiable, secure agent interactions and payment integration | [Guide →](docs/DID.md) |
+| 🧾 **ScopeBlind Receipts** | Cedar-backed authorization receipts for verifiable agent actions | [Guide →](docs/SCOPEBLIND.md) |
 | 🏥 **Health Check & Metrics** | Monitor agent health and performance with built-in endpoints | [Guide →](docs/HEALTH_METRICS.md) |
 | 🌍 **Language-Agnostic (gRPC)** | Bindufy agents written in TypeScript, Kotlin, Rust, or any language via gRPC adapter | [Guide →](docs/GRPC_LANGUAGE_AGNOSTIC.md) |
 

--- a/bindu/common/protocol/types.py
+++ b/bindu/common/protocol/types.py
@@ -573,6 +573,9 @@ class TaskSendParams(TypedDict):
     payment_context: NotRequired[dict[str, Any]]
     """Payment context for X402 extension (optional)."""
 
+    scopeblind_context: NotRequired[dict[str, Any]]
+    """Authorization context for ScopeBlind extension (optional)."""
+
 
 @pydantic.with_config(ConfigDict(alias_generator=to_camel))
 class TaskIdParams(TypedDict):

--- a/bindu/extensions/scopeblind/__init__.py
+++ b/bindu/extensions/scopeblind/__init__.py
@@ -1,0 +1,35 @@
+"""ScopeBlind extension for verifiable authorization receipts.
+
+This extension keeps authorization separate from agent identity. DID signing
+continues to answer "who said this?", while ScopeBlind receipts answer
+"was this action authorized under policy?".
+"""
+
+from __future__ import annotations
+
+from .extension import ScopeBlindAuthorizationContext, ScopeBlindExtension
+from .receipt import (
+    ScopeBlindArtifactDigest,
+    ScopeBlindReceipt,
+    ScopeBlindReceiptPayload,
+    attach_receipt_to_artifacts,
+    build_task_receipt_metadata,
+)
+from .verifier import (
+    VerificationResult,
+    verify_artifact_receipt,
+    verify_receipt,
+)
+
+__all__: list[str] = [
+    "ScopeBlindArtifactDigest",
+    "ScopeBlindAuthorizationContext",
+    "ScopeBlindExtension",
+    "ScopeBlindReceipt",
+    "ScopeBlindReceiptPayload",
+    "VerificationResult",
+    "attach_receipt_to_artifacts",
+    "build_task_receipt_metadata",
+    "verify_artifact_receipt",
+    "verify_receipt",
+]

--- a/bindu/extensions/scopeblind/extension.py
+++ b/bindu/extensions/scopeblind/extension.py
@@ -1,0 +1,358 @@
+"""ScopeBlind extension and Cedar policy evaluation."""
+
+from __future__ import annotations
+
+import os
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import cached_property
+from pathlib import Path
+from typing import Any, Literal, TypedDict
+
+import base58
+from cedar import Authorizer, Context, EntityUid, PolicySet, Request as CedarRequest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from bindu.common.protocol.types import AgentExtension, Artifact
+from bindu.settings import app_settings
+from bindu.utils.logging import get_logger
+
+from .receipt import (
+    ScopeBlindReceipt,
+    ScopeBlindReceiptPayload,
+    build_artifact_digest,
+    build_task_receipt_metadata,
+    sha256_digest,
+)
+
+logger = get_logger("bindu.scopeblind_extension")
+
+
+class ScopeBlindAuthorizationContext(TypedDict):
+    """JSON-serializable authorization context carried through execution."""
+
+    mode: Literal["enforce", "shadow"]
+    allowed: bool
+    decision: Literal["Allow", "Deny"]
+    policy_hash: str
+    policy_ids: list[str]
+    errors: list[str]
+    principal: dict[str, Any]
+    action: dict[str, Any]
+    resource: dict[str, Any]
+    context: dict[str, Any]
+    verification_key: str
+    issuer: str
+
+
+@dataclass(frozen=True)
+class ScopeBlindDecision:
+    """Internal authorization decision representation."""
+
+    allowed: bool
+    decision: Literal["Allow", "Deny"]
+    policy_ids: list[str]
+    errors: list[str]
+    principal: dict[str, Any]
+    action: dict[str, Any]
+    resource: dict[str, Any]
+    context: dict[str, Any]
+
+    def to_context(
+        self,
+        *,
+        mode: Literal["enforce", "shadow"],
+        policy_hash: str,
+        verification_key: str,
+        issuer: str,
+    ) -> ScopeBlindAuthorizationContext:
+        """Convert the decision into task-safe serialized context."""
+        return ScopeBlindAuthorizationContext(
+            mode=mode,
+            allowed=self.allowed,
+            decision=self.decision,
+            policy_hash=policy_hash,
+            policy_ids=self.policy_ids,
+            errors=self.errors,
+            principal=self.principal,
+            action=self.action,
+            resource=self.resource,
+            context=self.context,
+            verification_key=verification_key,
+            issuer=issuer,
+        )
+
+
+class ScopeBlindExtension:
+    """Authorization extension that signs receipts with a dedicated key."""
+
+    def __init__(
+        self,
+        mode: Literal["enforce", "shadow"],
+        cedar_policies: str,
+        key_dir: Path | None = None,
+    ):
+        """Initialize the ScopeBlind extension.
+
+        Args:
+            mode: Whether denials should block execution or be logged only
+            cedar_policies: Inline Cedar policy source or a file/directory path
+            key_dir: Optional directory for receipt signing keys
+        """
+        if mode not in ("enforce", "shadow"):
+            raise ValueError("mode must be either 'enforce' or 'shadow'")
+        if not cedar_policies:
+            raise ValueError("cedar_policies is required")
+
+        self.mode = mode
+        self.cedar_policies = cedar_policies
+        self._key_dir = Path(key_dir) if key_dir else Path(app_settings.scopeblind.pki_dir)
+        self.private_key_path = self._key_dir / app_settings.scopeblind.private_key_filename
+        self.public_key_path = self._key_dir / app_settings.scopeblind.public_key_filename
+        self.generate_and_save_key_pair()
+
+    def __repr__(self) -> str:
+        """Return string representation of the extension."""
+        return (
+            f"ScopeBlindExtension(mode={self.mode}, "
+            f"cedar_policies={self.cedar_policies!r})"
+        )
+
+    @cached_property
+    def policy_source(self) -> str:
+        """Load Cedar policy text from a string, file, or directory."""
+        raw_value = self.cedar_policies.strip()
+        expanded = Path(os.path.expanduser(raw_value))
+        if expanded.is_file():
+            return expanded.read_text(encoding="utf-8")
+        if expanded.is_dir():
+            policy_parts = [
+                path.read_text(encoding="utf-8")
+                for path in sorted(expanded.glob("*.cedar"))
+            ]
+            if not policy_parts:
+                raise ValueError(f"No Cedar policy files found in {expanded}")
+            return "\n".join(policy_parts)
+        return self.cedar_policies
+
+    @cached_property
+    def policy_hash(self) -> str:
+        """Stable hash of the active Cedar policy set."""
+        return sha256_digest(self.policy_source)
+
+    @cached_property
+    def policy_set(self) -> PolicySet:
+        """Parse the Cedar policy set once and cache it."""
+        return PolicySet(self.policy_source)
+
+    @cached_property
+    def authorizer(self) -> Authorizer:
+        """Shared Cedar authorizer instance."""
+        return Authorizer()
+
+    def _generate_key_pair_data(self) -> tuple[bytes, bytes]:
+        """Generate a dedicated Ed25519 keypair for receipt signing."""
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        public_key = private_key.public_key()
+        private_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        public_pem = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        return private_pem, public_pem
+
+    def generate_and_save_key_pair(self) -> None:
+        """Generate receipt signing keys if they do not already exist."""
+        self._key_dir.mkdir(parents=True, exist_ok=True)
+        if self.private_key_path.exists() and self.public_key_path.exists():
+            return
+
+        private_pem, public_pem = self._generate_key_pair_data()
+        self.private_key_path.write_bytes(private_pem)
+        self.public_key_path.write_bytes(public_pem)
+
+    @cached_property
+    def private_key(self) -> ed25519.Ed25519PrivateKey:
+        """Load the private signing key."""
+        key_bytes = self.private_key_path.read_bytes()
+        private_key = serialization.load_pem_private_key(key_bytes, password=None)
+        if not isinstance(private_key, ed25519.Ed25519PrivateKey):
+            raise ValueError("ScopeBlind private key is not Ed25519")
+        return private_key
+
+    @cached_property
+    def public_key(self) -> ed25519.Ed25519PublicKey:
+        """Load the public verification key."""
+        key_bytes = self.public_key_path.read_bytes()
+        public_key = serialization.load_pem_public_key(key_bytes)
+        if not isinstance(public_key, ed25519.Ed25519PublicKey):
+            raise ValueError("ScopeBlind public key is not Ed25519")
+        return public_key
+
+    @cached_property
+    def public_key_base58(self) -> str:
+        """Base58-encoded raw Ed25519 public key."""
+        raw_bytes = self.public_key.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        return base58.b58encode(raw_bytes).decode("ascii")
+
+    @cached_property
+    def issuer(self) -> str:
+        """Stable issuer identifier for receipt metadata."""
+        return f"scopeblind:{self.policy_hash[:16]}"
+
+    @cached_property
+    def agent_extension(self) -> AgentExtension:
+        """Get agent extension configuration for capabilities/agent card."""
+        return AgentExtension(
+            uri=app_settings.scopeblind.extension_uri,
+            description=app_settings.scopeblind.extension_description,
+            required=(self.mode == "enforce"),
+            params={
+                "mode": self.mode,
+                "verification_key": self.public_key_base58,
+                "policy_hash": self.policy_hash,
+            },
+        )
+
+    def _build_principal(self, request: Any) -> tuple[EntityUid, dict[str, Any]]:
+        """Build the Cedar principal from auth context or anonymous fallback."""
+        user_info = getattr(request.state, "user", None)
+        if isinstance(user_info, dict) and user_info.get("sub"):
+            principal_kind = "Service" if user_info.get("is_m2m") else "User"
+            principal_id = str(user_info["sub"])
+            principal_data = {
+                "entity_type": principal_kind,
+                "entity_id": principal_id,
+                "client_id": user_info.get("client_id", ""),
+                "scopes": user_info.get("scope", []) or [],
+                "authenticated": True,
+            }
+        else:
+            principal_kind = "Anonymous"
+            principal_id = "anonymous"
+            principal_data = {
+                "entity_type": principal_kind,
+                "entity_id": principal_id,
+                "client_id": "",
+                "scopes": [],
+                "authenticated": False,
+            }
+
+        return EntityUid(principal_kind, principal_id), principal_data
+
+    def _build_action(self, method: str) -> tuple[EntityUid, dict[str, Any]]:
+        """Build the Cedar action entity."""
+        return EntityUid("Action", method), {"entity_type": "Action", "entity_id": method}
+
+    def _build_resource(self, request: Any) -> tuple[EntityUid, dict[str, Any]]:
+        """Build the Cedar resource from the request path."""
+        path = getattr(request.url, "path", "/")
+        return EntityUid("Route", path), {"entity_type": "Route", "entity_id": path}
+
+    def _build_context(self, request: Any, method: str, request_data: dict[str, Any]) -> dict[str, Any]:
+        """Build the JSON context passed to Cedar and receipts."""
+        user_info = getattr(request.state, "user", None)
+        return {
+            "http_method": request.method,
+            "jsonrpc_method": method,
+            "path": request.url.path,
+            "client_ip": request.client.host if request.client else "unknown",
+            "authenticated": bool(getattr(request.state, "authenticated", False)),
+            "token_scopes": (user_info.get("scope", []) if isinstance(user_info, dict) else []),
+            "request_id": request_data.get("id"),
+        }
+
+    def evaluate_request(self, request: Any, method: str, request_data: dict[str, Any]) -> ScopeBlindDecision:
+        """Evaluate Cedar policies for the incoming request."""
+        principal_uid, principal = self._build_principal(request)
+        action_uid, action = self._build_action(method)
+        resource_uid, resource = self._build_resource(request)
+        context_data = self._build_context(request, method, request_data)
+
+        try:
+            cedar_request = CedarRequest(
+                principal=principal_uid,
+                action=action_uid,
+                resource=resource_uid,
+                context=Context(context_data),
+            )
+            response = self.authorizer.is_authorized(cedar_request, self.policy_set)
+            policy_ids = [str(reason) for reason in getattr(response, "reason", [])]
+            errors = [str(error) for error in getattr(response, "errors", [])]
+            allowed = bool(getattr(response, "allowed", False))
+            decision = "Allow" if allowed else "Deny"
+            return ScopeBlindDecision(
+                allowed=allowed,
+                decision=decision,
+                policy_ids=policy_ids,
+                errors=errors,
+                principal=principal,
+                action=action,
+                resource=resource,
+                context=context_data,
+            )
+        except Exception as error:
+            logger.error("ScopeBlind policy evaluation failed", error=str(error), exc_info=True)
+            return ScopeBlindDecision(
+                allowed=False,
+                decision="Deny",
+                policy_ids=[],
+                errors=[str(error)],
+                principal=principal,
+                action=action,
+                resource=resource,
+                context=context_data,
+            )
+
+    def create_receipt(
+        self,
+        *,
+        authorization_context: ScopeBlindAuthorizationContext,
+        artifacts: list[Artifact],
+        task_id: Any,
+        context_id: Any,
+        state: str,
+    ) -> ScopeBlindReceipt:
+        """Create and sign a receipt for the completed task."""
+        payload = ScopeBlindReceiptPayload(
+            version=app_settings.scopeblind.receipt_version,
+            mode=authorization_context["mode"],
+            decision=authorization_context["decision"],
+            issued_at=datetime.now(timezone.utc).isoformat(),
+            principal=authorization_context["principal"],
+            action=authorization_context["action"],
+            resource=authorization_context["resource"],
+            context=authorization_context["context"],
+            policy_hash=authorization_context["policy_hash"],
+            policy_ids=list(authorization_context.get("policy_ids", [])),
+            errors=list(authorization_context.get("errors", [])),
+            task_id=str(task_id) if task_id is not None else None,
+            context_id=str(context_id) if context_id is not None else None,
+            state=state,
+            artifacts=[build_artifact_digest(artifact) for artifact in artifacts],
+        )
+        payload_hash = sha256_digest(payload)
+        signature = self.private_key.sign(payload_hash.encode("utf-8"))
+        return ScopeBlindReceipt(
+            payload=payload,
+            payload_hash=payload_hash,
+            verification_key=self.public_key_base58,
+            signature=base58.b58encode(signature).decode("ascii"),
+            issuer=authorization_context.get("issuer", self.issuer),
+        )
+
+    def build_task_metadata(
+        self,
+        receipt: ScopeBlindReceipt,
+    ) -> dict[str, Any]:
+        """Build task metadata for a signed receipt."""
+        return build_task_receipt_metadata(receipt)

--- a/bindu/extensions/scopeblind/extension.py
+++ b/bindu/extensions/scopeblind/extension.py
@@ -170,12 +170,24 @@ class ScopeBlindExtension:
     def generate_and_save_key_pair(self) -> None:
         """Generate receipt signing keys if they do not already exist."""
         self._key_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(self._key_dir, 0o700)
+        except OSError:
+            logger.warning("Could not tighten ScopeBlind key dir permissions", path=str(self._key_dir))
         if self.private_key_path.exists() and self.public_key_path.exists():
             return
 
         private_pem, public_pem = self._generate_key_pair_data()
         self.private_key_path.write_bytes(private_pem)
+        try:
+            os.chmod(self.private_key_path, 0o600)
+        except OSError:
+            logger.warning("Could not tighten ScopeBlind private key permissions", path=str(self.private_key_path))
         self.public_key_path.write_bytes(public_pem)
+        try:
+            os.chmod(self.public_key_path, 0o644)
+        except OSError:
+            pass
 
     @cached_property
     def private_key(self) -> ed25519.Ed25519PrivateKey:

--- a/bindu/extensions/scopeblind/receipt.py
+++ b/bindu/extensions/scopeblind/receipt.py
@@ -1,0 +1,139 @@
+"""Receipt data structures and deterministic serialization helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+from uuid import UUID
+
+from bindu.common.protocol.types import Artifact
+from bindu.settings import app_settings
+
+
+ScopeBlindDecision = Literal["Allow", "Deny"]
+
+
+@dataclass(frozen=True)
+class ScopeBlindArtifactDigest:
+    """Digest entry describing one artifact covered by a receipt."""
+
+    artifact_id: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class ScopeBlindReceiptPayload:
+    """Canonical payload that is hashed and signed."""
+
+    version: str
+    mode: Literal["enforce", "shadow"]
+    decision: ScopeBlindDecision
+    issued_at: str
+    principal: dict[str, Any]
+    action: dict[str, Any]
+    resource: dict[str, Any]
+    context: dict[str, Any]
+    policy_hash: str
+    policy_ids: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    task_id: str | None = None
+    context_id: str | None = None
+    state: str | None = None
+    artifacts: list[ScopeBlindArtifactDigest] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ScopeBlindReceipt:
+    """Signed authorization receipt."""
+
+    payload: ScopeBlindReceiptPayload
+    payload_hash: str
+    verification_key: str
+    signature: str
+    algorithm: str = "ed25519"
+    issuer: str | None = None
+
+
+def _jsonable(value: Any) -> Any:
+    """Recursively convert values to deterministic JSON-safe structures."""
+    if is_dataclass(value):
+        return _jsonable(asdict(value))
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat()
+    if isinstance(value, dict):
+        return {str(key): _jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def deterministic_json_dumps(value: Any) -> str:
+    """Serialize JSON deterministically for hashing and signing."""
+    return json.dumps(
+        _jsonable(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def sha256_digest(value: Any) -> str:
+    """Compute a stable SHA-256 digest for the given value."""
+    return hashlib.sha256(deterministic_json_dumps(value).encode("utf-8")).hexdigest()
+
+
+def receipt_to_dict(receipt: ScopeBlindReceipt) -> dict[str, Any]:
+    """Convert a receipt dataclass to a plain JSON-serializable dict."""
+    return _jsonable(receipt)
+
+
+def _artifact_without_scopeblind_metadata(artifact: Artifact) -> dict[str, Any]:
+    """Return a copy of the artifact excluding scopeblind receipt metadata."""
+    artifact_copy = dict(_jsonable(artifact))
+    metadata = artifact_copy.get("metadata")
+    if isinstance(metadata, dict):
+        metadata.pop(app_settings.scopeblind.meta_receipts_key, None)
+        if not metadata:
+            artifact_copy.pop("metadata", None)
+    return artifact_copy
+
+
+def build_artifact_digest(artifact: Artifact) -> ScopeBlindArtifactDigest:
+    """Build the digest entry used in receipt payloads."""
+    artifact_id = artifact.get("artifact_id")
+    return ScopeBlindArtifactDigest(
+        artifact_id=str(artifact_id) if artifact_id is not None else "",
+        sha256=sha256_digest(_artifact_without_scopeblind_metadata(artifact)),
+    )
+
+
+def attach_receipt_to_artifacts(
+    artifacts: list[Artifact],
+    receipt: ScopeBlindReceipt,
+) -> list[Artifact]:
+    """Attach the receipt to every artifact's metadata in-place."""
+    receipt_dict = receipt_to_dict(receipt)
+    for artifact in artifacts:
+        metadata = artifact.setdefault("metadata", {})
+        if isinstance(metadata, dict):
+            receipts = metadata.setdefault(app_settings.scopeblind.meta_receipts_key, [])
+            if isinstance(receipts, list):
+                receipts.append(receipt_dict)
+    return artifacts
+
+
+def build_task_receipt_metadata(receipt: ScopeBlindReceipt) -> dict[str, Any]:
+    """Build task metadata entries for a receipt."""
+    receipt_dict = receipt_to_dict(receipt)
+    return {
+        app_settings.scopeblind.meta_decision_key: receipt.payload.decision.lower(),
+        app_settings.scopeblind.meta_mode_key: receipt.payload.mode,
+        app_settings.scopeblind.meta_policy_hash_key: receipt.payload.policy_hash,
+        app_settings.scopeblind.meta_receipts_key: [receipt_dict],
+    }

--- a/bindu/extensions/scopeblind/verifier.py
+++ b/bindu/extensions/scopeblind/verifier.py
@@ -1,0 +1,121 @@
+"""Verification helpers for ScopeBlind receipts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import base58
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from bindu.common.protocol.types import Artifact
+
+from .receipt import build_artifact_digest, sha256_digest
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Structured verification outcome."""
+
+    valid: bool
+    signature_valid: bool
+    integrity_valid: bool
+    error: str | None = None
+
+
+def _payload_hash(payload: dict[str, Any]) -> str:
+    """Hash a receipt payload deterministically."""
+    return sha256_digest(payload)
+
+
+def _decode_public_key(base58_key: str) -> ed25519.Ed25519PublicKey:
+    """Decode a base58-encoded raw Ed25519 public key."""
+    raw_key = base58.b58decode(base58_key)
+    return ed25519.Ed25519PublicKey.from_public_bytes(raw_key)
+
+
+def verify_receipt(
+    receipt: dict[str, Any],
+    verification_key: str | None = None,
+) -> VerificationResult:
+    """Verify receipt integrity and signature.
+
+    The verifier can use the embedded verification key, which keeps receipt
+    verification separate from DID identity and other issuer infrastructure.
+    """
+    try:
+        payload = receipt["payload"]
+        expected_hash = _payload_hash(payload)
+        payload_hash = receipt.get("payload_hash")
+        if not isinstance(payload_hash, str) or expected_hash != payload_hash:
+            return VerificationResult(
+                valid=False,
+                signature_valid=False,
+                integrity_valid=False,
+                error="payload hash mismatch",
+            )
+
+        key = verification_key or receipt.get("verification_key")
+        if not isinstance(key, str) or not key:
+            return VerificationResult(
+                valid=False,
+                signature_valid=False,
+                integrity_valid=True,
+                error="missing verification key",
+            )
+
+        public_key = _decode_public_key(key)
+        signature = base58.b58decode(receipt["signature"])
+        public_key.verify(signature, payload_hash.encode("utf-8"))
+        return VerificationResult(
+            valid=True,
+            signature_valid=True,
+            integrity_valid=True,
+        )
+    except (InvalidSignature, KeyError, TypeError, ValueError) as error:
+        return VerificationResult(
+            valid=False,
+            signature_valid=False,
+            integrity_valid=False,
+            error=str(error),
+        )
+
+
+def verify_artifact_receipt(
+    artifact: Artifact,
+    receipt: dict[str, Any],
+    verification_key: str | None = None,
+) -> VerificationResult:
+    """Verify that an artifact still matches the digest embedded in a receipt."""
+    receipt_result = verify_receipt(receipt, verification_key=verification_key)
+    if not receipt_result.valid:
+        return receipt_result
+
+    artifact_id = str(artifact.get("artifact_id", ""))
+    artifact_digests = receipt.get("payload", {}).get("artifacts", [])
+    matching_digest = next(
+        (
+            digest
+            for digest in artifact_digests
+            if digest.get("artifact_id") == artifact_id
+        ),
+        None,
+    )
+    if matching_digest is None:
+        return VerificationResult(
+            valid=False,
+            signature_valid=True,
+            integrity_valid=False,
+            error="artifact digest missing from receipt",
+        )
+
+    actual_digest = build_artifact_digest(artifact).sha256
+    expected_digest = matching_digest.get("sha256")
+    integrity_valid = actual_digest == expected_digest
+    return VerificationResult(
+        valid=receipt_result.signature_valid and integrity_valid,
+        signature_valid=receipt_result.signature_valid,
+        integrity_valid=integrity_valid,
+        error=None if integrity_valid else "artifact digest mismatch",
+    )

--- a/bindu/penguin/bindufy.py
+++ b/bindu/penguin/bindufy.py
@@ -158,15 +158,22 @@ def _setup_scopeblind_extension(
     caller_dir: Path | None = None,
 ) -> ScopeBlindExtension:
     """Create ScopeBlind extension from config."""
-    cedar_policies = scopeblind_config["cedar_policies"]
-    policy_path = Path(os.path.expanduser(cedar_policies))
-    if not policy_path.is_absolute() and caller_dir is not None:
-        policy_path = (caller_dir / policy_path).resolve()
+    raw_cedar_policies = scopeblind_config["cedar_policies"].strip()
+    policy_path = Path(os.path.expanduser(raw_cedar_policies))
+    resolved_policy_path = policy_path
+    if not resolved_policy_path.is_absolute() and caller_dir is not None:
+        resolved_policy_path = (caller_dir / resolved_policy_path).resolve()
+
+    cedar_policies = (
+        str(resolved_policy_path)
+        if resolved_policy_path.exists()
+        else raw_cedar_policies
+    )
 
     key_dir = ((caller_dir or Path.cwd()) / app_settings.scopeblind.pki_dir).resolve()
     extension = ScopeBlindExtension(
         mode=scopeblind_config.get("mode", "enforce"),
-        cedar_policies=str(policy_path),
+        cedar_policies=cedar_policies,
         key_dir=key_dir,
     )
     logger.info(f"ScopeBlind extension created: {extension}")

--- a/bindu/penguin/bindufy.py
+++ b/bindu/penguin/bindufy.py
@@ -22,6 +22,7 @@ from bindu.common.models import (
     DeploymentConfig,
     TelemetryConfig,
 )
+from bindu.extensions.scopeblind import ScopeBlindExtension
 from bindu.extensions.x402 import X402AgentExtension
 from bindu.penguin.did_setup import initialize_did_extension
 from bindu.penguin.manifest import create_manifest, validate_agent_function
@@ -150,6 +151,26 @@ def _setup_x402_extension(normalized_costs: list[dict[str, Any]]) -> X402AgentEx
 
     logger.info(f"X402 extension created: {x402_extension}")
     return x402_extension
+
+
+def _setup_scopeblind_extension(
+    scopeblind_config: dict[str, Any],
+    caller_dir: Path | None = None,
+) -> ScopeBlindExtension:
+    """Create ScopeBlind extension from config."""
+    cedar_policies = scopeblind_config["cedar_policies"]
+    policy_path = Path(os.path.expanduser(cedar_policies))
+    if not policy_path.is_absolute() and caller_dir is not None:
+        policy_path = (caller_dir / policy_path).resolve()
+
+    key_dir = ((caller_dir or Path.cwd()) / app_settings.scopeblind.pki_dir).resolve()
+    extension = ScopeBlindExtension(
+        mode=scopeblind_config.get("mode", "enforce"),
+        cedar_policies=str(policy_path),
+        key_dir=key_dir,
+    )
+    logger.info(f"ScopeBlind extension created: {extension}")
+    return extension
 
 
 def _register_in_hydra(
@@ -481,6 +502,22 @@ def _bindufy_core(
     capabilities = add_extension_to_capabilities(
         validated_config.get("capabilities", {}), did_extension
     )
+
+    scopeblind_extension = next(
+        (
+            ext
+            for ext in capabilities.get("extensions", [])
+            if isinstance(ext, ScopeBlindExtension)
+        ),
+        None,
+    )
+
+    if scopeblind_extension is None and validated_config.get("scopeblind"):
+        scopeblind_extension = _setup_scopeblind_extension(
+            validated_config["scopeblind"],
+            caller_dir=caller_dir,
+        )
+        capabilities = add_extension_to_capabilities(capabilities, scopeblind_extension)
 
     # Only add x402 extension if execution_cost is configured
     execution_cost = validated_config.get("execution_cost")

--- a/bindu/penguin/config_validator.py
+++ b/bindu/penguin/config_validator.py
@@ -49,6 +49,7 @@ class ConfigValidator:
         "extra_metadata": {},
         "agent_trust": None,
         "key_password": None,
+        "scopeblind": None,
         "auth": None,
         "oltp_endpoint": None,
         "oltp_service_name": None,
@@ -270,6 +271,20 @@ class ConfigValidator:
                 # Any other type is invalid
                 raise ValueError(
                     "Field 'execution_cost' must be a dict or a list of dicts"
+                )
+
+        if "scopeblind" in config and config["scopeblind"] is not None:
+            if not isinstance(config["scopeblind"], dict):
+                raise ValueError("Field 'scopeblind' must be a dictionary")
+            mode = config["scopeblind"].get("mode", "enforce")
+            if mode not in ["enforce", "shadow"]:
+                raise ValueError(
+                    "Field 'scopeblind.mode' must be 'enforce' or 'shadow'"
+                )
+            cedar_policies = config["scopeblind"].get("cedar_policies")
+            if not isinstance(cedar_policies, str) or not cedar_policies.strip():
+                raise ValueError(
+                    "Field 'scopeblind.cedar_policies' must be a non-empty string"
                 )
 
     # ------------------------------------------------------------------

--- a/bindu/server/applications.py
+++ b/bindu/server/applications.py
@@ -31,13 +31,16 @@ from starlette.types import Lifespan, Receive, Scope, Send
 
 from bindu.common.models import (
     AgentManifest,
-    TelemetryConfig,
-    StorageConfig,
     SchedulerConfig,
     SentryConfig,
+    StorageConfig,
+    TelemetryConfig,
 )
 from bindu.settings import app_settings
-from bindu.utils import get_x402_extension_from_capabilities
+from bindu.utils import (
+    get_scopeblind_extension_from_capabilities,
+    get_x402_extension_from_capabilities,
+)
 from bindu.utils.retry import execute_with_retry
 
 from .scheduler.base import Scheduler
@@ -110,6 +113,7 @@ class BinduApplication(Starlette):
 
         # Setup middleware chain
         x402_ext = get_x402_extension_from_capabilities(manifest)
+        scopeblind_ext = get_scopeblind_extension_from_capabilities(manifest)
         payment_requirements_for_middleware = None
         if x402_ext:
             # Type narrowing: if x402_ext exists, manifest must exist
@@ -123,6 +127,7 @@ class BinduApplication(Starlette):
         middleware_list = self._setup_middleware(
             middleware,
             x402_ext,
+            scopeblind_ext,
             payment_requirements_for_middleware,
             manifest,
             auth_enabled,
@@ -147,6 +152,7 @@ class BinduApplication(Starlette):
         self._scheduler: Scheduler | None = None
         self._agent_card_json_schema: bytes | None = None
         self._x402_ext = x402_ext
+        self._scopeblind_ext = scopeblind_ext
         self._payment_session_manager = None
         self._payment_requirements = None
         self._paywall_config = None
@@ -539,6 +545,7 @@ class BinduApplication(Starlette):
         self,
         middleware: Sequence[Middleware] | None,
         x402_ext: Any,
+        scopeblind_ext: Any,
         payment_requirements: list[Any] | None,
         manifest: AgentManifest,
         auth_enabled: bool,
@@ -549,6 +556,7 @@ class BinduApplication(Starlette):
         Args:
             middleware: Custom middleware to include
             x402_ext: X402 extension instance
+            scopeblind_ext: ScopeBlind extension instance
             payment_requirements: Payment requirements for X402
             manifest: Agent manifest
             auth_enabled: Whether authentication is enabled
@@ -605,6 +613,20 @@ class BinduApplication(Starlette):
             auth_middleware = self._create_auth_middleware()
             # Add auth middleware after CORS and X402
             middleware_list.append(auth_middleware)
+
+        if scopeblind_ext:
+            from .middleware import ScopeBlindMiddleware
+
+            logger.info(
+                "ScopeBlind authorization middleware enabled",
+                mode=scopeblind_ext.mode,
+                policy_hash=scopeblind_ext.policy_hash,
+            )
+            scopeblind_middleware = Middleware(
+                ScopeBlindMiddleware,  # type: ignore[arg-type]
+                scopeblind_ext=scopeblind_ext,
+            )
+            middleware_list.append(scopeblind_middleware)
 
         # Add metrics middleware (should be last to capture all requests)
         from .middleware import MetricsMiddleware

--- a/bindu/server/endpoints/a2a_protocol.py
+++ b/bindu/server/endpoints/a2a_protocol.py
@@ -86,6 +86,23 @@ def _attach_payment_context(request: Request, a2a_request: Any, method: str) -> 
         )
 
 
+def _attach_scopeblind_context(request: Request, a2a_request: Any, method: str) -> None:
+    """Attach ScopeBlind authorization context to message metadata if available."""
+    if method not in ("message/send", "message/stream"):
+        return
+
+    scopeblind_context = getattr(request.state, "scopeblind_context", None)
+    if scopeblind_context is None:
+        return
+
+    if "params" not in a2a_request or "message" not in a2a_request["params"]:
+        return
+
+    msg_obj = a2a_request["params"]["message"]
+    msg_obj.setdefault("metadata", {})
+    msg_obj["metadata"]["_scopeblind_context"] = scopeblind_context
+
+
 def _serialize_state_obj(obj: Any) -> dict:
     """Safely serialize a payment state object to a plain dict.
 
@@ -185,6 +202,7 @@ async def agent_run_endpoint(app: BinduApplication, request: Request) -> Respons
 
         # Attach payment context to message metadata if available
         _attach_payment_context(request, a2a_request, method)
+        _attach_scopeblind_context(request, a2a_request, method)
 
         jsonrpc_response = await handler(a2a_request)
 

--- a/bindu/server/endpoints/agent_card.py
+++ b/bindu/server/endpoints/agent_card.py
@@ -44,6 +44,10 @@ def _serialize_extension(ext: Any) -> dict | None:
                 "agent_id": ext.agent_id,
             },
         }
+    elif hasattr(ext, "agent_extension"):
+        serialized = getattr(ext, "agent_extension")
+        if isinstance(serialized, dict):
+            return serialized
     elif isinstance(ext, dict):
         # Already in correct format
         return ext

--- a/bindu/server/handlers/message_handlers.py
+++ b/bindu/server/handlers/message_handlers.py
@@ -156,6 +156,9 @@ class MessageHandlers:
         payment_context = message_metadata.pop("_payment_context", None)
         if payment_context is not None:
             scheduler_params["payment_context"] = payment_context
+        scopeblind_context = message_metadata.pop("_scopeblind_context", None)
+        if scopeblind_context is not None:
+            scheduler_params["scopeblind_context"] = scopeblind_context
         await self.scheduler.run_task(scheduler_params)
         return task, context_id
 

--- a/bindu/server/middleware/__init__.py
+++ b/bindu/server/middleware/__init__.py
@@ -10,7 +10,7 @@
 """MIDDLEWARE MODULE EXPORTS.
 
 This module provides middleware layers for the bindu framework including
-authentication and payment protocol enforcement.
+authentication, payment protocol enforcement, and authorization receipts.
 
 MIDDLEWARE STRUCTURE:
 
@@ -22,6 +22,9 @@ MIDDLEWARE STRUCTURE:
    - X402Middleware: x402 payment protocol enforcement
      Automatically handles payment verification and settlement for agents
      with execution_cost configured.
+
+3. AUTHORIZATION MIDDLEWARE:
+   - ScopeBlindMiddleware: Cedar policy enforcement with signed receipts
 """
 
 from __future__ import annotations as _annotations
@@ -31,6 +34,7 @@ from .auth import HydraMiddleware
 
 # Export payment middleware from x402/ subdirectory
 from .x402 import X402Middleware
+from .scopeblind import ScopeBlindMiddleware
 
 # Export metrics middleware
 from .metrics import MetricsMiddleware
@@ -40,6 +44,8 @@ __all__ = [
     "HydraMiddleware",
     # Payment middleware
     "X402Middleware",
+    # Authorization middleware
+    "ScopeBlindMiddleware",
     # Metrics middleware
     "MetricsMiddleware",
 ]

--- a/bindu/server/middleware/scopeblind.py
+++ b/bindu/server/middleware/scopeblind.py
@@ -1,0 +1,113 @@
+"""ScopeBlind authorization middleware for Bindu."""
+
+from __future__ import annotations
+
+import json
+
+from opentelemetry.trace import get_current_span
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from bindu.common.protocol.types import InsufficientPermissionsError
+from bindu.server.endpoints.utils import extract_error_fields, jsonrpc_error
+from bindu.settings import app_settings
+from bindu.utils.logging import get_logger
+
+logger = get_logger("bindu.server.middleware.scopeblind")
+
+PROTECTED_PATH = "/"
+PROTECTED_METHOD = "POST"
+
+
+class ScopeBlindMiddleware(BaseHTTPMiddleware):
+    """Evaluate Cedar policies before a task is submitted."""
+
+    def __init__(self, app, scopeblind_ext):
+        """Initialize ScopeBlind middleware."""
+        super().__init__(app)
+        self.scopeblind_ext = scopeblind_ext
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        """Authorize the incoming request and propagate receipt context."""
+        if (
+            not self.scopeblind_ext
+            or request.url.path != PROTECTED_PATH
+            or request.method != PROTECTED_METHOD
+        ):
+            return await call_next(request)
+
+        try:
+            body = await request.body()
+            request_data = json.loads(body.decode("utf-8"))
+            method = request_data.get("method", "")
+
+            from starlette.requests import Request as StarletteRequest
+
+            async def receive():
+                return {"type": "http.request", "body": body}
+
+            request = StarletteRequest(request.scope, receive)
+        except Exception as error:
+            logger.warning(
+                "ScopeBlind middleware could not parse request body",
+                error=str(error),
+            )
+            return await call_next(request)
+
+        if method not in app_settings.scopeblind.protected_methods:
+            return await call_next(request)
+
+        decision = self.scopeblind_ext.evaluate_request(request, method, request_data)
+        auth_context = decision.to_context(
+            mode=self.scopeblind_ext.mode,
+            policy_hash=self.scopeblind_ext.policy_hash,
+            verification_key=self.scopeblind_ext.public_key_base58,
+            issuer=self.scopeblind_ext.issuer,
+        )
+        request.state.scopeblind_context = auth_context
+        self._set_span_attributes(auth_context)
+
+        if not decision.allowed and self.scopeblind_ext.mode == "enforce":
+            logger.warning(
+                "ScopeBlind denied request in enforce mode",
+                method=method,
+                policy_ids=decision.policy_ids,
+                errors=decision.errors,
+            )
+            code, message = extract_error_fields(InsufficientPermissionsError)
+            return jsonrpc_error(
+                code,
+                message,
+                "ScopeBlind denied this action under the configured Cedar policies.",
+                request_id=request_data.get("id"),
+                status=403,
+            )
+
+        if not decision.allowed:
+            logger.warning(
+                "ScopeBlind denied request in shadow mode; allowing execution",
+                method=method,
+                policy_ids=decision.policy_ids,
+                errors=decision.errors,
+            )
+
+        return await call_next(request)
+
+    @staticmethod
+    def _set_span_attributes(auth_context: dict[str, object]) -> None:
+        """Attach ScopeBlind metadata to the active span when available."""
+        current_span = get_current_span()
+        if current_span.is_recording():
+            current_span.set_attribute(
+                "bindu.scopeblind.decision",
+                str(auth_context.get("decision", "")),
+            )
+            current_span.set_attribute(
+                "bindu.scopeblind.mode",
+                str(auth_context.get("mode", "")),
+            )
+            current_span.set_attribute(
+                "bindu.scopeblind.policy_hash",
+                str(auth_context.get("policy_hash", "")),
+            )

--- a/bindu/server/workers/manifest_worker.py
+++ b/bindu/server/workers/manifest_worker.py
@@ -35,6 +35,7 @@ from uuid import UUID
 from opentelemetry.trace import Status, StatusCode, get_current_span, get_tracer
 from x402.facilitator import FacilitatorClient, FacilitatorConfig
 
+from bindu.extensions.scopeblind import attach_receipt_to_artifacts
 from bindu.settings import app_settings
 
 from bindu.common.protocol.types import (
@@ -48,6 +49,7 @@ from bindu.common.protocol.types import (
 from bindu.penguin.manifest import AgentManifest
 from bindu.server.workers.base import Worker
 from bindu.server.workers.helpers import ResponseDetector, ResultProcessor
+from bindu.utils.capabilities import get_scopeblind_extension_from_capabilities
 from bindu.utils.logging import get_logger
 from bindu.utils.retry import retry_worker_operation
 from bindu.utils.worker import ArtifactBuilder, MessageConverter, TaskStateManager
@@ -123,6 +125,7 @@ class ManifestWorker(Worker):
 
         # Extract payment context if available (from x402 middleware)
         payment_context = params.get("payment_context")
+        scopeblind_context = params.get("scopeblind_context")
 
         await TaskStateManager.validate_task_state(task)
 
@@ -216,7 +219,11 @@ class ManifestWorker(Worker):
                 # Add span event for state transition
                 self._add_state_change_event(from_state="working", to_state=state)
                 await self._handle_terminal_state(
-                    task, results, state, payment_context=payment_context
+                    task,
+                    results,
+                    state,
+                    payment_context=payment_context,
+                    scopeblind_context=scopeblind_context,
                 )
 
         except Exception as e:
@@ -428,6 +435,7 @@ class ManifestWorker(Worker):
         state: TaskState = "completed",
         additional_metadata: dict[str, Any] | None = None,
         payment_context: dict[str, Any] | None = None,
+        scopeblind_context: dict[str, Any] | None = None,
     ) -> None:
         """Handle terminal task states (completed/failed).
 
@@ -451,6 +459,7 @@ class ManifestWorker(Worker):
             state: Terminal state (completed or failed)
             additional_metadata: Optional metadata to attach to task
             payment_context: Optional payment details from x402 middleware
+            scopeblind_context: Optional authorization details from ScopeBlind middleware
 
         Raises:
             ValueError: If state is not a terminal state
@@ -479,6 +488,14 @@ class ManifestWorker(Worker):
                 else:
                     additional_metadata = settlement_metadata
 
+            additional_metadata = self._apply_scopeblind_receipt(
+                task=task,
+                state=state,
+                artifacts=artifacts,
+                additional_metadata=additional_metadata,
+                scopeblind_context=scopeblind_context,
+            )
+
             # Persist task state BEFORE sending any notifications (outbox pattern).
             # If a notification fires before the DB write and then the process crashes,
             # clients receive an artifact webhook but the task is still "working" in the
@@ -502,6 +519,13 @@ class ManifestWorker(Worker):
             error_message = MessageConverter.to_protocol_messages(
                 results, task["id"], task["context_id"]
             )
+            additional_metadata = self._apply_scopeblind_receipt(
+                task=task,
+                state=state,
+                artifacts=[],
+                additional_metadata=additional_metadata,
+                scopeblind_context=scopeblind_context,
+            )
             await self.storage.update_task(
                 task["id"],
                 state=state,
@@ -514,6 +538,61 @@ class ManifestWorker(Worker):
             # Canceled: State change only, NO new content
             await self.storage.update_task(task["id"], state=state)
             await self._notify_lifecycle(task["id"], task["context_id"], state, True)
+
+    def _apply_scopeblind_receipt(
+        self,
+        *,
+        task: Task,
+        state: str,
+        artifacts: list[Artifact],
+        additional_metadata: dict[str, Any] | None,
+        scopeblind_context: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Create and attach ScopeBlind receipt metadata when present."""
+        if scopeblind_context is None:
+            return additional_metadata
+
+        scopeblind_ext = get_scopeblind_extension_from_capabilities(self.manifest)
+        if scopeblind_ext is None:
+            return additional_metadata
+
+        receipt = scopeblind_ext.create_receipt(
+            authorization_context=scopeblind_context,
+            artifacts=artifacts,
+            task_id=task["id"],
+            context_id=task["context_id"],
+            state=state,
+        )
+        if artifacts:
+            attach_receipt_to_artifacts(artifacts, receipt)
+
+        receipt_metadata = scopeblind_ext.build_task_metadata(receipt)
+        merged_metadata = dict(additional_metadata or {})
+        merged_metadata.update(receipt_metadata)
+        self._set_scopeblind_span_attributes(receipt)
+        return merged_metadata
+
+    @staticmethod
+    def _set_scopeblind_span_attributes(receipt: Any) -> None:
+        """Attach ScopeBlind receipt metadata to the current span."""
+        current_span = get_current_span()
+        if current_span.is_recording():
+            current_span.set_attribute(
+                "bindu.scopeblind.decision",
+                receipt.payload.decision,
+            )
+            current_span.set_attribute(
+                "bindu.scopeblind.mode",
+                receipt.payload.mode,
+            )
+            current_span.set_attribute(
+                "bindu.scopeblind.policy_hash",
+                receipt.payload.policy_hash,
+            )
+            current_span.set_attribute(
+                "bindu.scopeblind.payload_hash",
+                receipt.payload_hash,
+            )
 
     async def _handle_task_failure(self, task: Task, error: str) -> None:
         """Handle task execution failure.

--- a/bindu/settings.py
+++ b/bindu/settings.py
@@ -343,6 +343,30 @@ class X402Settings(BaseSettings):
     }
 
 
+class ScopeBlindSettings(BaseSettings):
+    """ScopeBlind authorization receipt configuration settings."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_prefix="SCOPEBLIND__",
+        extra="allow",
+    )
+
+    extension_uri: str = "https://github.com/getbindu/bindu/extensions/scopeblind/v0.1"
+    extension_description: str = (
+        "Cedar-backed authorization receipts for verifiable agent actions"
+    )
+    protected_methods: list[str] = ["message/send", "message/stream"]
+    receipt_version: str = "1"
+    pki_dir: str = ".scopeblind"
+    private_key_filename: str = "scopeblind_private.pem"
+    public_key_filename: str = "scopeblind_public.pem"
+    meta_receipts_key: str = "scopeblind.receipts"
+    meta_decision_key: str = "scopeblind.decision"
+    meta_mode_key: str = "scopeblind.mode"
+    meta_policy_hash_key: str = "scopeblind.policy_hash"
+
+
 class AgentSettings(BaseSettings):
     """Agent behavior and protocol configuration settings."""
 
@@ -1033,6 +1057,7 @@ class Settings(BaseSettings):
     logging: LoggingSettings = LoggingSettings()
     observability: ObservabilitySettings = ObservabilitySettings()
     x402: X402Settings = X402Settings()
+    scopeblind: ScopeBlindSettings = ScopeBlindSettings()
     agent: AgentSettings = AgentSettings()
     auth: AuthSettings = AuthSettings()
     hydra: HydraSettings = HydraSettings()

--- a/bindu/utils/__init__.py
+++ b/bindu/utils/__init__.py
@@ -13,6 +13,7 @@ Backward compatibility maintained through re-exports.
 # Core utilities (kept at top level)
 from .capabilities import (
     add_extension_to_capabilities,
+    get_scopeblind_extension_from_capabilities,
     get_x402_extension_from_capabilities,
 )
 from .exceptions import (
@@ -41,6 +42,7 @@ __all__ = [
     "find_skill_by_id",
     # Capability utilities
     "add_extension_to_capabilities",
+    "get_scopeblind_extension_from_capabilities",
     "get_x402_extension_from_capabilities",
     # DID utilities
     "validate_did_extension",

--- a/bindu/utils/capabilities.py
+++ b/bindu/utils/capabilities.py
@@ -55,3 +55,14 @@ def get_x402_extension_from_capabilities(manifest: Any) -> Optional[Any]:
             return ext
 
     return None
+
+
+def get_scopeblind_extension_from_capabilities(manifest: Any) -> Optional[Any]:
+    """Extract ScopeBlind extension from manifest capabilities."""
+    from bindu.extensions.scopeblind import ScopeBlindExtension
+
+    for ext in manifest.capabilities.get("extensions", []):
+        if isinstance(ext, ScopeBlindExtension):
+            return ext
+
+    return None

--- a/docs/SCOPEBLIND.md
+++ b/docs/SCOPEBLIND.md
@@ -1,0 +1,99 @@
+# ScopeBlind Authorization Receipts
+
+ScopeBlind adds verifiable authorization receipts to Bindu agents.
+
+It complements DID signing instead of replacing it:
+
+- DID answers: "Which agent produced this artifact?"
+- ScopeBlind answers: "Was this action authorized under the configured policy?"
+
+## What It Does
+
+- Evaluates Cedar policies before task execution
+- Blocks denied actions in `enforce` mode
+- Logs denied actions but still executes in `shadow` mode
+- Signs a deterministic receipt with a dedicated Ed25519 key
+- Attaches receipts to completed task metadata and artifact metadata
+- Supports verification without depending on the agent DID key
+
+## Configuration
+
+Use top-level `scopeblind` config in `bindufy()`:
+
+```python
+from bindu.penguin.bindufy import bindufy
+
+config = {
+    "author": "you@example.com",
+    "name": "policy-agent",
+    "deployment": {"url": "http://localhost:3773"},
+    "scopeblind": {
+        "mode": "enforce",
+        "cedar_policies": "./policies",
+    },
+}
+
+bindufy(config, handler)
+```
+
+You can also add a `ScopeBlindExtension` directly to `capabilities.extensions` if you are assembling capabilities manually.
+
+## Cedar Policies
+
+ScopeBlind accepts either:
+
+- a directory containing `*.cedar` files
+- a single Cedar policy file path
+- an inline Cedar policy string
+
+Example policy:
+
+```cedar
+permit(principal, action == Action::"message/send", resource);
+```
+
+Example deny policy:
+
+```cedar
+forbid(principal, action == Action::"message/send", resource);
+```
+
+## Receipt Metadata
+
+Completed tasks and artifacts include metadata under:
+
+- `scopeblind.receipts`
+- `scopeblind.decision`
+- `scopeblind.mode`
+- `scopeblind.policy_hash`
+
+The receipt payload includes:
+
+- principal, action, resource, and context
+- the policy hash used for evaluation
+- the final decision
+- artifact digests covered by the receipt
+- a detached Ed25519 signature over the payload hash
+
+## Verification
+
+Verify receipts with the helper functions:
+
+```python
+from bindu.extensions.scopeblind import verify_receipt, verify_artifact_receipt
+
+receipt_result = verify_receipt(receipt_dict)
+artifact_result = verify_artifact_receipt(artifact_dict, receipt_dict)
+```
+
+Verification checks:
+
+- payload hash integrity
+- Ed25519 signature validity
+- artifact digest integrity
+
+## Key Separation
+
+ScopeBlind uses its own signing key material under `.scopeblind/`.
+
+This is intentionally separate from the DID extension so identity and authorization remain distinct.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "tenacity==9.1.4",
     "pynacl==1.5.0",
     "numpy==2.3.5",
+    "cedar-python==0.1.4",
     #Native File Handling
     "pypdf==5.1.0",
     "python-docx==1.1.2",

--- a/tests/unit/extensions/scopeblind/test_scopeblind_extension.py
+++ b/tests/unit/extensions/scopeblind/test_scopeblind_extension.py
@@ -1,0 +1,159 @@
+"""Tests for the ScopeBlind extension and verifier."""
+
+from __future__ import annotations
+
+import json
+
+from pathlib import Path
+from uuid import uuid4
+
+from starlette.requests import Request
+
+from bindu.common.protocol.types import Artifact, TextPart
+from bindu.extensions.scopeblind import (
+    ScopeBlindExtension,
+    verify_artifact_receipt,
+    verify_receipt,
+)
+
+
+def _write_policy(policy_dir: Path, content: str) -> Path:
+    """Write a Cedar policy file into the given directory."""
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    policy_path = policy_dir / "policy.cedar"
+    policy_path.write_text(content, encoding="utf-8")
+    return policy_path
+
+
+def _build_request(method_name: str = "message/send") -> Request:
+    """Build a Starlette request for authorization evaluation tests."""
+    body = json.dumps({"jsonrpc": "2.0", "id": "1", "method": method_name}).encode(
+        "utf-8"
+    )
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "raw_path": b"/",
+        "scheme": "http",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "state": {},
+    }
+    request = Request(scope, receive)
+    request.state.authenticated = True
+    request.state.user = {
+        "sub": "alice",
+        "is_m2m": False,
+        "scope": ["agent:invoke"],
+        "client_id": "client-1",
+    }
+    return request
+
+
+class TestScopeBlindExtension:
+    """Test ScopeBlind extension functionality."""
+
+    def test_agent_extension_metadata(self, tmp_path: Path):
+        """Agent card metadata should expose receipt verification details."""
+        policy_dir = tmp_path / "policies"
+        _write_policy(
+            policy_dir,
+            'permit(principal, action == Action::"message/send", resource);',
+        )
+        extension = ScopeBlindExtension(
+            mode="enforce",
+            cedar_policies=str(policy_dir),
+            key_dir=tmp_path / "keys",
+        )
+
+        agent_extension = extension.agent_extension
+
+        assert agent_extension["required"] is True
+        assert agent_extension["params"]["mode"] == "enforce"
+        assert (
+            agent_extension["params"]["verification_key"] == extension.public_key_base58
+        )
+        assert agent_extension["params"]["policy_hash"] == extension.policy_hash
+
+    def test_receipt_verification_and_tampering(self, tmp_path: Path):
+        """Receipts should verify cleanly and fail after tampering."""
+        policy_dir = tmp_path / "policies"
+        _write_policy(
+            policy_dir,
+            'permit(principal, action == Action::"message/send", resource);',
+        )
+        extension = ScopeBlindExtension(
+            mode="enforce",
+            cedar_policies=str(policy_dir),
+            key_dir=tmp_path / "keys",
+        )
+        request = _build_request()
+        decision = extension.evaluate_request(
+            request,
+            "message/send",
+            {"jsonrpc": "2.0", "id": "1", "method": "message/send"},
+        )
+        auth_context = decision.to_context(
+            mode=extension.mode,
+            policy_hash=extension.policy_hash,
+            verification_key=extension.public_key_base58,
+            issuer=extension.issuer,
+        )
+
+        artifact = Artifact(
+            artifact_id=uuid4(),
+            name="result",
+            parts=[TextPart(kind="text", text="authorized")],
+        )
+        receipt = extension.create_receipt(
+            authorization_context=auth_context,
+            artifacts=[artifact],
+            task_id=uuid4(),
+            context_id=uuid4(),
+            state="completed",
+        )
+        receipt_dict = {
+            "payload": {
+                **receipt.payload.__dict__,
+                "artifacts": [digest.__dict__ for digest in receipt.payload.artifacts],
+            },
+            "payload_hash": receipt.payload_hash,
+            "verification_key": receipt.verification_key,
+            "signature": receipt.signature,
+            "algorithm": receipt.algorithm,
+            "issuer": receipt.issuer,
+        }
+
+        verification = verify_receipt(receipt_dict)
+        artifact_verification = verify_artifact_receipt(artifact, receipt_dict)
+
+        assert verification.valid is True
+        assert artifact_verification.valid is True
+
+        tampered_receipt = dict(receipt_dict)
+        tampered_payload = dict(receipt_dict["payload"])
+        tampered_payload["decision"] = "Deny"
+        tampered_receipt["payload"] = tampered_payload
+
+        tampered_receipt_result = verify_receipt(tampered_receipt)
+        assert tampered_receipt_result.valid is False
+        assert tampered_receipt_result.error == "payload hash mismatch"
+
+        tampered_artifact = Artifact(
+            artifact_id=artifact["artifact_id"],
+            name=artifact["name"],
+            parts=[TextPart(kind="text", text="tampered")],
+        )
+        tampered_artifact_result = verify_artifact_receipt(
+            tampered_artifact,
+            receipt_dict,
+        )
+        assert tampered_artifact_result.valid is False
+        assert tampered_artifact_result.integrity_valid is False

--- a/tests/unit/penguin/test_bindufy.py
+++ b/tests/unit/penguin/test_bindufy.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from bindu.penguin.bindufy import (
     _generate_agent_id,
     _normalize_execution_costs,
+    _setup_scopeblind_extension,
     _setup_x402_extension,
     _parse_deployment_url,
     bindufy,
@@ -180,6 +181,26 @@ class TestBindufyUtilities:
         extension = _setup_x402_extension(costs)
 
         assert extension.pay_to_address == "0x123"
+
+    def test_setup_scopeblind_extension(self, tmp_path):
+        """Test creating ScopeBlind extension from config."""
+        policy_dir = tmp_path / "policies"
+        policy_dir.mkdir(parents=True, exist_ok=True)
+        (policy_dir / "policy.cedar").write_text(
+            'permit(principal, action == Action::"message/send", resource);',
+            encoding="utf-8",
+        )
+
+        extension = _setup_scopeblind_extension(
+            {
+                "mode": "shadow",
+                "cedar_policies": str(policy_dir),
+            },
+            caller_dir=tmp_path,
+        )
+
+        assert extension.mode == "shadow"
+        assert extension.cedar_policies == str(policy_dir)
 
 
 def test_bindufy_non_callable_handler_raises_clear_error():

--- a/tests/unit/server/endpoints/test_agent_card.py
+++ b/tests/unit/server/endpoints/test_agent_card.py
@@ -40,6 +40,20 @@ class TestAgentCardUtilities:
 
         assert result is None
 
+    def test_serialize_extension_agent_extension_type(self):
+        """Test serializing extensions that expose agent_extension metadata."""
+
+        class MockExtension:
+            agent_extension = {
+                "uri": "https://example.com/scopeblind",
+                "required": True,
+                "params": {"mode": "enforce"},
+            }
+
+        result = _serialize_extension(MockExtension())
+
+        assert result == MockExtension.agent_extension
+
     def test_serialize_extensions_in_place(self):
         """Test serializing extensions list in capabilities."""
         mock_ext = Mock()

--- a/tests/unit/server/middleware/test_scopeblind.py
+++ b/tests/unit/server/middleware/test_scopeblind.py
@@ -1,0 +1,126 @@
+"""Tests for ScopeBlind middleware."""
+
+from __future__ import annotations
+
+import json
+
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from bindu.extensions.scopeblind import ScopeBlindExtension
+from bindu.server.middleware.scopeblind import ScopeBlindMiddleware
+
+
+def _write_policy(policy_dir: Path, content: str) -> None:
+    """Write a test Cedar policy."""
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    (policy_dir / "policy.cedar").write_text(content, encoding="utf-8")
+
+
+def _build_request() -> Request:
+    """Build a test HTTP request."""
+    body = json.dumps({"jsonrpc": "2.0", "id": "1", "method": "message/send"}).encode(
+        "utf-8"
+    )
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "raw_path": b"/",
+        "scheme": "http",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "state": {},
+    }
+    request = Request(scope, receive)
+    request.state.authenticated = True
+    request.state.user = {
+        "sub": "alice",
+        "is_m2m": False,
+        "scope": ["agent:invoke"],
+        "client_id": "client-1",
+    }
+    return request
+
+
+class TestScopeBlindMiddleware:
+    """Test ScopeBlind middleware behavior."""
+
+    @pytest.mark.asyncio
+    async def test_allow_calls_next(self, tmp_path: Path):
+        """Allowed requests should continue through the middleware chain."""
+        policy_dir = tmp_path / "policies"
+        _write_policy(
+            policy_dir,
+            'permit(principal, action == Action::"message/send", resource);',
+        )
+        extension = ScopeBlindExtension(
+            mode="enforce",
+            cedar_policies=str(policy_dir),
+            key_dir=tmp_path / "keys",
+        )
+        middleware = ScopeBlindMiddleware(app=Mock(), scopeblind_ext=extension)
+        request = _build_request()
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 200
+        call_next.assert_called_once()
+        assert request.state.scopeblind_context["decision"] == "Allow"
+
+    @pytest.mark.asyncio
+    async def test_enforce_deny_blocks_execution(self, tmp_path: Path):
+        """Denied requests in enforce mode should return 403 and skip execution."""
+        policy_dir = tmp_path / "policies"
+        _write_policy(
+            policy_dir,
+            'forbid(principal, action == Action::"message/send", resource);',
+        )
+        extension = ScopeBlindExtension(
+            mode="enforce",
+            cedar_policies=str(policy_dir),
+            key_dir=tmp_path / "keys",
+        )
+        middleware = ScopeBlindMiddleware(app=Mock(), scopeblind_ext=extension)
+        request = _build_request()
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 403
+        call_next.assert_not_called()
+        assert request.state.scopeblind_context["decision"] == "Deny"
+
+    @pytest.mark.asyncio
+    async def test_shadow_deny_allows_execution(self, tmp_path: Path):
+        """Denied requests in shadow mode should continue and preserve denial context."""
+        policy_dir = tmp_path / "policies"
+        _write_policy(
+            policy_dir,
+            'forbid(principal, action == Action::"message/send", resource);',
+        )
+        extension = ScopeBlindExtension(
+            mode="shadow",
+            cedar_policies=str(policy_dir),
+            key_dir=tmp_path / "keys",
+        )
+        middleware = ScopeBlindMiddleware(app=Mock(), scopeblind_ext=extension)
+        request = _build_request()
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 200
+        call_next.assert_called_once()
+        assert request.state.scopeblind_context["decision"] == "Deny"

--- a/tests/unit/server/workers/test_manifest_worker.py
+++ b/tests/unit/server/workers/test_manifest_worker.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 
 from bindu.common.protocol.types import Task, TaskSendParams
+from bindu.extensions.scopeblind import ScopeBlindExtension
 from bindu.server.workers.manifest_worker import ManifestWorker
 
 
@@ -390,6 +391,77 @@ class TestManifestWorker:
         )
 
         mock_storage.update_task.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_terminal_state_attaches_scopeblind_receipt(self, tmp_path):
+        """Completed tasks should persist ScopeBlind receipt metadata on tasks and artifacts."""
+        policy_dir = tmp_path / "policies"
+        policy_dir.mkdir(parents=True, exist_ok=True)
+        (policy_dir / "policy.cedar").write_text(
+            'permit(principal, action == Action::"message/send", resource);',
+            encoding="utf-8",
+        )
+        scopeblind_ext = ScopeBlindExtension(
+            mode="shadow",
+            cedar_policies=str(policy_dir),
+            key_dir=tmp_path / "keys",
+        )
+
+        mock_manifest = Mock()
+        mock_manifest.did_extension = Mock()
+        mock_manifest.did_extension.did = "did:example:123"
+        mock_manifest.did_extension.sign_text = Mock(return_value="did-signature")
+        mock_manifest.capabilities = {"extensions": [scopeblind_ext]}
+        mock_scheduler = Mock()
+        mock_storage = AsyncMock()
+
+        task_id = uuid4()
+        context_id = uuid4()
+        task = cast(
+            Task,
+            {
+                "id": task_id,
+                "context_id": context_id,
+                "status": {"state": "working", "timestamp": "2024-01-01T00:00:00Z"},
+            },
+        )
+
+        worker = ManifestWorker(
+            manifest=mock_manifest, scheduler=mock_scheduler, storage=mock_storage
+        )
+
+        scopeblind_context = {
+            "mode": "shadow",
+            "allowed": False,
+            "decision": "Deny",
+            "policy_hash": scopeblind_ext.policy_hash,
+            "policy_ids": [],
+            "errors": [],
+            "principal": {"entity_type": "User", "entity_id": "alice"},
+            "action": {"entity_type": "Action", "entity_id": "message/send"},
+            "resource": {"entity_type": "Route", "entity_id": "/"},
+            "context": {"jsonrpc_method": "message/send"},
+            "verification_key": scopeblind_ext.public_key_base58,
+            "issuer": scopeblind_ext.issuer,
+        }
+
+        await worker._handle_terminal_state(
+            task,
+            "Task completed",
+            "completed",
+            scopeblind_context=scopeblind_context,
+        )
+
+        call_kwargs = mock_storage.update_task.call_args.kwargs
+        assert call_kwargs["state"] == "completed"
+        assert "scopeblind.receipts" in call_kwargs["metadata"]
+        assert call_kwargs["metadata"]["scopeblind.decision"] == "deny"
+        receipt = call_kwargs["metadata"]["scopeblind.receipts"][0]
+        artifact = call_kwargs["new_artifacts"][0]
+        assert (
+            artifact["metadata"]["scopeblind.receipts"][0]["payload_hash"]
+            == receipt["payload_hash"]
+        )
 
     def test_add_state_change_event_with_error(self):
         """Test adding state change event with error."""

--- a/tests/unit/utils/test_capabilities.py
+++ b/tests/unit/utils/test_capabilities.py
@@ -2,6 +2,7 @@
 
 from bindu.utils.capabilities import (
     add_extension_to_capabilities,
+    get_scopeblind_extension_from_capabilities,
     get_x402_extension_from_capabilities,
 )
 
@@ -64,3 +65,21 @@ class TestCapabilityUtilities:
         result = get_x402_extension_from_capabilities(manifest)
 
         assert result is None
+
+    def test_get_scopeblind_extension_found(self, tmp_path):
+        """Test retrieving scopeblind extension when present."""
+        from unittest.mock import Mock
+
+        from bindu.extensions.scopeblind import ScopeBlindExtension
+
+        ext = ScopeBlindExtension(
+            mode="enforce",
+            cedar_policies="permit(principal, action, resource);",
+            key_dir=tmp_path / "scopeblind-keys",
+        )
+        manifest = Mock()
+        manifest.capabilities = {"extensions": ["other-ext", ext]}
+
+        result = get_scopeblind_extension_from_capabilities(manifest)
+
+        assert result == ext

--- a/uv.lock
+++ b/uv.lock
@@ -374,6 +374,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "base58" },
     { name = "cdp-sdk" },
+    { name = "cedar-python" },
     { name = "cookiecutter" },
     { name = "cryptography" },
     { name = "detect-secrets" },
@@ -479,6 +480,7 @@ requires-dist = [
     { name = "base58", specifier = "==2.1.1" },
     { name = "base58", marker = "extra == 'core'", specifier = "==2.1.1" },
     { name = "cdp-sdk", specifier = "==0.21.0" },
+    { name = "cedar-python", specifier = "==0.1.4" },
     { name = "cookiecutter", specifier = "==2.6.0" },
     { name = "cryptography", specifier = "==44.0.2" },
     { name = "cryptography", marker = "extra == 'core'", specifier = "==44.0.2" },
@@ -714,6 +716,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/a9/a6710aba25bce3af9e0c5aa7f5174f762e21bbf959befabc35ef2ff5d01f/cdp_sdk-0.21.0.tar.gz", hash = "sha256:6d832189e84cec76c3353f52835ddf06789630325ca5f0ea1a48ad663b698e7d", size = 136408, upload-time = "2025-02-28T22:58:54.515Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/44/3eb4efd9f262ccf3281b6662b1d1270cf2574b85f4900d5c40101cb3a463/cdp_sdk-0.21.0-py3-none-any.whl", hash = "sha256:36a2ec372c79354133f142566674f6f5a21f474d31f378154a3b4e0e0089818a", size = 350638, upload-time = "2025-02-28T22:58:53.344Z" },
+]
+
+[[package]]
+name = "cedar-python"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/bc/eaeeb3683fb8d9a262187d42255197549458cfa5c6bf49c5ff36e0d22355/cedar_python-0.1.4.tar.gz", hash = "sha256:6006a0db7fc314bb0d157e6d6d259acb380bb02a2735c919554581145a648043", size = 126765, upload-time = "2026-01-20T22:10:36.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/80/e05bf327f350a8ec64c94194f54740854ef77633124822f980e61a02834c/cedar_python-0.1.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:e85fb56f955db469898d930613c29660bb5ab76fb395b3f04089d60e228b2ebe", size = 3970434, upload-time = "2026-01-20T22:10:02.553Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/f8f3254579695b6916297e35e566edee3b5999ca20bfd1e2a90f102dd099/cedar_python-0.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:350139ace8f9baa983538a1601128b2f8a77639ceed10de50e86f030b5405233", size = 3830992, upload-time = "2026-01-20T22:10:05.528Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e1/4f68a70034759b061d2aa0a8b21e2c92edae7c654e52e93146e7bc89b969/cedar_python-0.1.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6091f3a82efbdf6979eaacec92cd410903e727fddf39021811de95a031cc5d90", size = 4215255, upload-time = "2026-01-20T22:10:08.44Z" },
+    { url = "https://files.pythonhosted.org/packages/00/cd/cb798acc873f3b1a844278c412b59df76c81dc3c2827041de08d7b691c7e/cedar_python-0.1.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eca6ab21cca34c79a8770ca540c18b78006e0a8f4db4308e2697b00101c8f34", size = 4348426, upload-time = "2026-01-20T22:10:10.801Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/e5/43bc79c0289871e6195c24df06cecf13bb9012ec4a8d5ae669238d6ddbf4/cedar_python-0.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:532f7fdff3a55aad8443f5ac3183fa0937effc5162098aaf5efe1ff627da6387", size = 3734435, upload-time = "2026-01-20T22:10:13.332Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/43/c51a75d9677c2cbdc2938900b8aef30381c1bf1bb2830d00fbba2aea8ca5/cedar_python-0.1.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9f697cef012c95e96a40354922e461aa2b7c952fdf0d4cb3af365ee17f513b74", size = 3969880, upload-time = "2026-01-20T22:10:15.481Z" },
+    { url = "https://files.pythonhosted.org/packages/19/96/dfeead1ed7cd00870cff8f7cbc482ac6c5f8d5e9f8eb94ce297a9517adca/cedar_python-0.1.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b6f08055fa92536791eb69d141ab3baf8ba93c5553c1c2b0893e282dbca27b49", size = 3830481, upload-time = "2026-01-20T22:10:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c3/d521b6f937814b0b3880f89eb0ced64284633e730ed9dd18c636e97a6bc3/cedar_python-0.1.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3343dfa00f63c8cdfa285bb516136697c23ad015f71f2212ddc18f4a3d1e8287", size = 4214991, upload-time = "2026-01-20T22:10:20.689Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/d4dcc53d9967ce443ec3d47f0e74a917852a40cfa0e1682a66e738c592a4/cedar_python-0.1.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6dcd098df1e00b66f3398a1b166f70248a4c01e2a1dd8d5437b5956e6ddab5d", size = 4348235, upload-time = "2026-01-20T22:10:22.852Z" },
+    { url = "https://files.pythonhosted.org/packages/03/4f/50ffdfa7fff50aef0ad81cffe1ce4883c79819a55ac6b46cba69ec09cfb9/cedar_python-0.1.4-cp313-cp313-win_amd64.whl", hash = "sha256:b38e0c7c9acad95f1e84e561b88e178a49c54d56e51c33a40c0d6b80d07385b9", size = 3733591, upload-time = "2026-01-20T22:10:25.418Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/bf/ae630a82bb8c75bd8969cf457275fd6d47350e0ab2b74f030603195e6e00/cedar_python-0.1.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:282bdde7236645a08ba63aaf2cfc920c2d7ff391aabf1a1528e81155f64e4daa", size = 3968250, upload-time = "2026-01-20T22:10:27.347Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/c67c024fbf6e678c1a4cff379e290fc505fdace4b727a51065802af471b5/cedar_python-0.1.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b41b5b447affd68ca2bce5567d1e4b65bce222ed5d5102bdd9c8f159802a6f68", size = 3827892, upload-time = "2026-01-20T22:10:29.595Z" },
+    { url = "https://files.pythonhosted.org/packages/59/12/60dff22827d64f6f768e748d5bac39f11fdbf2f6017a02425522a87c22dd/cedar_python-0.1.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9c4f6169b1d44d7e4fe419b46159459c669626a525c49ef5697853ee1da4457", size = 4213378, upload-time = "2026-01-20T22:10:31.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/35/4a3bed56fcb5e1df31e7582ed8591a2c5bc62c15bd0fabf37b9032a2d4ee/cedar_python-0.1.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9526b582aaa7027f601b3ab3d929768db436ff2fac5924468fd9f3db7cc91e4", size = 4346180, upload-time = "2026-01-20T22:10:33.463Z" },
+    { url = "https://files.pythonhosted.org/packages/61/29/8bccab1c1fe1c03ca4b36022c04d58961a475c82ef986ce14136a8f4bc86/cedar_python-0.1.4-cp314-cp314-win_amd64.whl", hash = "sha256:a8781f5a01ab770e0cda1cd3e2cc6d90114091353f896c7774b371f06195f992", size = 3730311, upload-time = "2026-01-20T22:10:34.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

* **Problem**: No standardized mechanism to enforce authorization policies and produce verifiable audit artifacts for agent actions.
* **Why it matters**: Without cryptographically verifiable receipts, agent actions lack trust, auditability, and external verification—critical for multi-agent and cross-domain systems.
* **What changed**: Introduced `ScopeBlindExtension` with Cedar policy evaluation, middleware enforcement/shadow modes, and deterministic signed receipts attached to task/artifact lifecycle.
* **What did NOT change** (scope boundary): Existing extensions (DID, x402), task execution model, and middleware architecture remain unchanged.

---

## Change Type (select all that apply)

* [ ] Bug fix
* [x] Feature
* [ ] Refactor
* [x] Documentation
* [x] Security hardening
* [x] Tests
* [ ] Chore/infra

---

## Scope (select all touched areas)

* [x] Server / API endpoints
* [x] Extensions (DID, x402, etc.)
* [ ] Storage backends
* [ ] Scheduler backends
* [x] Observability / monitoring
* [x] Authentication / authorization
* [ ] CLI / utilities
* [x] Tests
* [x] Documentation
* [ ] CI/CD / infra

---

## Linked Issue/PR

* Closes #439
* Related # (if any)

---

## User-Visible / Behavior Changes

* New optional extension: `ScopeBlindExtension`
* New config:

  * `mode`: `"enforce"` (default strict) or `"shadow"`
  * `cedar_policies`: policy definition string
* In **enforce mode**: unauthorized actions are blocked
* In **shadow mode**: unauthorized actions are allowed but logged
* Task results and artifacts now include signed authorization receipts when extension is enabled

---

## Security Impact (required)

* New permissions/capabilities? **Yes**
* Secrets/credentials handling changed? **Yes**
* New/changed network calls? **No**
* Database schema/migration changes? **No**
* Authentication/authorization changes? **Yes**

**Risk + Mitigation:**

* **Risk**: Incorrect Cedar policies may unintentionally deny or allow actions

  * **Mitigation**: Shadow mode allows safe validation before enforcement
* **Risk**: Key misuse for signing receipts

  * **Mitigation**: Dedicated ScopeBlind key separation (not tied to DID identity)
* **Risk**: Receipt tampering

  * **Mitigation**: SHA-256 hashing + Ed25519 signature verification ensures integrity

---

## Verification

### Environment

* OS: Linux
* Python version: 3.11
* Storage backend: Default (local/in-memory)
* Scheduler backend: Default worker-based execution

### Steps to Test

1. Enable `ScopeBlindExtension` with a Cedar policy
2. Trigger agent action (allowed and denied cases)
3. Inspect task/artifact metadata for attached receipt
4. Verify receipt signature and integrity using verifier

### Expected Behavior

* Allowed actions execute normally with attached receipt
* Denied actions:

  * Blocked in enforce mode
  * Logged but executed in shadow mode
* Receipts are deterministic and verifiable

### Actual Behavior

* Matches expected behavior across all tested scenarios

---

## Evidence (attach at least one)

* [x] Test output / logs
* [x] Failing test before + passing after

(See: `.local/test-results.json`, `.local/scopeblind-pytest.txt`) 

---

## Human Verification (required)

* **Verified scenarios**:

  * Allow policy → execution succeeds with receipt
  * Deny policy (enforce) → execution blocked
  * Deny policy (shadow) → execution allowed with warning
  * Receipt verification (valid signature)
  * Receipt tampering detection

* **Edge cases checked**:

  * Empty/invalid policies
  * Deterministic serialization consistency
  * Missing signature / corrupted payload

* **What you did NOT verify**:

  * Large-scale distributed verification across external systems
  * Performance under extreme throughput

---

## Compatibility / Migration

* Backward compatible? **Yes**
* Config/env changes? **Yes**
* Database migration needed? **No**

**If yes, exact upgrade steps:**

1. Add `ScopeBlindExtension` to configuration
2. Provide Cedar policy string
3. Choose mode (`shadow` recommended initially)

---

## Failure Recovery (if this breaks)

* How to disable/revert this change quickly:

  * Remove/disable `ScopeBlindExtension` from config

* Files/config to restore:

  * Extension registration in application config

* Known bad symptoms reviewers should watch for:

  * Unexpected action denials
  * Missing receipts in metadata
  * Signature verification failures

---

## Risks and Mitigations

* **Risk**: Policy misconfiguration blocks valid workflows

  * **Mitigation**: Use shadow mode before enforce
* **Risk**: Increased latency due to signing/verification

  * **Mitigation**: Lightweight hashing + Ed25519 (minimal overhead)

---

## Checklist

* [x] Tests pass (`uv run pytest`)
* [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
* [x] Documentation updated (if needed)
* [x] Security impact assessed
* [x] Human verification completed
* [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ScopeBlind authorization receipts with verifiable signatures and artifact digests.
  * Middleware evaluates policies (enforce/shadow) on protected requests, records decisions, and attaches receipts to completed tasks/artifacts.
  * Agent metadata now exposes ScopeBlind extension and verification info.

* **Documentation**
  * Added comprehensive ScopeBlind docs covering configuration, modes, receipts, and verification.

* **Configuration**
  * New ScopeBlind settings for policies, mode, keys, and metadata keys.

* **Tests**
  * Added unit tests for middleware, extension, verification, and task receipt attachment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->