### PR TITLE
fix(did): normalize DID document keys to camelCase on the wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ the root cause, and the workaround.
 | Subsystem | High | Medium | Low | Nit |
 |---|---:|---:|---:|---:|
 | Gateway | 3 | 11 | 13 | 4 |
-| Bindu Core (Python) | 4 | 7 | 3 | 0 |
+| Bindu Core (Python) | 4 | 7 | 2 | 0 |
 | SDKs (TypeScript) | — | — | — | — |
 | Frontend | — | — | — | — |
 

--- a/bindu/server/endpoints/did_endpoints.py
+++ b/bindu/server/endpoints/did_endpoints.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
+from pydantic.alias_generators import to_camel
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
@@ -23,6 +24,41 @@ from .utils import (
 )
 
 logger = get_logger("bindu.server.endpoints.did_endpoints")
+
+
+def _normalize_did_document_keys(value: Any) -> Any:
+    """Recursively convert snake_case keys to camelCase for on-the-wire output.
+
+    The DID document is assembled by the DID extension as a plain dict
+    (see :meth:`DIDAgentExtension.get_did_document`) rather than through a
+    pydantic model, because the W3C schema requires the ``@context`` key
+    which isn't a valid Python identifier. Today all the keys the extension
+    emits are already W3C-correct (``@context``, ``id``, ``created``,
+    ``authentication``, ``publicKeyBase58``). This helper keeps the
+    endpoint's output in sync with the rest of the A2A wire format (which
+    uses camelCase via pydantic's ``by_alias=True``) regardless of what
+    future extensions add to the document.
+
+    Rules:
+    - Keys starting with ``@`` (the W3C JSON-LD convention) pass through.
+    - Keys without an underscore pass through — they're already single
+      words or camelCase. This avoids damaging deliberate acronym casing
+      like ``URI`` or ``ID``.
+    - Keys containing an underscore are converted via
+      :func:`pydantic.alias_generators.to_camel` — the same transform the
+      rest of ``bindu/common/protocol/types.py`` uses.
+
+    Returns the value unchanged for non-dict, non-list inputs (strings,
+    numbers, booleans, etc.).
+    """
+    if isinstance(value, dict):
+        return {
+            (k if (not isinstance(k, str) or k.startswith("@") or "_" not in k) else to_camel(k)): _normalize_did_document_keys(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_normalize_did_document_keys(item) for item in value]
+    return value
 
 
 def _did_not_found_error(did: str, reason: str, client_ip: str) -> Response:
@@ -94,4 +130,4 @@ async def did_resolve_endpoint(app: BinduApplication, request: Request) -> Respo
 
     logger.debug(f"Resolving DID {did} for {client_ip}")
     did_document = did_extension.get_did_document()
-    return JSONResponse(content=did_document)
+    return JSONResponse(content=_normalize_did_document_keys(did_document))

--- a/bugs/core/2026-04-19-did-document-endpoint-raw-dict.md
+++ b/bugs/core/2026-04-19-did-document-endpoint-raw-dict.md
@@ -1,0 +1,164 @@
+---
+id: 2026-04-19-did-document-endpoint-raw-dict
+title: DID resolution endpoint bypassed the camelCase wire contract
+severity: low
+status: fixed
+found: 2026-04-18
+fixed: 2026-04-19
+area: bindu/server/endpoints
+commit: (this PR)
+pr:
+issue:
+---
+
+## Symptom
+
+A peer discovering a Bindu agent via `/did/resolve` received a
+JSON-LD DID document formatted to the W3C spec:
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/did/v1", "https://getbindu.com/ns/v1"],
+  "id":  "did:bindu:raahul_dutta_at_example_com:joke_agent:...",
+  "created": "2026-04-19T13:20:01.976492+00:00",
+  "authentication": [{
+    "id":  "did:bindu:...#key-1",
+    "type": "Ed25519VerificationKey2020",
+    "controller": "did:bindu:...",
+    "publicKeyBase58": "7dNzT2ZzYKsibUFirPVWZheh2TGKZuy3fGdCkcq2f2RM"
+  }]
+}
+```
+
+All keys were correct — `@context`, `publicKeyBase58`, etc. Nothing
+observable broke. But the endpoint's output path was *structurally*
+different from every other A2A endpoint: it called
+`JSONResponse(content=did_document)` with the dict the DID
+extension returned, no aliasing, no validation. Every other A2A
+endpoint in the codebase routes its payload through pydantic's
+`by_alias=True` serialization so snake_case Python attribute names
+become camelCase on the wire.
+
+That meant: the day anyone added a Bindu-specific field to
+`get_did_document()` using Python-idiomatic snake_case — say, a
+`service_endpoint`, `agent_trust`, or `key_agreement` block — the
+field would leak onto the wire in snake_case. Strict A2A tooling
+downstream would see an inconsistent document and either misparse
+or reject.
+
+Low-severity, but the kind of latent bug that becomes a real
+compatibility break once someone touches the extension.
+
+## Root cause
+
+At [`bindu/server/endpoints/did_endpoints.py:97`](../../bindu/server/endpoints/did_endpoints.py)
+(pre-fix):
+
+```python
+did_document = did_extension.get_did_document()
+return JSONResponse(content=did_document)
+```
+
+The DID document is assembled as a plain dict by
+[`DIDAgentExtension.get_did_document`](../../bindu/extensions/did/did_agent_extension.py)
+— not a pydantic model. Why? Because the W3C DID spec requires the
+`@context` key, which is not a valid Python identifier and doesn't
+round-trip cleanly through a plain TypedDict attribute name. The
+path of least resistance was to build it as a dict with literal key
+strings.
+
+Consequence: the wire-format contract that `bindu/common/protocol/types.py`
+enforces everywhere else (`alias_generator=to_camel`,
+`by_alias=True`) had no hook into this path. The endpoint was
+*accidentally* correct today because the human who wrote
+`get_did_document()` happened to type `publicKeyBase58` camelCase.
+One future typo, one PR that adds a new field the Python way, and
+the contract silently breaks.
+
+## Fix
+
+Added a small recursive normalizer at
+[`bindu/server/endpoints/did_endpoints.py`](../../bindu/server/endpoints/did_endpoints.py)
+that converts snake_case dict keys to camelCase on the way out,
+preserving `@context` and already-camelCase keys unchanged. The
+endpoint now returns
+`JSONResponse(content=_normalize_did_document_keys(did_document))`.
+
+Rules the normalizer applies:
+
+- Keys starting with `@` pass through (JSON-LD convention,
+  including `@context`, `@id`, `@type`).
+- Keys without an underscore pass through (they're already single
+  words or camelCase).
+- Keys containing an underscore go through
+  `pydantic.alias_generators.to_camel` — the exact transform used
+  by the rest of the A2A type system.
+
+Tests in [`tests/unit/server/endpoints/test_did_endpoints.py`](../../tests/unit/server/endpoints/test_did_endpoints.py)
+— 9 cases:
+
+- Today's W3C-correct document is returned byte-for-byte unchanged
+  (no over-eager transforms).
+- `@context` preserved.
+- `snake_case` → `camelCase`.
+- `alreadyCamelCase` passes through untouched (no double-transform).
+- Nested dicts and lists are walked recursively.
+- Realistic future document with a mix of W3C + Bindu-specific
+  keys produces a fully camelCase output.
+- Scalars, None, True, empty containers all round-trip safely.
+
+No behavioral change observable from current clients; future
+extensions are safe by construction.
+
+## Why the tests didn't catch it
+
+There were no tests for `did_endpoints.py` at all. The endpoint was
+exercised in practice only by happy-path discovery calls, which
+read the current W3C-correct document and were satisfied. A bug
+that only manifests when someone *adds a field* can't be caught by
+happy-path tests — you need a contract test asserting the shape of
+the output regardless of what the data source chooses to emit.
+
+The new tests are exactly that contract. They include a "realistic
+future document" case that simulates a downstream change to
+`get_did_document()` — if someone adds a snake_case field, the
+existing test catches it before it ships.
+
+## Class of bug — where else to watch
+
+The general shape: **a JSON-producing endpoint that bypasses the
+project's central serialization layer because its type is awkward
+to express as a pydantic model**.
+
+Places to audit for the same pattern:
+
+- Any endpoint using `JSONResponse(content=<raw dict>)` where the
+  dict isn't validated through pydantic. Grep:
+  `grep -rn 'JSONResponse(content=' bindu/server/endpoints/`.
+  Today that pattern appears a few places worth re-checking.
+- Any extension's `get_*_document()` / `to_dict()` helper that
+  returns a manually-assembled dict intended for the wire. The DID
+  extension is one; check skills, negotiation, and x402 extensions
+  for siblings.
+- Error-response builders. Many error shapes are handwritten dicts;
+  `jsonrpc_error` in `bindu/server/endpoints/utils.py` is the
+  canonical path but not every error site goes through it.
+
+The deeper lesson: **if a type is awkward to express as a pydantic
+model, add the normalizer that bridges raw dicts into the same
+wire-format contract — don't let the raw dict out un-normalized.**
+A five-line helper beats a future compatibility break.
+
+## Follow-ups
+
+- One latent concern: the W3C DID spec defines ``keyAgreement``,
+  ``assertionMethod``, ``capabilityInvocation``, and similar blocks
+  as sibling arrays of ``authentication``. These are already
+  camelCase in the spec and would pass through unchanged today.
+  But if a future Bindu extension adds a private field for
+  internal routing (e.g. ``service_endpoint`` for peer discovery),
+  the normalizer will emit ``serviceEndpoint``. That's the correct
+  output for A2A peers, but not necessarily what the DID extension
+  author intended. If that tension arises, consider namespacing
+  Bindu extensions under a single ``binduMeta`` block rather than
+  flattening into the top-level document.

--- a/bugs/known-issues.md
+++ b/bugs/known-issues.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-_Last updated: 2026-04-19 — restructured into scannable tables and story-format entries for the high-severity items._
+_Last updated: 2026-04-19 — restructured into scannable tables and story-format entries for the high-severity items. `did-document-endpoint-returns-raw-dict` removed — see [`core/2026-04-19-did-document-endpoint-raw-dict.md`](./core/2026-04-19-did-document-endpoint-raw-dict.md)._
 
 This file is user-facing. It's the first thing a new contributor or
 operator reads to calibrate expectations: what Bindu doesn't do
@@ -42,7 +42,7 @@ Issue referencing the slug (e.g. "Fixes `context-window-hardcoded`").
 | Subsystem | High | Medium | Low | Nit |
 |---|---:|---:|---:|---:|
 | [Gateway](#gateway) | 3 | 11 | 13 | 4 |
-| [Bindu Core (Python)](#bindu-core-python) | 4 | 7 | 3 | 0 |
+| [Bindu Core (Python)](#bindu-core-python) | 4 | 7 | 2 | 0 |
 | [SDKs (TypeScript)](#sdks-typescript) | — | — | — | — |
 | [Frontend](#frontend) | — | — | — | — |
 
@@ -686,7 +686,6 @@ test for it in the same PR.
 | [`context-id-silent-fallback`](#context-id-silent-fallback) | medium | Malformed `context_id` silently creates a new context |
 | [`did-signature-overbroad-exception-catch`](#did-signature-overbroad-exception-catch) | low (hyg) | Bare `except Exception` in `verify_signature` masks bugs |
 | [`artifact-name-not-sanitized`](#artifact-name-not-sanitized) | low (sec) | Agent-supplied artifact names not basenamed |
-| [`did-document-endpoint-returns-raw-dict`](#did-document-endpoint-returns-raw-dict) | low | DID doc endpoint bypasses alias serialization |
 
 ### High
 
@@ -1018,25 +1017,6 @@ visible.
 should apply `os.path.basename` and an allow-list regex before
 writing. Fix in-core is to sanitize in `from_result`:
 `artifact_name = os.path.basename(artifact_name) or "result"`.
-**Tracking:** _(no issue yet)_
-
-### did-document-endpoint-returns-raw-dict
-
-**Severity:** low (protocol consistency)
-**Summary:**
-[`bindu/server/endpoints/did_endpoints.py`](../bindu/server/endpoints/did_endpoints.py)
-returns the DID document extension output with
-`JSONResponse(content=did_document)`, bypassing the pydantic
-`by_alias=True` serialization used everywhere else. For W3C DID
-documents the key names are already the expected form, so this is
-usually harmless. But any Bindu-specific extension fields mixed
-into the document leak out as snake_case, inconsistent with the
-rest of the API. If the DID document is ever consumed by strict
-A2A tooling, the inconsistency becomes a real compatibility bug.
-**Workaround:** Confirm any DID extension fields use camelCase
-keys at the source. Fix is to route the response through a
-pydantic RootModel with the standard camelCase alias generator, or
-to assert on the key shape before returning.
 **Tracking:** _(no issue yet)_
 
 ---

--- a/tests/unit/server/endpoints/test_did_endpoints.py
+++ b/tests/unit/server/endpoints/test_did_endpoints.py
@@ -1,0 +1,119 @@
+"""Tests for ``did_endpoints._normalize_did_document_keys``.
+
+The DID document is assembled as a plain dict by the DID extension
+rather than a pydantic model (the W3C ``@context`` key is not a valid
+Python identifier). The ``/did/resolve`` endpoint must still emit
+camelCase on the wire to match the rest of the A2A protocol. These
+tests guard that guarantee so a future extension adding a
+snake_case field cannot silently leak through.
+
+See ``bugs/core/2026-04-19-did-document-endpoint-raw-dict.md`` for
+context.
+"""
+
+from __future__ import annotations
+
+from bindu.server.endpoints.did_endpoints import _normalize_did_document_keys
+
+
+class TestNormalizeDidDocumentKeys:
+    """Guard the camelCase contract on DID document serialization."""
+
+    def test_today_w3c_document_passes_through_unchanged(self):
+        """Current ``get_did_document()`` output is already W3C-correct.
+        Normalizer must not damage it — no over-eager transforms."""
+        today = {
+            "@context": [
+                "https://www.w3.org/ns/did/v1",
+                "https://getbindu.com/ns/v1",
+            ],
+            "id": "did:bindu:raahul_dutta_at_example_com:joke_agent:x",
+            "created": "2026-04-18T00:00:00+00:00",
+            "authentication": [
+                {
+                    "id": "did:bindu:x#key-1",
+                    "type": "Ed25519VerificationKey2020",
+                    "controller": "did:bindu:x",
+                    "publicKeyBase58": "7dNzT2ZzYKsibUFirPVWZheh2TGKZuy3fGdCkcq2f2RM",
+                }
+            ],
+        }
+        assert _normalize_did_document_keys(today) == today
+
+    def test_at_context_preserved(self):
+        """W3C JSON-LD uses ``@context`` — the ``@`` prefix is
+        intentional and must pass through."""
+        doc = {"@context": ["https://example.com"]}
+        assert _normalize_did_document_keys(doc) == doc
+
+    def test_snake_case_converted_to_camel(self):
+        """This is the fix — a future extension adds snake_case,
+        it comes out camelCase."""
+        doc = {"service_endpoint": "https://example.com/svc"}
+        assert _normalize_did_document_keys(doc) == {
+            "serviceEndpoint": "https://example.com/svc"
+        }
+
+    def test_already_camel_passes_through(self):
+        """Don't double-transform already-camelCase keys."""
+        doc = {"publicKeyBase58": "ABC", "keyAgreement": []}
+        assert _normalize_did_document_keys(doc) == doc
+
+    def test_nested_dicts_normalized(self):
+        """snake_case inside a nested object must also convert."""
+        doc = {
+            "authentication": [
+                {
+                    "public_key_base58": "X",
+                    "verification_method": "vm",
+                }
+            ],
+        }
+        out = _normalize_did_document_keys(doc)
+        assert out["authentication"][0] == {
+            "publicKeyBase58": "X",
+            "verificationMethod": "vm",
+        }
+
+    def test_mixed_keys_in_same_object(self):
+        """A realistic future document: W3C keys + Bindu-specific ones."""
+        doc = {
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": "did:bindu:x",
+            "agent_trust": {
+                "identity_provider": "hydra",
+                "inherited_roles": [],
+                "creator_id": "system",
+            },
+        }
+        out = _normalize_did_document_keys(doc)
+        assert "@context" in out
+        assert "id" in out
+        assert "agentTrust" in out and "agent_trust" not in out
+        assert out["agentTrust"] == {
+            "identityProvider": "hydra",
+            "inheritedRoles": [],
+            "creatorId": "system",
+        }
+
+    def test_scalars_and_none_pass_through(self):
+        """Non-dict / non-list values at the top level return unchanged."""
+        assert _normalize_did_document_keys("did:bindu:x") == "did:bindu:x"
+        assert _normalize_did_document_keys(42) == 42
+        assert _normalize_did_document_keys(None) is None
+        assert _normalize_did_document_keys(True) is True
+
+    def test_empty_containers(self):
+        """Empty dicts and lists are valid JSON — must round-trip."""
+        assert _normalize_did_document_keys({}) == {}
+        assert _normalize_did_document_keys([]) == []
+
+    def test_list_of_mixed_types(self):
+        """Lists can contain a mix of dicts, lists, and scalars."""
+        value = [{"snake_key": 1}, ["nested"], "scalar", 42]
+        assert _normalize_did_document_keys(value) == [
+            {"snakeKey": 1},
+            ["nested"],
+            "scalar",
+            42,
+        ]


### PR DESCRIPTION
Closes `did-document-endpoint-returns-raw-dict` from `bugs/known-issues.md`.

## The bug

`/did/resolve` returned its JSON-LD DID document via `JSONResponse(content=did_document)` — a raw dict from the DID extension, not routed through the pydantic alias pipeline that every other A2A endpoint uses. Today's output is accidentally W3C-correct because whoever wrote `get_did_document()` happened to type `publicKeyBase58` camelCase. A future extension adding a snake_case field (say `service_endpoint`, `agent_trust`) would silently leak onto the wire in snake_case, breaking the camelCase contract every other endpoint honors.

Low severity because **today's** output is correct. The fix is about locking the contract so a latent bug can't graduate to a real one the next time someone touches the extension.

## Why the dict-not-model shape existed

The W3C JSON-LD spec requires `@context`, which isn't a valid Python identifier. Expressing it as a pydantic TypedDict attribute is awkward — so the path of least resistance was a plain dict. That choice dropped the wire contract on the floor.

## Fix

Small recursive normalizer at the endpoint — walks the dict, converts snake_case keys via `pydantic.alias_generators.to_camel` (same transform the A2A type system uses). Keys starting with `@` (JSON-LD) and keys without underscores (already camelCase or single words) pass through unchanged. Applied right before `JSONResponse`.

```python
did_document = did_extension.get_did_document()
return JSONResponse(content=_normalize_did_document_keys(did_document))
```

Today's W3C document is returned byte-for-byte identical. Future extensions get the right wire shape for free.

## Tests

`tests/unit/server/endpoints/test_did_endpoints.py` — 9 cases:

- Today's W3C document returned unchanged (no over-eager transforms)
- `@context` preserved
- `snake_case` → `camelCase`
- `alreadyCamelCase` passes through (no double-transform)
- Nested dicts and lists walked recursively
- Realistic future-extension document with mixed keys produces fully camelCase output
- Scalars, None, True, empty containers all round-trip safely

All **809 unit tests pass**.

## Housekeeping

- `bugs/known-issues.md` — entry removed from both the Quick index table and the Low section; Bindu Core Low count 3 → 2 in the ToC table; header `Last updated` line points at the new postmortem.
- `README.md` — issue-count matrix updated (Bindu Core Low: 3 → 2).
- New postmortem: [`bugs/core/2026-04-19-did-document-endpoint-raw-dict.md`](bugs/core/2026-04-19-did-document-endpoint-raw-dict.md) — documents the "awkward-to-model-in-pydantic → accidentally bypass the wire contract" pattern and names follow-up audit targets (`grep -rn 'JSONResponse(content=' bindu/server/endpoints/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DID resolution endpoint to consistently format response keys in camelCase, ensuring API response consistency.

* **Documentation**
  * Updated issue tracking tables reflecting the resolved issue.
  * Added postmortem documentation for the DID endpoint fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->