### PR TITLE
fix(did): narrow create_signature_payload to str|bytes only

### DIFF
--- a/bindu/utils/did/signature.py
+++ b/bindu/utils/did/signature.py
@@ -16,51 +16,88 @@ logger = get_logger("bindu.utils.did_signature")
 
 
 def create_signature_payload(
-    body: str | bytes | dict, did: str, timestamp: Optional[int] = None
+    body: str | bytes, did: str, timestamp: Optional[int] = None
 ) -> Dict[str, Any]:
-    """Create signature payload for request signing.
+    """Create the signature payload a signer or verifier should sign.
+
+    The returned dict is serialized with ``json.dumps(..., sort_keys=True)``
+    by the caller and passed to Ed25519. Signer and verifier MUST agree
+    on the exact bytes, which means they MUST agree on how ``body`` was
+    serialized to bytes before this function is called.
+
+    Only ``str`` and ``bytes`` are accepted. Passing ``dict`` used to
+    be supported with an implicit ``json.dumps(body, sort_keys=True)``
+    canonicalization, but that hid a serious footgun: a caller who
+    signed a dict got one signature, and the verifier on the server
+    side (which receives raw wire bytes, not a dict) got another for
+    the same logical body. The mismatch surfaced as
+    ``crypto_mismatch`` with no diagnostic hint about why.
+
+    The fix: callers must serialize their body to bytes *once* and use
+    those exact bytes for both the signing payload AND the HTTP body
+    they send on the wire. If you have a dict and need to sign it,
+    serialize it explicitly::
+
+        body_bytes = json.dumps(data).encode("utf-8")
+        headers    = sign_request(body_bytes, did, did_extension)
+        httpx.post(url, content=body_bytes, headers=headers)
 
     Args:
-        body: Request body (string, bytes, or dict)
+        body: Request body as a string or bytes. Dict inputs raise
+            ``TypeError`` — see above.
         did: Client's DID
         timestamp: Unix timestamp (defaults to current time)
 
     Returns:
-        Signature payload dict
+        Signature payload dict ``{"body": str, "did": str, "timestamp": int}``
+
+    Raises:
+        TypeError: If ``body`` is not ``str`` or ``bytes``.
     """
     if timestamp is None:
         timestamp = int(time.time())
 
-    # Convert body to string
-    if isinstance(body, dict):
-        body_str = json.dumps(body, sort_keys=True)
-    elif isinstance(body, bytes):
+    if isinstance(body, bytes):
         body_str = body.decode("utf-8")
+    elif isinstance(body, str):
+        body_str = body
     else:
-        body_str = str(body)
+        raise TypeError(
+            f"body must be str or bytes, got {type(body).__name__}. "
+            "If you have a dict, serialize it to bytes with "
+            "json.dumps(data).encode('utf-8') and use the same bytes "
+            "for both signing and the HTTP body."
+        )
 
     return {"body": body_str, "timestamp": timestamp, "did": did}
 
 
 def sign_request(
-    body: str | bytes | dict, did: str, did_extension, timestamp: Optional[int] = None
+    body: str | bytes, did: str, did_extension, timestamp: Optional[int] = None
 ) -> Dict[str, str]:
-    """Sign a request with DID private key.
+    """Sign a request with a DID private key.
+
+    See :func:`create_signature_payload` for the signer/verifier
+    contract — notably, ``body`` must be the exact bytes (or string)
+    that will appear on the wire. Dict inputs are rejected to prevent
+    a class of bugs where the signing and sending paths disagree on
+    canonicalization.
 
     Args:
-        body: Request body
+        body: Request body as a string or bytes.
         did: Client's DID
         did_extension: DIDExtension instance with private key
         timestamp: Unix timestamp (defaults to current time)
 
     Returns:
         Dict with signature headers (X-DID, X-DID-Signature, X-DID-Timestamp)
+
+    Raises:
+        TypeError: If ``body`` is not ``str`` or ``bytes``.
     """
-    # Create signature payload
     payload = create_signature_payload(body, did, timestamp)
     payload_str = json.dumps(payload, sort_keys=True)
 
-    # Sign with private key
     signature = did_extension.sign_message(payload_str)
 
     return {

--- a/bindu/utils/http/auth_client.py
+++ b/bindu/utils/http/auth_client.py
@@ -79,12 +79,14 @@ class HybridAuthClient:
         logger.info(f"Access token obtained for {self.credentials.client_id}")
 
     def _create_signed_request_headers(
-        self, body: str | bytes | dict
+        self, body: str | bytes
     ) -> Dict[str, str]:
         """Create complete headers for signed request with OAuth token.
 
         Args:
-            body: Request body
+            body: Request body — must be a str or bytes (dict no longer
+                accepted, see bindu.utils.did.sign_request for the
+                contract).
 
         Returns:
             Dict with all required headers

--- a/tests/unit/utils/did/test_signature_payload.py
+++ b/tests/unit/utils/did/test_signature_payload.py
@@ -1,0 +1,139 @@
+"""Tests for ``create_signature_payload`` and ``sign_request`` contract.
+
+The single invariant these tests guard: **the caller must serialize
+its body to bytes/str exactly once, and both the signing path and
+the wire must use those exact bytes.** The pre-cleanup function
+silently canonicalized a dict into a different string than the
+bytes that would hit the wire, which caused dict-caller +
+bytes-verifier pairs to disagree on the signature even when they
+were signing the same logical data.
+
+The cleanup removes the ``dict`` input branch — callers with a dict
+now have to serialize explicitly, which surfaces the choice of
+canonicalization and prevents the silent-mismatch bug.
+
+See ``bugs/core/2026-04-19-create-signature-payload-dict-branch.md``
+when it lands for the full story.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bindu.utils.did.signature import create_signature_payload, sign_request
+
+
+class TestCreateSignaturePayload:
+    def test_bytes_input_decoded_raw(self):
+        body = b'{"x": 1}'
+        out = create_signature_payload(body, did="did:bindu:test", timestamp=1000)
+        assert out == {
+            "body": '{"x": 1}',
+            "did": "did:bindu:test",
+            "timestamp": 1000,
+        }
+
+    def test_str_input_passes_through_unchanged(self):
+        body = '{"x": 1}'
+        out = create_signature_payload(body, did="did:bindu:test", timestamp=1000)
+        assert out["body"] == body
+
+    def test_bytes_with_non_ascii_content(self):
+        """UTF-8 content round-trips through decode()."""
+        body = '{"msg": "hëllo"}'.encode("utf-8")
+        out = create_signature_payload(body, did="did:bindu:test", timestamp=1000)
+        assert out["body"] == '{"msg": "hëllo"}'
+
+    def test_dict_input_rejected(self):
+        """A dict used to be silently canonicalized with
+        ``json.dumps(body, sort_keys=True)``. That produced a string
+        different from the wire bytes any normal JSON encoder would
+        produce, and the signing side and verifying side disagreed.
+
+        Post-cleanup: dict is explicitly rejected so callers must
+        serialize ONCE and use the same bytes for signing and for the
+        HTTP body."""
+        with pytest.raises(TypeError, match="json.dumps"):
+            create_signature_payload(
+                {"x": 1}, did="did:bindu:test", timestamp=1000
+            )
+
+    def test_list_input_rejected(self):
+        """Any non-str/bytes rejected — not just dict."""
+        with pytest.raises(TypeError, match="str or bytes"):
+            create_signature_payload(
+                [1, 2, 3], did="did:bindu:test", timestamp=1000  # type: ignore[arg-type]
+            )
+
+    def test_timestamp_defaults_to_now_if_none(self):
+        """Default timestamp is current time to within a second."""
+        import time
+
+        before = int(time.time())
+        out = create_signature_payload(b"{}", did="did:bindu:test")
+        after = int(time.time())
+        assert before <= out["timestamp"] <= after
+
+    def test_returns_stable_keys(self):
+        """The returned dict has exactly these three keys, in any
+        order — the caller does ``json.dumps(..., sort_keys=True)``
+        before signing."""
+        out = create_signature_payload(b"{}", did="did:bindu:x", timestamp=1)
+        assert set(out.keys()) == {"body", "did", "timestamp"}
+
+
+class TestSignRequest:
+    """``sign_request`` is the thin wrapper that produces the three
+    X-DID-* headers. It delegates serialization to
+    ``create_signature_payload``, so the same type contract applies."""
+
+    class _FakeExt:
+        calls: list[str] = []
+
+        def sign_message(self, text: str) -> str:
+            # Record the exact payload the signer was asked to sign —
+            # tests assert on this to prove the canonicalization path.
+            self.calls.append(text)
+            return "dummy-signature"
+
+    def test_bytes_body_produces_headers(self):
+        ext = self._FakeExt()
+        headers = sign_request(
+            body=b'{"x": 1}',
+            did="did:bindu:test",
+            did_extension=ext,
+            timestamp=1000,
+        )
+        assert headers["X-DID"] == "did:bindu:test"
+        assert headers["X-DID-Timestamp"] == "1000"
+        assert headers["X-DID-Signature"] == "dummy-signature"
+
+    def test_signer_sees_canonical_payload_with_body_as_is(self):
+        """Guards the ``body`` string is passed through unchanged, not
+        re-serialized. A body of ``'{"x": 1}'`` must appear in the
+        signed payload with that exact content — any whitespace
+        difference from a re-parse-and-redump would produce a
+        different signature than the server will reconstruct from the
+        wire bytes."""
+        ext = self._FakeExt()
+        sign_request(
+            body=b'{"x": 1}',
+            did="did:bindu:t",
+            did_extension=ext,
+            timestamp=1000,
+        )
+        # The payload handed to sign_message contains the body as-is.
+        signed_payload = json.loads(ext.calls[0])
+        assert signed_payload["body"] == '{"x": 1}'
+
+    def test_dict_body_rejected(self):
+        """Same TypeError as create_signature_payload — dict is out."""
+        with pytest.raises(TypeError):
+            sign_request(
+                body={"x": 1},  # type: ignore[arg-type]
+                did="did:bindu:t",
+                did_extension=self._FakeExt(),
+                timestamp=1000,
+            )


### PR DESCRIPTION
**Phase 0** of the calling-side DID work. Removes the dict input branch from `create_signature_payload` so the signer/verifier contract has one canonical shape instead of two.

## The footgun this closes

Pre-cleanup, `create_signature_payload` had two branches:

\`\`\`python
if isinstance(body, dict):
    body_str = json.dumps(body, sort_keys=True)   # canonicalized
elif isinstance(body, bytes):
    body_str = body.decode(\"utf-8\")               # raw bytes
\`\`\`

Caller with a dict → signs canonical form. Wire body → some-arbitrary JSON encoding. Server re-parses wire bytes (hits the bytes branch) → reconstructs a **different** string than the signer did. Signatures disagree even though the logical data is identical. The caller sees \`crypto_mismatch\` with no diagnostic hint.

This bit the Postman pre-request script I wrote earlier in the session — same bug in reverse. It's the exact shape of bug the calling-side phases are going to multiply (gateway signer, frontend signer, Postman script — three new signers all needing to agree with the Python verifier byte-for-byte).

## Fix

Dict (and any other non-str/bytes) input raises \`TypeError\` with a message pointing the caller at the fix:

\`\`\`python
body_bytes = json.dumps(data).encode(\"utf-8\")
headers    = sign_request(body_bytes, did, ext)
httpx.post(url, content=body_bytes, headers=headers)
\`\`\`

One serialization decision. Same bytes for sign and send. Disagreement-by-construction impossible.

## Scope

- \`bindu/utils/did/signature.py\` — \`create_signature_payload\` narrowed, dict branch deleted. Docstring explains the new contract and links to the replacement pattern.
- \`bindu/utils/did/signature.py\` — \`sign_request\` type narrowed too (delegates validation).
- \`bindu/utils/http/auth_client.py\` — \`_create_signed_request_headers\` type narrowed to match.

## Internal-caller audit

- \`bindu/utils/http/auth_client.py:137\` already passes a string (\`body_str = json.dumps(data)\`). No behavior change.
- No other internal callers of either function with a dict.
- **SDKs**: grep for \`X-DID\`, \`sign_request\`, \`signRequest\`, \`tweetnacl\`, \`nacl.sign\` across \`sdks/\` — zero matches. No TS SDK signing today to break.

## Tests

\`tests/unit/utils/did/test_signature_payload.py\` — 10 cases:

- bytes input decoded raw (happy path)
- str input unchanged
- non-ASCII UTF-8 round-trips
- dict input raises \`TypeError\` with \"json.dumps\" in the message
- list input raises \`TypeError\` (generalized non-str/bytes rejection)
- timestamp defaults to \`int(time.time())\`
- returned dict has exactly \`{body, did, timestamp}\`
- \`sign_request\` produces all three \`X-DID-*\` headers
- \`sign_request\` passes body through unchanged to signer (regression guard against accidental re-canonicalization)
- \`sign_request\` dict input rejected with same TypeError

**All 810 unit tests pass.**

## Merge coordination

This PR and [#469](https://github.com/GetBindu/Bindu/pull/469) both touch \`signature.py\` but in different functions:

- #469 narrows exceptions in \`verify_signature\` (lines 73–135)
- this PR narrows types in \`create_signature_payload\` + \`sign_request\` (lines 18–70)

No line overlap → clean merge either order. Same for \`tests/unit/utils/did/\` — both create \`__init__.py\`, git auto-merges empty files.

## Why no postmortem

This is a proactive cleanup tied to upcoming calling-side DID work (Phase 1 = gateway DID signing), not a fix of a shipped user-visible bug. The in-code docstring captures the lesson where future readers will hit it. Postmortem convention is for bugs that shipped and taught something; this is teaching forward, not backward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Request signing and authentication functions now require request bodies as strings or bytes only; dictionary input is no longer accepted.
  * Callers must pre-serialize dictionary objects to bytes before signing and submitting HTTP requests.
  * Error messages provide clear guidance on proper input requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->