### PR TITLE
docs(known-issues): add did-admission-control-missing

### DIFF
--- a/bugs/known-issues.md
+++ b/bugs/known-issues.md
@@ -709,6 +709,55 @@ deprecated in your configuration and add a startup assertion that
 refuses to boot when the flag is false and auth is enabled.
 **Tracking:** _(no issue yet)_
 
+### did-admission-control-missing
+
+**Severity:** medium (security, admission control)
+**Summary:**
+[`bindu/server/middleware/auth/hydra.py`](../bindu/server/middleware/auth/hydra.py)
+verifies that an inbound request was signed by the private key of the
+DID declared in the OAuth token's `client_id`. Crypto is correct:
+forging signatures for a known DID is not feasible. But there is no
+admission-control layer above that — the server trusts ANY
+Hydra-registered DID that presents a valid OAuth token and a valid
+signature. No allowlist, no trust-chain check, no pattern match
+against an expected DID namespace.
+
+Concretely: in a multi-tenant deployment (or one where Hydra's
+admin API is reachable by more than the operator), a third party
+can `hydra create oauth2-client` with `client_id=did:bindu:evil:*`
+and a public key they control, then call the agent. Their token
+validates (Hydra issued it), their signature validates (they hold
+the matching private key), and the request reaches the handler.
+
+What they gain:
+- Ability to submit tasks — the agent burns its compute / LLM
+  budget executing on their behalf.
+- The response stream — they get whatever the agent produces.
+
+What they cannot do (already mitigated):
+- Read other tenants' tasks — PR #460
+  (`idor-task-context-no-ownership-check`, see postmortem
+  [`2026-04-18-idor-task-ownership.md`](./2026-04-18-idor-task-ownership.md))
+  scopes reads and lists by `owner_did`. Rows they create are only
+  visible to them.
+
+Single-tenant deployments with locked-down Hydra admin access are
+not reachable by this; Hydra registration is the de facto trust
+boundary. Severity rises to high for SaaS / multi-tenant / shared
+Hydra shapes.
+
+**Workaround:** Tightly restrict Hydra admin API access to the
+operator; audit the list of registered OAuth clients before
+exposing the agent. For stronger posture, deploy behind a reverse
+proxy that filters incoming `Authorization` headers by a known
+allowlist of token introspection subjects, or add a small
+post-auth middleware that rejects the request when
+`client_did not in app_settings.auth.allowed_dids`. A native fix
+would add an `ALLOWED_DIDS` config (exact-match or pattern) to
+`app_settings.auth` and enforce it in the Hydra middleware after
+signature verification passes — ~30 lines in one file.
+**Tracking:** _(no issue yet)_
+
 ### cors-allow-credentials-with-user-origins
 
 **Severity:** medium (security, CORS misconfig)


### PR DESCRIPTION
## Why

Surfaced during Postman-based testing of the merged DID signature fix (PR #461). The crypto layer correctly refuses forged signatures and unsigned requests, but there is no layer above it asking *\"should this DID be allowed to call us at all?\"* — the server trusts any Hydra-registered DID that presents a valid token and a valid signature.

## The gap

In a multi-tenant or shared-Hydra deployment, a third party can register their own OAuth client with a DID-style \`client_id\`, put their own public key in metadata, sign requests correctly, and reach the agent. Their token validates, their signature validates, the handler runs.

They cannot read other tenants' data — PR #460 (\`idor-task-context-no-ownership-check\`, postmortem \`bugs/2026-04-18-idor-task-ownership.md\`) already scopes reads and lists by \`owner_did\`. What they still gain is **agent compute** — the agent executes on their behalf, burning LLM budget.

## Severity

Rated **medium** in the entry because a locked-down single-tenant Hydra deployment is not reachable (Hydra registration becomes the de facto trust boundary). Severity should be re-evaluated to **high** for SaaS / multi-tenant / shared-Hydra shapes.

## Remediation paths (documented in the workaround section)

1. **Operational** — tightly restrict Hydra admin API access; audit registered OAuth clients before exposing the agent.
2. **Reverse-proxy filter** — front the agent with nginx/Envoy that rejects tokens whose introspected subject isn't in an allowlist.
3. **Native fix** — add \`ALLOWED_DIDS\` (exact-match or pattern) to \`app_settings.auth\` and enforce it in the Hydra middleware after signature verification passes. ~30 lines in one file.

## Related entries

- \`authz-scope-check-behind-optional-flag\` — complementary gap on the authz layer
- \`idor-task-context-no-ownership-check\` — already fixed (PR #460)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented a known security limitation related to tenant isolation in the authentication system, including existing mitigations and recommended workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->