### PR TITLE
fix(ci): unblock main — allowlist gateway fixtures + pydocstyle in backfill

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,6 +127,42 @@
     }
   ],
   "results": {
+    "gateway/tests/bindu/protocol.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "gateway/tests/bindu/protocol.test.ts",
+        "hashed_secret": "5695d82df36a3f4285afb43feae4003d435b1a9e",
+        "is_verified": false,
+        "line_number": 41
+      }
+    ],
+    "scripts/dryrun-fixtures/echo-agent/NOTES.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/dryrun-fixtures/echo-agent/NOTES.md",
+        "hashed_secret": "d85a0b4a463c6fc39387457c95a6897b41cf53be",
+        "is_verified": false,
+        "line_number": 66
+      }
+    ],
+    "scripts/dryrun-fixtures/echo-agent/did-doc.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/dryrun-fixtures/echo-agent/did-doc.json",
+        "hashed_secret": "d85a0b4a463c6fc39387457c95a6897b41cf53be",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "scripts/dryrun-fixtures/echo-agent/final-task.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/dryrun-fixtures/echo-agent/final-task.json",
+        "hashed_secret": "b756d744e3ca6f6a1400eee09c6c2d1c589fa033",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
     "tests/unit/auth/test_hydra_client.py": [
       {
         "type": "Secret Keyword",
@@ -268,5 +304,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-19T19:49:25Z"
+  "generated_at": "2026-04-19T08:24:51Z"
 }

--- a/scripts/backfill_owner_did.py
+++ b/scripts/backfill_owner_did.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""One-shot backfill script for the owner_did column.
+r"""One-shot backfill script for the owner_did column.
 
 Use this after deploying alembic revision 20260418_0001 (which adds the
 nullable owner_did column) and BEFORE rolling out the Phase 2 enforcement
@@ -12,9 +12,9 @@ Usage:
 
     python scripts/backfill_owner_did.py --owner-did did:bindu:legacy
     python scripts/backfill_owner_did.py --owner-did did:bindu:legacy --dry-run
-    python scripts/backfill_owner_did.py --owner-did did:bindu:legacy \\
-        --database-url postgresql+asyncpg://user:pw@host/bindu
-    python scripts/backfill_owner_did.py --owner-did did:bindu:legacy \\
+    python scripts/backfill_owner_did.py --owner-did did:bindu:legacy \
+        --database-url postgresql+asyncpg://user:pw@host/bindu  # pragma: allowlist secret
+    python scripts/backfill_owner_did.py --owner-did did:bindu:legacy \
         --schema did_bindu_alice
 
 ``--schema`` targets a single DID-specific schema created by the
@@ -43,7 +43,9 @@ from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
 
 
 def _parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     p.add_argument(
         "--owner-did",
         required=True,
@@ -97,12 +99,8 @@ async def _run(
         async with engine.begin() as conn:
             tasks_null = await _count_null(conn, schema, "tasks")
             contexts_null = await _count_null(conn, schema, "contexts")
-            print(
-                f"schema={schema} tasks.owner_did IS NULL: {tasks_null} rows"
-            )
-            print(
-                f"schema={schema} contexts.owner_did IS NULL: {contexts_null} rows"
-            )
+            print(f"schema={schema} tasks.owner_did IS NULL: {tasks_null} rows")
+            print(f"schema={schema} contexts.owner_did IS NULL: {contexts_null} rows")
 
             if dry_run:
                 print("--dry-run: rolling back, no data changed.")
@@ -140,6 +138,10 @@ def _resolve_database_url(explicit: str | None) -> str:
 
 
 def main(runner: Callable[..., Awaitable[int]] = _run) -> int:
+    """CLI entry point. Returns a process exit code.
+
+    ``runner`` is injectable for tests — defaults to the real ``_run``.
+    """
     args = _parse_args()
     database_url = _resolve_database_url(args.database_url)
     return asyncio.run(


### PR DESCRIPTION
## Why

Post-merge CI on `main` broke after #463 landed — two pre-commit
hooks fail in the [failing run](https://github.com/GetBindu/Bindu/actions/runs/24614599903):

1. **`detect-secrets`** — 4 high-entropy strings in gateway dry-run
   fixtures + tests are not present in `.secrets.baseline`:
   - `scripts/dryrun-fixtures/echo-agent/NOTES.md:66` (sample DID doc public key)
   - `scripts/dryrun-fixtures/echo-agent/did-doc.json:13` (same public key)
   - `scripts/dryrun-fixtures/echo-agent/final-task.json:47` (sample DID signature)
   - `gateway/tests/bindu/protocol.test.ts:41` (deterministic hex test expectation)
   - plus one flag on a docstring example URL in `scripts/backfill_owner_did.py`

2. **`pydocstyle`** on `scripts/backfill_owner_did.py` — two issues:
   - `D301`: docstring contains literal `\\` (bash line-continuations) without `r"""` prefix
   - `D103`: `main()` missing a docstring

## Fix

### `.secrets.baseline`
Re-ran `detect-secrets scan --baseline .secrets.baseline` to pick up the
4 new fixture/test locations. Entries land as unaudited (`is_secret`
unset) — same shape as the existing 22 baseline entries, so the
pre-commit hook passes. The pre-push `verify-secrets-audited` hook is
orthogonal and is not in the failing CI step.

### `scripts/backfill_owner_did.py`
- Docstring is now a raw string (`r"""..."""`) — the `\` line-continuations
  in the usage examples render as proper shell backslashes in `--help`
  output and pydocstyle no longer complains.
- `main()` gains a one-line docstring.
- The placeholder `postgresql+asyncpg://user:pw@host/bindu` in the
  docstring keeps an inline `# pragma: allowlist secret` so it does
  not need a second baseline entry.

## Local verification

```
$ detect-secrets-hook --baseline .secrets.baseline <flagged files>
→ exit 0

$ pydocstyle scripts/backfill_owner_did.py
→ exit 0

$ pytest tests/unit/
→ 795 passed, 3 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret scanning baseline with new findings.
  * Updated baseline generation timestamp.

* **Style & Refactor**
  * Improved code formatting and documentation in internal scripts.
  * Enhanced CLI script with clearer parameter organization and improved internal comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->