### PR TITLE
fix(manifest): derive agent card identity_provider from runtime auth

### DIFF
--- a/bindu/penguin/manifest.py
+++ b/bindu/penguin/manifest.py
@@ -38,12 +38,33 @@ REQUIRED_PARAM_NAME = "messages"
 def _create_default_agent_trust() -> AgentTrust:
     """Create a default AgentTrust configuration with minimal required fields.
 
+    The ``identity_provider`` field is derived from the active auth
+    configuration rather than hardcoded. If Hydra OAuth2 is enabled at
+    runtime (``AUTH__ENABLED=true`` and ``AUTH__PROVIDER=hydra``), the agent
+    card advertises ``"hydra"`` — matching what the middleware layer actually
+    enforces. Otherwise it advertises ``"custom"`` (the previous default).
+
+    Users who pass an explicit ``agent_trust`` to the config still override
+    this default entirely; see ``create_agent_manifest``.
+
     Returns:
         AgentTrust: A minimal valid AgentTrust instance for agents without
                     explicit trust configuration.
     """
+    # Lazy import to avoid a circular dependency between penguin/manifest.py
+    # and anything that settings might reach into at import time.
+    from bindu.settings import app_settings
+
+    identity_provider: Literal["hydra", "custom"] = "custom"
+    configured_provider = getattr(app_settings.auth, "provider", None) or ""
+    if (
+        getattr(app_settings.auth, "enabled", False)
+        and configured_provider.lower() == "hydra"
+    ):
+        identity_provider = "hydra"
+
     return AgentTrust(
-        identity_provider="custom",
+        identity_provider=identity_provider,
         inherited_roles=[],
         creator_id="system",
         creation_timestamp=int(datetime.now(UTC).timestamp()),

--- a/tests/unit/penguin/test_manifest.py
+++ b/tests/unit/penguin/test_manifest.py
@@ -1,8 +1,13 @@
 """Minimal focused tests for manifest creation."""
 
+from unittest.mock import patch
+
 import pytest
 
-from bindu.penguin.manifest import validate_agent_function
+from bindu.penguin.manifest import (
+    _create_default_agent_trust,
+    validate_agent_function,
+)
 
 
 class TestValidateAgentFunction:
@@ -43,3 +48,54 @@ class TestValidateAgentFunction:
 
         with pytest.raises(ValueError, match="must have only"):
             validate_agent_function(agent_func)
+
+
+class TestDefaultAgentTrustIdentityProvider:
+    """The agent-card's advertised identity_provider must match the runtime
+    auth provider. A mismatch caused the card to say 'custom' while the
+    HydraMiddleware was actually enforcing DID signatures on the wire —
+    confusing operators and lying to peers discovering the agent."""
+
+    def test_defaults_to_custom_when_auth_disabled(self):
+        with patch("bindu.settings.app_settings") as mock_settings:
+            mock_settings.auth.enabled = False
+            mock_settings.auth.provider = ""
+            trust = _create_default_agent_trust()
+        assert trust["identity_provider"] == "custom"
+
+    def test_returns_hydra_when_auth_enabled_and_provider_is_hydra(self):
+        with patch("bindu.settings.app_settings") as mock_settings:
+            mock_settings.auth.enabled = True
+            mock_settings.auth.provider = "hydra"
+            trust = _create_default_agent_trust()
+        assert trust["identity_provider"] == "hydra"
+
+    def test_returns_hydra_case_insensitive(self):
+        """Env var or config may carry 'Hydra' or 'HYDRA' — should still
+        match the middleware's case-insensitive comparison."""
+        with patch("bindu.settings.app_settings") as mock_settings:
+            mock_settings.auth.enabled = True
+            mock_settings.auth.provider = "HYDRA"
+            trust = _create_default_agent_trust()
+        assert trust["identity_provider"] == "hydra"
+
+    def test_returns_custom_when_auth_enabled_but_provider_is_not_hydra(self):
+        """Guard the Literal contract — if a future provider lands that
+        isn't yet a valid IdentityProvider value, we must fall back to
+        'custom' rather than emit a type-invalid card."""
+        with patch("bindu.settings.app_settings") as mock_settings:
+            mock_settings.auth.enabled = True
+            mock_settings.auth.provider = "some-future-provider"
+            trust = _create_default_agent_trust()
+        assert trust["identity_provider"] == "custom"
+
+    def test_returns_custom_when_auth_enabled_but_provider_missing(self):
+        """Defensive — enabled without a provider is a misconfig, but must
+        not crash the default trust path."""
+        with patch("bindu.settings.app_settings") as mock_settings:
+            mock_settings.auth.enabled = True
+            # provider attribute missing entirely
+            del mock_settings.auth.provider
+            mock_settings.auth.provider = None  # re-set as None for getattr
+            trust = _create_default_agent_trust()
+        assert trust["identity_provider"] == "custom"


### PR DESCRIPTION
## The bug (reproducible)

Run a Bindu agent with `AUTH__ENABLED=true` and `AUTH__PROVIDER=hydra` in `.env`. Two observers give different answers:

1. **The wire** — `HydraMiddleware` enforces DID signatures. Unsigned requests get `403` with `Invalid DID signature`.
2. **The agent card** — `GET /.well-known/agent.json` returns:
   ```json
   "agentTrust": {
     "identityProvider": "custom",
     ...
   }
   ```

That's a lie to peers discovering the agent. The middleware is clearly running Hydra; the card says custom. Operators debugging auth issues (and downstream agents making trust decisions based on the card) are both misled.

## Root cause

[`bindu/penguin/manifest.py:46`](../../blob/main/bindu/penguin/manifest.py#L46) — `_create_default_agent_trust()` hardcodes `identity_provider=\"custom\"` regardless of runtime config. Meanwhile [`bindu/server/applications.py:629`](../../blob/main/bindu/server/applications.py#L629) reads `app_settings.auth.provider` to decide which middleware to install. Two functions, one fact, two answers.

## Fix

`_create_default_agent_trust()` now reads the same `app_settings.auth` the middleware layer reads. If `auth.enabled` is true and `auth.provider` is `hydra` (case-insensitive), the card reports `\"hydra\"`; otherwise falls back to `\"custom\"`.

Defensive coercion handles `None` as a provider value — caught by a test on the first run (the test was written expecting a defensive fix, the production code wasn't; real bug, good catch).

User-provided `agent_trust` configs still override the default entirely. No behavior change for agents that already set `agent_trust` explicitly.

## Tests

`tests/unit/penguin/test_manifest.py` — 5 new cases:

- auth disabled → `\"custom\"`
- auth enabled + provider `\"hydra\"` → `\"hydra\"`
- case-insensitive (`\"HYDRA\"` also matches) → `\"hydra\"`
- auth enabled + unknown provider → `\"custom\"` (guards the Literal contract)
- `None` provider value → `\"custom\"` (defensive)

Full unit sweep: **800 passed, 3 skipped**.

## How to verify after merge

```bash
# With AUTH__ENABLED=true and AUTH__PROVIDER=hydra
curl http://localhost:3773/.well-known/agent.json | jq '.agentTrust.identityProvider'
# → \"hydra\"  (was \"custom\" before the fix)

# With auth off, no change:
AUTH__ENABLED=false curl http://localhost:3773/.well-known/agent.json | jq '.agentTrust.identityProvider'
# → \"custom\"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Agent trust identity provider now properly respects runtime authentication settings instead of using a hardcoded default value.

* **Tests**
  * Added comprehensive unit tests for agent trust configuration across various authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->