### PR TITLE
feat(gateway): auto Hydra registration + OAuth token acquisition (Phase 1b)

### DIFF
--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -39,3 +39,25 @@ GATEWAY_HOSTNAME=0.0.0.0
 # BINDU_GATEWAY_DID_SEED=
 # BINDU_GATEWAY_AUTHOR=ops@example.com
 # BINDU_GATEWAY_NAME=gateway
+#
+# -----------------------------------------------------------------------------
+# Hydra auto-registration (optional — enables auto OAuth token for did_signed peers)
+# -----------------------------------------------------------------------------
+# When the identity vars above are set AND both Hydra URLs below are set,
+# the gateway on boot:
+#   1. Registers itself as an OAuth client in Hydra (idempotent — safe to restart).
+#      client_id  = the gateway's DID
+#      client_secret = derived deterministically from the seed (no extra secret
+#                    to manage; rotating the seed rotates the secret)
+#      metadata.public_key = the gateway's base58-encoded Ed25519 public key
+#   2. Acquires an access token via OAuth client_credentials flow. The token is
+#      cached in memory and proactively refreshed 30s before expiry.
+# A peer configured with `auth.type = "did_signed"` AND NO `tokenEnvVar`
+# automatically uses this cached token. Federated deploys (multiple Hydras) can
+# still override per-peer with `tokenEnvVar`.
+#
+# Set both URLs together or neither. Partial config fails fast at boot.
+#
+# BINDU_GATEWAY_HYDRA_ADMIN_URL=http://hydra:4445
+# BINDU_GATEWAY_HYDRA_TOKEN_URL=http://hydra:4444/oauth2/token
+# BINDU_GATEWAY_HYDRA_SCOPE="openid offline agent:read agent:write"  # optional, space-separated

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -171,37 +171,85 @@ See [`plans/PLAN.md`](./plans/PLAN.md) §Architecture for the full picture.
 
 The gateway can sign outbound A2A requests with an Ed25519 identity so DID-enforcing Bindu peers accept them. Needed for any peer you configure with `auth.type = "did_signed"`; ignored otherwise.
 
-To enable, set all three env vars:
+### Two modes
+
+| Mode | When to use | Setup |
+|---|---|---|
+| **Auto** (recommended) | Single Hydra shared by the gateway and its peers | Set identity + Hydra URL env vars; gateway self-registers and auto-acquires tokens |
+| **Manual** (federated) | Peers use different Hydras | Set identity env vars; pre-register manually with each peer's Hydra; stash per-peer tokens in env vars |
+
+### Auto mode setup
 
 ```bash
-# Generate a seed once and treat it as a secret:
+# Identity (same for both modes)
 export BINDU_GATEWAY_DID_SEED="$(python -c 'import os,base64;print(base64.b64encode(os.urandom(32)).decode())')"
 export BINDU_GATEWAY_AUTHOR=ops@example.com
 export BINDU_GATEWAY_NAME=gateway
+
+# Hydra auto-registration
+export BINDU_GATEWAY_HYDRA_ADMIN_URL=http://hydra:4445
+export BINDU_GATEWAY_HYDRA_TOKEN_URL=http://hydra:4444/oauth2/token
+# export BINDU_GATEWAY_HYDRA_SCOPE="openid offline agent:read agent:write"  # optional
 ```
 
-On boot the gateway logs its derived DID and public key. Register both with each peer's Hydra (as the gateway's OAuth client), obtain an access token, and point the peer config at the token env var:
+On boot the gateway:
+
+1. Derives its DID and public key from the seed. Logs both.
+2. Registers itself with Hydra as an OAuth client (`client_id` = the DID, `metadata.public_key` = the base58 public key). Idempotent — safe to restart.
+3. Acquires an access token via `client_credentials`. In-memory cache + proactive refresh 30s before expiry.
+
+Peer config for auto mode:
 
 ```json
-{
-  "peers": [
-    {
-      "url": "http://agent:3773",
-      "auth": { "type": "did_signed", "tokenEnvVar": "AGENT_HYDRA_TOKEN" }
-    }
-  ]
-}
+{ "url": "http://agent:3773", "auth": { "type": "did_signed" } }
 ```
 
-The gateway will then:
+No `tokenEnvVar` needed — the gateway pulls the token from its cached Hydra provider.
 
-1. Serialize each JSON-RPC request body once.
-2. Sign those exact bytes with its private key (matching Python's `json.dumps(payload, sort_keys=True)` byte-for-byte — see `src/bindu/identity/local.ts`).
+### Manual mode setup (federated)
+
+Each peer uses its own Hydra. The gateway holds a token per peer, supplied via env vars:
+
+```bash
+# Identity only — no Hydra auto vars
+export BINDU_GATEWAY_DID_SEED="..."
+export BINDU_GATEWAY_AUTHOR=ops@example.com
+export BINDU_GATEWAY_NAME=gateway
+
+# One token per peer
+export RESEARCH_HYDRA_TOKEN="$(hydra token client ...)"
+export SUPPORT_HYDRA_TOKEN="$(hydra token client ...)"
+```
+
+Peer config:
+
+```json
+{ "url": "http://research:3773", "auth": { "type": "did_signed", "tokenEnvVar": "RESEARCH_HYDRA_TOKEN" } },
+{ "url": "http://support:3773",  "auth": { "type": "did_signed", "tokenEnvVar": "SUPPORT_HYDRA_TOKEN" } }
+```
+
+Mix-and-match is fine too: a peer with `tokenEnvVar` set uses that env var even when the auto provider is also configured (peer-scoped wins).
+
+### What happens on the wire
+
+For every outbound call to a `did_signed` peer:
+
+1. Serialize the JSON-RPC request body once.
+2. Sign those exact bytes with the gateway's private key. Matches Python's `json.dumps(payload, sort_keys=True)` byte-for-byte — see `src/bindu/identity/local.ts`.
 3. Send `Authorization: Bearer <token>` + `X-DID`, `X-DID-Signature`, `X-DID-Timestamp` headers on the same request.
 
-If the seed env var is set but malformed, or only some of the three identity vars are set, the gateway refuses to boot with a clear error. Better to fail fast at startup than three layers deep in a peer call.
+### Failure modes — all fail fast with clear errors
 
-Peers configured with `none` / `bearer` / `bearer_env` continue to work without identity. Leave the three env vars unset if no peer needs DID signing.
+| Scenario | When | Error |
+|---|---|---|
+| Seed malformed | Boot | `BINDU_GATEWAY_DID_SEED must decode to exactly 32 bytes` |
+| Partial identity config | Boot | `Partial DID identity config — set all three or none` |
+| Partial Hydra config (admin without token or vice versa) | Boot | `Partial Hydra config — set both or neither` |
+| Hydra admin unreachable | Boot | `Hydra admin GET /admin/clients/... returned 503: ...` |
+| `did_signed` peer but no identity | First call | `did_signed peer requires a gateway LocalIdentity` |
+| `did_signed` peer with no tokenEnvVar and no provider | First call | clear error naming both options |
+
+Peers configured with `none` / `bearer` / `bearer_env` continue to work with or without DID identity. Leave the env vars unset if no peer needs DID signing.
 
 ---
 

--- a/gateway/src/bindu/auth/resolver.ts
+++ b/gateway/src/bindu/auth/resolver.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import type { LocalIdentity } from "../identity/local"
+import type { TokenProvider } from "../identity/hydra-token"
 
 /**
  * Per-peer auth configuration — describes how to authenticate against a
@@ -26,11 +27,15 @@ export const PeerAuth = z.discriminatedUnion("type", [
   z.object({ type: z.literal("bearer_env"), envVar: z.string() }),
   z.object({
     type: z.literal("did_signed"),
-    /** Env var name holding the OAuth bearer token the peer's Hydra
-     *  issued to the gateway's DID client_id. Bundled with the DID
-     *  signature so the peer satisfies both its OAuth layer and its
-     *  DID layer in one request. */
-    tokenEnvVar: z.string(),
+    /** Optional. When set, the OAuth bearer token is read from this
+     *  process env var. When omitted, the gateway's own Hydra token
+     *  provider is used (auto-acquired via client_credentials at
+     *  boot). ``tokenEnvVar`` is the escape hatch for federated
+     *  deployments where the gateway needs different tokens per
+     *  peer (e.g. each peer runs its own Hydra). The auto path is
+     *  the common case: single shared Hydra, gateway registers
+     *  once, every peer call uses the same cached token. */
+    tokenEnvVar: z.string().optional(),
   }),
 ])
 export type PeerAuth = z.infer<typeof PeerAuth>
@@ -55,6 +60,7 @@ export async function buildAuthHeaders(
   auth: PeerAuth | undefined,
   body: string,
   identity?: LocalIdentity,
+  tokenProvider?: TokenProvider,
 ): Promise<Record<string, string>> {
   if (!auth || auth.type === "none") return {}
   if (auth.type === "bearer") return { Authorization: `Bearer ${auth.token}` }
@@ -75,13 +81,34 @@ export async function buildAuthHeaders(
           "Client layer was built with makeLayer(identity).",
       )
     }
-    const token = process.env[auth.tokenEnvVar]
-    if (!token) {
+
+    // Token resolution:
+    //   1. Peer-specific env var (escape hatch for federated deploys).
+    //   2. Gateway-wide token provider (the auto path from
+    //      BINDU_GATEWAY_HYDRA_TOKEN_URL at boot).
+    //   3. Neither → clear error pointing at both options.
+    let token: string
+    if (auth.tokenEnvVar) {
+      const v = process.env[auth.tokenEnvVar]
+      if (!v) {
+        throw new Error(
+          `auth: env var "${auth.tokenEnvVar}" is not set ` +
+            "(did_signed peer requires an OAuth bearer token alongside the DID signature)",
+        )
+      }
+      token = v
+    } else if (tokenProvider) {
+      token = await tokenProvider.getToken()
+    } else {
       throw new Error(
-        `auth: env var "${auth.tokenEnvVar}" is not set ` +
-          "(did_signed peer requires an OAuth bearer token alongside the DID signature)",
+        "auth: did_signed peer has no tokenEnvVar set and the gateway " +
+          "has no Hydra token provider configured. Set either " +
+          "peer.auth.tokenEnvVar on the peer config, or " +
+          "BINDU_GATEWAY_HYDRA_TOKEN_URL + BINDU_GATEWAY_HYDRA_SCOPE at " +
+          "boot for the auto path.",
       )
     }
+
     const signed = await identity.sign(body)
     return {
       Authorization: `Bearer ${token}`,

--- a/gateway/src/bindu/client/fetch.ts
+++ b/gateway/src/bindu/client/fetch.ts
@@ -1,5 +1,6 @@
 import { buildAuthHeaders, type PeerAuth } from "../auth/resolver"
 import type { LocalIdentity } from "../identity/local"
+import type { TokenProvider } from "../identity/hydra-token"
 import { BinduError, JsonRpcResponse, type JsonRpcRequest } from "../protocol/jsonrpc"
 
 /**
@@ -36,6 +37,11 @@ export interface RpcInput {
    *  — the signer needs it to sign the body. Safe to omit for other
    *  auth types. */
   identity?: LocalIdentity
+  /** Gateway's Hydra token provider. Used by ``auth.type === "did_signed"``
+   *  peers that omit ``tokenEnvVar`` — they fall back to this
+   *  provider (auto-acquired at boot). Safe to omit; only relevant
+   *  when the gateway has a configured Hydra. */
+  tokenProvider?: TokenProvider
   /** Extra headers that don't depend on the body (e.g. tracing
    *  propagation). Merged after auth headers so auth can't be
    *  overridden accidentally. */
@@ -76,7 +82,12 @@ export async function rpc<T = unknown>(input: RpcInput): Promise<RpcOutcome<T>> 
   const bodyStr = JSON.stringify(input.request)
 
   try {
-    const authHdrs = await buildAuthHeaders(input.auth, bodyStr, input.identity)
+    const authHdrs = await buildAuthHeaders(
+      input.auth,
+      bodyStr,
+      input.identity,
+      input.tokenProvider,
+    )
     const resp = await fetcher(url, {
       method: "POST",
       headers: {

--- a/gateway/src/bindu/client/index.ts
+++ b/gateway/src/bindu/client/index.ts
@@ -4,6 +4,7 @@ import type { Message, Part, Task } from "../protocol/types"
 import { sendAndPoll, type SendAndPollOutcome } from "./poll"
 import { type PeerAuth } from "../auth/resolver"
 import type { LocalIdentity } from "../identity/local"
+import type { TokenProvider } from "../identity/hydra-token"
 import { BinduError, ErrorCode } from "../protocol/jsonrpc"
 import { verifyArtifact } from "../identity/verify"
 import { createResolver, primaryPublicKeyBase58 } from "../identity/resolve"
@@ -77,20 +78,30 @@ export interface Interface {
 export class Service extends Context.Service<Service, Interface>()("@bindu/Client") {}
 
 /**
- * Build the Client layer with an optional gateway DID identity.
+ * Build the Client layer with the gateway's DID identity and an
+ * optional Hydra token provider.
  *
- * ``identity`` is what lets the gateway talk to ``did_signed`` peers —
+ * ``identity`` lets the gateway talk to ``did_signed`` peers —
  * every outbound call to such a peer is signed with this identity's
  * private key. For ``bearer`` / ``bearer_env`` / ``none`` peers,
- * identity is ignored and can be omitted (e.g. in tests, or
- * deployments that don't yet talk to any DID-enforcing agents).
+ * identity is ignored.
  *
- * Exported as a factory so ``index.ts`` can load the identity from
- * env at boot and inject it once. The default ``layer`` export below
- * is a no-identity variant for backward compat with existing tests
- * and any deployment that doesn't enable DID signing.
+ * ``tokenProvider`` is the auto path for the OAuth bearer: when a
+ * ``did_signed`` peer omits ``tokenEnvVar``, the gateway calls
+ * ``tokenProvider.getToken()`` to get a fresh-or-cached Hydra
+ * access_token. Safe to omit if all ``did_signed`` peers explicitly
+ * set ``tokenEnvVar`` (the federated pattern), or if the gateway
+ * doesn't talk to any ``did_signed`` peers.
+ *
+ * Exported as a factory so ``index.ts`` can wire the identity and
+ * token provider at boot. The default ``layer`` export below is a
+ * zero-argument variant for backward compat with existing tests and
+ * deployments that don't enable DID signing.
  */
-export const makeLayer = (identity?: LocalIdentity) =>
+export const makeLayer = (
+  identity?: LocalIdentity,
+  tokenProvider?: TokenProvider,
+) =>
   Layer.effect(
     Service,
     Effect.sync(() => {
@@ -98,7 +109,7 @@ export const makeLayer = (identity?: LocalIdentity) =>
 
       const callPeer: Interface["callPeer"] = (input) =>
         Effect.tryPromise({
-          try: () => runCall(input, didResolver, identity),
+          try: () => runCall(input, didResolver, identity, tokenProvider),
           catch: (e) =>
             e instanceof BinduError
               ? e
@@ -111,7 +122,7 @@ export const makeLayer = (identity?: LocalIdentity) =>
 
       const cancel: Interface["cancel"] = ({ peer, taskId }) =>
         Effect.tryPromise({
-          try: () => runCancel(peer, taskId, identity),
+          try: () => runCancel(peer, taskId, identity, tokenProvider),
           catch: (e) =>
             e instanceof BinduError
               ? e
@@ -126,14 +137,16 @@ export const makeLayer = (identity?: LocalIdentity) =>
     }),
   )
 
-/** Default layer — no identity. ``did_signed`` peers will fail at
- *  call time with a clear error pointing at ``makeLayer(identity)``. */
-export const layer = makeLayer(undefined)
+/** Default layer — no identity, no token provider. ``did_signed``
+ *  peers will fail at call time with a clear error pointing at
+ *  ``makeLayer(identity, tokenProvider)``. */
+export const layer = makeLayer(undefined, undefined)
 
 async function runCall(
   input: CallPeerInput,
   didResolver: ReturnType<typeof createResolver>,
   identity: LocalIdentity | undefined,
+  tokenProvider: TokenProvider | undefined,
 ): Promise<CallPeerOutcome> {
   const parts: Part[] =
     typeof input.input === "string" ? [{ kind: "text", text: input.input }] : input.input
@@ -154,6 +167,7 @@ async function runCall(
     peerUrl: input.peer.url,
     auth: input.peer.auth,
     identity,
+    tokenProvider,
     message,
     signal: input.signal,
     timeoutMs: input.timeoutMs,
@@ -212,10 +226,11 @@ async function runCancel(
   peer: PeerDescriptor,
   taskId: string,
   identity: LocalIdentity | undefined,
+  tokenProvider: TokenProvider | undefined,
 ): Promise<void> {
   const { cancel } = await import("./poll")
   await cancel(
-    { peerUrl: peer.url, auth: peer.auth, identity },
+    { peerUrl: peer.url, auth: peer.auth, identity, tokenProvider },
     taskId,
   )
 }

--- a/gateway/src/bindu/client/poll.ts
+++ b/gateway/src/bindu/client/poll.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto"
 import type { PeerAuth } from "../auth/resolver"
 import type { LocalIdentity } from "../identity/local"
+import type { TokenProvider } from "../identity/hydra-token"
 import { Task, isTerminal, needsCallerAction, type Message } from "../protocol/types"
 import { Normalize } from "../protocol"
 import { BinduError, ErrorCode, SCHEMA_MISMATCH_CODES } from "../protocol/jsonrpc"
@@ -32,6 +33,9 @@ export interface SendAndPollInput {
   auth?: PeerAuth
   /** Gateway identity — required iff ``auth.type === "did_signed"``. */
   identity?: LocalIdentity
+  /** Gateway token provider — used by did_signed peers that omit
+   *  ``tokenEnvVar``. */
+  tokenProvider?: TokenProvider
   /** Extra static headers (tracing, etc.) merged on top of auth. */
   extraHeaders?: Record<string, string>
   message: Message
@@ -62,6 +66,7 @@ export async function sendAndPoll(input: SendAndPollInput): Promise<SendAndPollO
     peerUrl: input.peerUrl,
     auth: input.auth,
     identity: input.identity,
+    tokenProvider: input.tokenProvider,
     extraHeaders: input.extraHeaders,
     signal: input.signal,
     timeoutMs: input.timeoutMs,

--- a/gateway/src/bindu/identity/hydra-admin.ts
+++ b/gateway/src/bindu/identity/hydra-admin.ts
@@ -1,0 +1,155 @@
+/**
+ * Hydra admin API client for the gateway's own OAuth client
+ * registration.
+ *
+ * The gateway registers itself with Hydra on boot so peers can
+ * verify it. The registration is idempotent: on restart the gateway
+ * re-registers with the same DID as ``client_id`` and the same
+ * deterministically-derived ``client_secret``; Hydra either confirms
+ * the client exists (200 GET) or creates it (404 → POST).
+ *
+ * The client_secret is derived from the gateway's seed (see
+ * ``deriveClientSecret`` below). This avoids the "where do I persist
+ * the OAuth secret" problem — there's no disk state the gateway
+ * needs to keep around beyond the seed env var it already requires.
+ * Anyone with the seed can compute the secret, but anyone with the
+ * seed could already impersonate the gateway by signing as it — the
+ * secret adds no new trust boundary, it's just a mechanism for the
+ * OAuth client_credentials flow.
+ *
+ * The shape of the POST body matches
+ * ``bindu/auth/hydra/registration.py`` so the same Hydra can host
+ * gateways and agents side-by-side without schema drift.
+ */
+
+import { sha256 } from "@noble/hashes/sha2.js"
+
+export interface HydraClientCredentials {
+  /** The DID, used as Hydra's client_id. */
+  clientId: string
+  /** Base64url-encoded 32-byte derivation — the OAuth2 client secret
+   *  used in the client_credentials grant. */
+  clientSecret: string
+}
+
+export interface EnsureHydraClientOpts {
+  /** Hydra admin URL, e.g. http://hydra:4445 (no trailing slash). */
+  adminUrl: string
+  did: string
+  clientName: string
+  publicKeyBase58: string
+  /** Deterministic secret derived from the seed — pass the value
+   *  from ``deriveClientSecret``. */
+  clientSecret: string
+  /** OAuth scopes to request. Typical: ["openid", "offline",
+   *  "agent:read", "agent:write"]. */
+  scope: string[]
+  /** Grant types. Typical for gateway: ["client_credentials"]. */
+  grantTypes?: string[]
+  /** Test hook. */
+  fetch?: typeof fetch
+}
+
+/**
+ * Deterministic client_secret derivation from the Ed25519 seed.
+ *
+ * Output: base64url-encoded 32 bytes. That's enough entropy to
+ * satisfy Hydra's client_secret requirements (Hydra accepts any
+ * non-empty string but ≥32 random bytes is the usual recommendation)
+ * without introducing an extra secret the operator has to manage.
+ *
+ * The tag ensures the derivation is scoped — if a future piece of
+ * Bindu also wants to derive a secret from the same seed for some
+ * other purpose, it uses a different tag so the two secrets don't
+ * collide.
+ */
+export function deriveClientSecret(seed: Uint8Array): string {
+  const tag = new TextEncoder().encode("bindu-gateway-hydra-client-secret/v1")
+  const combined = new Uint8Array(seed.length + tag.length)
+  combined.set(seed, 0)
+  combined.set(tag, seed.length)
+  const digest = sha256(combined)
+  return Buffer.from(digest)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")
+}
+
+/**
+ * Build the admin-API client payload. Shape matches what the Python
+ * agent registration sends at
+ * ``bindu/auth/hydra/registration.py:240-260``.
+ */
+function buildClientPayload(opts: EnsureHydraClientOpts): unknown {
+  return {
+    client_id: opts.did,
+    client_secret: opts.clientSecret,
+    client_name: opts.clientName,
+    grant_types: opts.grantTypes ?? ["client_credentials"],
+    response_types: ["code", "token"],
+    scope: opts.scope.join(" "),
+    token_endpoint_auth_method: "client_secret_post",
+    metadata: {
+      did: opts.did,
+      public_key: opts.publicKeyBase58,
+      key_type: "Ed25519",
+      verification_method: "Ed25519VerificationKey2020",
+      hybrid_auth: true,
+      registered_at: new Date().toISOString(),
+    },
+  }
+}
+
+/**
+ * Ensure a Hydra OAuth client exists for the given DID. Idempotent:
+ *
+ *   - If the client already exists (200 on GET), returns the
+ *     credentials we passed in.
+ *   - If not (404 on GET), POSTs the client payload and returns
+ *     credentials.
+ *   - Any other status (5xx, auth failure on admin API) is an error.
+ *
+ * Never persists the client_secret to disk — it's derived from the
+ * seed, so operators only need to keep ``BINDU_GATEWAY_DID_SEED``
+ * safe.
+ */
+export async function ensureHydraClient(
+  opts: EnsureHydraClientOpts,
+): Promise<HydraClientCredentials> {
+  const fetcher = opts.fetch ?? fetch
+  const base = opts.adminUrl.replace(/\/$/, "")
+  const encoded = encodeURIComponent(opts.did)
+
+  // Check if the client already exists.
+  const getResp = await fetcher(`${base}/admin/clients/${encoded}`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  })
+
+  if (getResp.status === 200) {
+    return { clientId: opts.did, clientSecret: opts.clientSecret }
+  }
+  if (getResp.status !== 404) {
+    const body = await getResp.text().catch(() => "")
+    throw new Error(
+      `Hydra admin GET /admin/clients/${opts.did} returned ${getResp.status}: ${body.slice(0, 300)}`,
+    )
+  }
+
+  // Not found — create it.
+  const postResp = await fetcher(`${base}/admin/clients`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(buildClientPayload(opts)),
+  })
+
+  if (postResp.status !== 200 && postResp.status !== 201) {
+    const body = await postResp.text().catch(() => "")
+    throw new Error(
+      `Hydra admin POST /admin/clients returned ${postResp.status}: ${body.slice(0, 300)}`,
+    )
+  }
+
+  return { clientId: opts.did, clientSecret: opts.clientSecret }
+}

--- a/gateway/src/bindu/identity/hydra-token.ts
+++ b/gateway/src/bindu/identity/hydra-token.ts
@@ -1,0 +1,124 @@
+/**
+ * OAuth2 client_credentials token provider for the gateway's DID
+ * identity. In-memory cache + proactive refresh so every outbound
+ * call to a did_signed peer gets a fresh-enough token without
+ * round-tripping Hydra each time.
+ *
+ * Why here instead of a per-request fetch:
+ *
+ *   * Latency — Hydra introspection on every call would add tens
+ *     of ms to each outbound RPC. Cache hits are free.
+ *   * Rate limit — some Hydra deployments throttle /oauth2/token;
+ *     exhausting a rate budget during a plan's tool-call fan-out
+ *     would cascade into 429s.
+ *   * Concurrency — several concurrent outbound calls during the
+ *     same plan must not each trigger a separate refresh. The
+ *     provider shares a single in-flight promise across callers.
+ *
+ * Deliberately in-memory only. A persistent cache (disk / Redis)
+ * would add complexity without improving the common path — on
+ * gateway restart we re-register with Hydra via hydra-admin
+ * anyway, so cold-start token fetch is already the expected cost.
+ */
+
+export interface TokenProvider {
+  /** Returns a fresh access token, fetching from Hydra when the
+   *  cache is cold or the cached token is within
+   *  ``refreshThresholdSec`` of expiry. Concurrent callers during
+   *  a refresh share the same in-flight promise. */
+  getToken(): Promise<string>
+}
+
+export interface CreateTokenProviderOpts {
+  /** Hydra public token endpoint, e.g. http://hydra:4444/oauth2/token */
+  tokenUrl: string
+  clientId: string
+  clientSecret: string
+  scope: string[]
+  /** Refresh the token when it has less than this many seconds
+   *  remaining. Default 30 — long enough to survive a slow plan
+   *  turn without expiring mid-request. */
+  refreshThresholdSec?: number
+  /** Test hook. */
+  fetch?: typeof fetch
+  /** Clock injection for deterministic tests. Production: Date.now. */
+  now?: () => number
+}
+
+interface TokenResponse {
+  access_token: string
+  token_type: string
+  expires_in: number
+  scope?: string
+}
+
+export function createTokenProvider(
+  opts: CreateTokenProviderOpts,
+): TokenProvider {
+  const fetcher = opts.fetch ?? fetch
+  const now = opts.now ?? Date.now
+  const refreshThresholdMs = (opts.refreshThresholdSec ?? 30) * 1000
+
+  // Cached token state. null = no cached value; ``expiresAtMs`` is
+  // an absolute epoch ms, ``refresh at'' is
+  // expiresAtMs - refreshThresholdMs.
+  let cached: { token: string; expiresAtMs: number } | null = null
+  // In-flight fetch. Shared across concurrent callers so we only
+  // hit Hydra once per refresh window.
+  let inFlight: Promise<string> | null = null
+
+  async function fetchToken(): Promise<string> {
+    const body = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: opts.clientId,
+      client_secret: opts.clientSecret,
+      scope: opts.scope.join(" "),
+    })
+
+    const resp = await fetcher(opts.tokenUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: body.toString(),
+    })
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "")
+      throw new Error(
+        `Hydra token endpoint returned ${resp.status}: ${text.slice(0, 300)}`,
+      )
+    }
+
+    const data = (await resp.json()) as TokenResponse
+    if (!data.access_token || typeof data.expires_in !== "number") {
+      throw new Error(
+        `Hydra token response missing access_token or expires_in: ${JSON.stringify(data).slice(0, 300)}`,
+      )
+    }
+
+    cached = {
+      token: data.access_token,
+      expiresAtMs: now() + data.expires_in * 1000,
+    }
+    return data.access_token
+  }
+
+  async function getToken(): Promise<string> {
+    // Cache hit — return immediately if we have enough runway.
+    if (cached && cached.expiresAtMs - now() > refreshThresholdMs) {
+      return cached.token
+    }
+
+    // Already refreshing — share the in-flight promise.
+    if (inFlight) return inFlight
+
+    inFlight = fetchToken().finally(() => {
+      inFlight = null
+    })
+    return inFlight
+  }
+
+  return { getToken }
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -23,6 +23,14 @@ import {
   loadLocalIdentity,
   type LocalIdentity,
 } from "./bindu/identity/local"
+import {
+  deriveClientSecret,
+  ensureHydraClient,
+} from "./bindu/identity/hydra-admin"
+import {
+  createTokenProvider,
+  type TokenProvider,
+} from "./bindu/identity/hydra-token"
 
 /**
  * Bindu Gateway boot.
@@ -43,7 +51,10 @@ import {
 // BinduClient layer. Peers configured with auth.type=did_signed use
 // this identity's private key to sign outbound bodies.
 
-function buildAppLayer(identity: LocalIdentity | undefined) {
+function buildAppLayer(
+  identity: LocalIdentity | undefined,
+  tokenProvider: TokenProvider | undefined,
+) {
   // Level 1 — zero-dependency services
   const level1 = Layer.mergeAll(
     Config.layer,
@@ -51,7 +62,7 @@ function buildAppLayer(identity: LocalIdentity | undefined) {
     Auth.layer,
     Permission.layer,
     ToolRegistry.layer,
-    BinduClient.makeLayer(identity),
+    BinduClient.makeLayer(identity, tokenProvider),
     Skill.defaultLayer,
   )
 
@@ -80,10 +91,10 @@ function buildAppLayer(identity: LocalIdentity | undefined) {
 
 /**
  * Default export kept for backward compat — a layer built without
- * a DID identity. did_signed peers will fail at call time with a
- * clear error pointing at BINDU_GATEWAY_DID_SEED.
+ * a DID identity or token provider. did_signed peers will fail at
+ * call time with a clear error pointing at BINDU_GATEWAY_DID_SEED.
  */
-export const appLayer = buildAppLayer(undefined)
+export const appLayer = buildAppLayer(undefined, undefined)
 
 /**
  * Load the gateway's DID identity from environment if all required
@@ -119,16 +130,85 @@ export function tryLoadIdentity(): LocalIdentity | undefined {
   return loadLocalIdentity({ author, name })
 }
 
+const DEFAULT_SCOPES = ["openid", "offline", "agent:read", "agent:write"]
+
+/**
+ * Auto-register the gateway with Hydra (if configured) and spin
+ * up a TokenProvider for outbound did_signed peer calls.
+ *
+ * Contract:
+ *
+ *   * Requires ``identity`` (the gateway's DID) — returns undefined
+ *     if no identity was loaded, since there's nothing to register.
+ *   * Reads three optional env vars:
+ *
+ *       BINDU_GATEWAY_HYDRA_ADMIN_URL   (e.g. http://hydra:4445)
+ *       BINDU_GATEWAY_HYDRA_TOKEN_URL   (e.g. http://hydra:4444/oauth2/token)
+ *       BINDU_GATEWAY_HYDRA_SCOPE       (space-separated; default:
+ *                                        "openid offline agent:read agent:write")
+ *
+ *   * If BOTH URLs are set: registers with Hydra (idempotent) and
+ *     returns a TokenProvider.
+ *   * If NEITHER is set: returns undefined. did_signed peers must
+ *     then carry a tokenEnvVar or fail at call time.
+ *   * If only one is set: throws a clear error. Partial config is
+ *     the worst of all worlds.
+ *
+ * Blocks boot until registration completes — if the admin API is
+ * unreachable at boot, we want to fail fast rather than discover
+ * the problem on the first peer call.
+ */
+export async function setupHydraIntegration(
+  identity: LocalIdentity,
+): Promise<TokenProvider | undefined> {
+  const adminUrl = process.env.BINDU_GATEWAY_HYDRA_ADMIN_URL
+  const tokenUrl = process.env.BINDU_GATEWAY_HYDRA_TOKEN_URL
+  const scopeStr = process.env.BINDU_GATEWAY_HYDRA_SCOPE
+
+  if (!adminUrl && !tokenUrl) return undefined
+
+  if (!adminUrl || !tokenUrl) {
+    throw new Error(
+      "Partial Hydra config — set both or neither: " +
+        "BINDU_GATEWAY_HYDRA_ADMIN_URL, BINDU_GATEWAY_HYDRA_TOKEN_URL. " +
+        `Got: admin=${adminUrl ? "set" : "missing"}, token=${tokenUrl ? "set" : "missing"}`,
+    )
+  }
+
+  const scope = scopeStr ? scopeStr.split(/\s+/).filter(Boolean) : DEFAULT_SCOPES
+
+  // Re-derive the seed here (not pulled from identity for security —
+  // identity doesn't expose raw seed bytes). Safe because the env
+  // var was already loaded by loadLocalIdentity.
+  const seedB64 = process.env.BINDU_GATEWAY_DID_SEED!
+  const seed = new Uint8Array(Buffer.from(seedB64, "base64"))
+  const clientSecret = deriveClientSecret(seed)
+
+  console.log(`[bindu-gateway] registering with Hydra at ${adminUrl}...`)
+  await ensureHydraClient({
+    adminUrl,
+    did: identity.did,
+    clientName: process.env.BINDU_GATEWAY_NAME ?? "gateway",
+    publicKeyBase58: identity.publicKeyBase58,
+    clientSecret,
+    scope,
+  })
+  console.log(`[bindu-gateway] Hydra registration confirmed for ${identity.did}`)
+
+  return createTokenProvider({
+    tokenUrl,
+    clientId: identity.did,
+    clientSecret,
+    scope,
+  })
+}
+
 export async function main(): Promise<{ close: () => Promise<void> }> {
   const identity = tryLoadIdentity()
   if (identity) {
     console.log(`[bindu-gateway] DID identity loaded: ${identity.did}`)
     console.log(
       `[bindu-gateway] public key (base58): ${identity.publicKeyBase58}`,
-    )
-    console.log(
-      `[bindu-gateway] register this DID + public key with each peer's Hydra ` +
-        `before talking to auth.type=did_signed peers.`,
     )
   } else {
     console.log(
@@ -137,7 +217,18 @@ export async function main(): Promise<{ close: () => Promise<void> }> {
     )
   }
 
-  const runtime = ManagedRuntime.make(buildAppLayer(identity))
+  const tokenProvider = identity
+    ? await setupHydraIntegration(identity)
+    : undefined
+  if (identity && !tokenProvider) {
+    console.log(
+      `[bindu-gateway] Hydra integration not configured — did_signed peers ` +
+        `must each set tokenEnvVar. Set BINDU_GATEWAY_HYDRA_ADMIN_URL + ` +
+        `_TOKEN_URL to auto-register and auto-acquire tokens.`,
+    )
+  }
+
+  const runtime = ManagedRuntime.make(buildAppLayer(identity, tokenProvider))
 
   const cfg = await runtime.runPromise(
     Effect.gen(function* () {

--- a/gateway/tests/bindu/auth-resolver.test.ts
+++ b/gateway/tests/bindu/auth-resolver.test.ts
@@ -36,7 +36,12 @@ describe("PeerAuth schema", () => {
   it("rejects unknown variants and missing required fields", () => {
     expect(PeerAuth.safeParse({ type: "unknown" } as any).success).toBe(false)
     expect(PeerAuth.safeParse({ type: "bearer" } as any).success).toBe(false)
-    expect(PeerAuth.safeParse({ type: "did_signed" } as any).success).toBe(false)
+    // did_signed: tokenEnvVar is optional (falls back to gateway
+    // token provider), so `{ type: "did_signed" }` alone is valid.
+    expect(PeerAuth.safeParse({ type: "did_signed" }).success).toBe(true)
+    expect(
+      PeerAuth.safeParse({ type: "did_signed", tokenEnvVar: 42 } as any).success,
+    ).toBe(false)
   })
 })
 
@@ -143,6 +148,78 @@ describe("buildAuthHeaders — did_signed variant", () => {
     expect(h["X-DID"]).toBe(identity.did)
     expect(h["X-DID-Timestamp"]).toMatch(/^\d+$/)
     expect(h["X-DID-Signature"]).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/) // base58
+  })
+
+  it("falls back to tokenProvider when tokenEnvVar is omitted", async () => {
+    withEnv({ [SEED_ENV]: Buffer.from(new Uint8Array(32)).toString("base64") })
+    const identity = loadLocalIdentity({
+      author: "ops@example.com",
+      name: "gateway",
+      seedEnvVar: SEED_ENV,
+    })
+
+    let providerCalls = 0
+    const fakeProvider = {
+      async getToken() {
+        providerCalls += 1
+        return "auto-acquired-token"
+      },
+    }
+
+    const h = await buildAuthHeaders(
+      { type: "did_signed" /* no tokenEnvVar */ },
+      '{"x":1}',
+      identity,
+      fakeProvider,
+    )
+
+    expect(h.Authorization).toBe("Bearer auto-acquired-token")
+    expect(h["X-DID-Signature"]).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/)
+    expect(providerCalls).toBe(1)
+  })
+
+  it("tokenEnvVar takes precedence over tokenProvider when both are set", async () => {
+    withEnv({
+      [SEED_ENV]: Buffer.from(new Uint8Array(32)).toString("base64"),
+      [TOKEN_ENV]: "env-token",
+    })
+    const identity = loadLocalIdentity({
+      author: "ops@example.com",
+      name: "gateway",
+      seedEnvVar: SEED_ENV,
+    })
+
+    const fakeProvider = {
+      getToken: async () => "provider-token",
+    }
+
+    const h = await buildAuthHeaders(
+      { type: "did_signed", tokenEnvVar: TOKEN_ENV },
+      '{"x":1}',
+      identity,
+      fakeProvider,
+    )
+
+    // Explicit peer-scoped env var wins over gateway-wide provider.
+    expect(h.Authorization).toBe("Bearer env-token")
+  })
+
+  it("refuses when neither tokenEnvVar nor tokenProvider is available", async () => {
+    withEnv({ [SEED_ENV]: Buffer.from(new Uint8Array(32)).toString("base64") })
+    const identity = loadLocalIdentity({
+      author: "ops@example.com",
+      name: "gateway",
+      seedEnvVar: SEED_ENV,
+    })
+
+    await expect(
+      buildAuthHeaders(
+        { type: "did_signed" /* no tokenEnvVar */ },
+        '{"x":1}',
+        identity,
+        /* tokenProvider */ undefined,
+      ),
+    ).rejects.toThrow(/BINDU_GATEWAY_HYDRA_TOKEN_URL/)
   })
 
   it("signs the exact body string passed in (regression guard)", async () => {

--- a/gateway/tests/bindu/hydra-admin.test.ts
+++ b/gateway/tests/bindu/hydra-admin.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the Hydra admin client — idempotent OAuth client
+ * registration for the gateway's own DID.
+ *
+ * Coverage priorities:
+ *   1. ``deriveClientSecret`` is deterministic and scoped (same seed
+ *      always produces the same secret; different tags would produce
+ *      different secrets).
+ *   2. ``ensureHydraClient`` is idempotent: an existing client (200
+ *      GET) means no POST. A missing client (404 GET) means POST.
+ *   3. Any non-200/404 from the GET, or non-2xx from the POST, is an
+ *      error with the Hydra response body surfaced so operators can
+ *      diagnose auth / network / permission issues.
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import {
+  deriveClientSecret,
+  ensureHydraClient,
+} from "../../src/bindu/identity/hydra-admin"
+
+function mockResponse(body: unknown, status = 200): Response {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const FIXTURE = {
+  adminUrl: "http://hydra:4445",
+  did: "did:bindu:test:gateway:abc",
+  clientName: "gateway",
+  publicKeyBase58: "4zvwRjXUKGfvwnParsHAS3HuSVzV5cA4McphgmoCtajS",
+  scope: ["openid", "agent:execute"],
+}
+
+describe("deriveClientSecret", () => {
+  it("is deterministic — same seed → same secret", () => {
+    const seed = new Uint8Array(32).fill(1)
+    expect(deriveClientSecret(seed)).toBe(deriveClientSecret(seed))
+  })
+
+  it("different seeds → different secrets", () => {
+    expect(deriveClientSecret(new Uint8Array(32).fill(1))).not.toBe(
+      deriveClientSecret(new Uint8Array(32).fill(2)),
+    )
+  })
+
+  it("produces base64url output (no +/= padding)", () => {
+    const secret = deriveClientSecret(new Uint8Array(32).fill(0))
+    expect(secret).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(secret.length).toBeGreaterThanOrEqual(32)
+  })
+})
+
+describe("ensureHydraClient — idempotent registration", () => {
+  it("GET 200 means client exists — no POST", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith(`/admin/clients/${encodeURIComponent(FIXTURE.did)}`)) {
+        return mockResponse({ client_id: FIXTURE.did }, 200)
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+
+    const creds = await ensureHydraClient({
+      ...FIXTURE,
+      clientSecret: "secret-x",
+      fetch: fetchMock as any,
+    })
+
+    expect(creds).toEqual({ clientId: FIXTURE.did, clientSecret: "secret-x" })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("GET 404 then POST 201 — creates the client with the right payload", async () => {
+    const sentBodies: string[] = []
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === "GET" || !init?.method) {
+        return mockResponse("", 404)
+      }
+      sentBodies.push(init.body as string)
+      return mockResponse({ client_id: FIXTURE.did }, 201)
+    })
+
+    const creds = await ensureHydraClient({
+      ...FIXTURE,
+      clientSecret: "secret-abc",
+      fetch: fetchMock as any,
+    })
+
+    expect(creds).toEqual({
+      clientId: FIXTURE.did,
+      clientSecret: "secret-abc",
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    // POST body carries the expected Hydra client shape.
+    const posted = JSON.parse(sentBodies[0])
+    expect(posted.client_id).toBe(FIXTURE.did)
+    expect(posted.client_secret).toBe("secret-abc")
+    expect(posted.client_name).toBe(FIXTURE.clientName)
+    expect(posted.grant_types).toEqual(["client_credentials"])
+    expect(posted.token_endpoint_auth_method).toBe("client_secret_post")
+    expect(posted.scope).toBe("openid agent:execute")
+    expect(posted.metadata.did).toBe(FIXTURE.did)
+    expect(posted.metadata.public_key).toBe(FIXTURE.publicKeyBase58)
+    expect(posted.metadata.key_type).toBe("Ed25519")
+    expect(posted.metadata.hybrid_auth).toBe(true)
+  })
+
+  it("GET 5xx on admin URL surfaces the status and body", async () => {
+    const fetchMock = vi.fn(async () => mockResponse("hydra down", 503))
+    await expect(
+      ensureHydraClient({
+        ...FIXTURE,
+        clientSecret: "s",
+        fetch: fetchMock as any,
+      }),
+    ).rejects.toThrow(/503.*hydra down/)
+  })
+
+  it("POST 4xx after 404 GET surfaces the error", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET")
+        return mockResponse("", 404)
+      return mockResponse("forbidden", 403)
+    })
+
+    await expect(
+      ensureHydraClient({
+        ...FIXTURE,
+        clientSecret: "s",
+        fetch: fetchMock as any,
+      }),
+    ).rejects.toThrow(/403.*forbidden/)
+  })
+
+  it("accepts grantTypes override (e.g. adding authorization_code)", async () => {
+    const sentBodies: string[] = []
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET")
+        return mockResponse("", 404)
+      sentBodies.push(init.body as string)
+      return mockResponse("", 201)
+    })
+
+    await ensureHydraClient({
+      ...FIXTURE,
+      clientSecret: "s",
+      grantTypes: ["client_credentials", "refresh_token"],
+      fetch: fetchMock as any,
+    })
+
+    const posted = JSON.parse(sentBodies[0])
+    expect(posted.grant_types).toEqual([
+      "client_credentials",
+      "refresh_token",
+    ])
+  })
+
+  it("trailing slash on adminUrl is tolerated", async () => {
+    let getUrl = ""
+    const fetchMock = vi.fn(async (url: string) => {
+      getUrl = url
+      return mockResponse("", 200)
+    })
+
+    await ensureHydraClient({
+      ...FIXTURE,
+      adminUrl: "http://hydra:4445/",
+      clientSecret: "s",
+      fetch: fetchMock as any,
+    })
+
+    // No double slash in the constructed URL.
+    expect(getUrl).not.toContain("//admin")
+    expect(getUrl).toContain("/admin/clients/")
+  })
+})

--- a/gateway/tests/bindu/hydra-token.test.ts
+++ b/gateway/tests/bindu/hydra-token.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the OAuth client_credentials token provider.
+ *
+ * The critical properties:
+ *
+ *   1. Caches across calls — successive getToken() returns the
+ *      same string without re-fetching while the cached token has
+ *      headroom.
+ *   2. Refreshes proactively — when remaining lifetime drops below
+ *      refreshThresholdSec, the next getToken() fetches a fresh
+ *      token. Verified with a controlled clock.
+ *   3. Coalesces concurrent callers — N concurrent getToken() calls
+ *      during a refresh share a single in-flight fetch. Prevents
+ *      stampede + rate-limit risk during a plan's tool-call
+ *      fan-out.
+ *   4. Surfaces Hydra errors with status + body — so operators can
+ *      diagnose auth / scope / network issues.
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { createTokenProvider } from "../../src/bindu/identity/hydra-token"
+
+function tokenResponse(access_token: string, expires_in = 3600): Response {
+  return new Response(
+    JSON.stringify({ access_token, expires_in, token_type: "bearer" }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  )
+}
+
+const OPTS = {
+  tokenUrl: "http://hydra:4444/oauth2/token",
+  clientId: "did:bindu:test",
+  clientSecret: "secret",
+  scope: ["openid", "agent:execute"],
+}
+
+describe("createTokenProvider", () => {
+  it("fetches on first call, caches for subsequent calls", async () => {
+    const fetchMock = vi.fn(async () => tokenResponse("abc", 3600))
+    const provider = createTokenProvider({
+      ...OPTS,
+      fetch: fetchMock as any,
+    })
+
+    expect(await provider.getToken()).toBe("abc")
+    expect(await provider.getToken()).toBe("abc")
+    expect(await provider.getToken()).toBe("abc")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("sends the right form body to Hydra", async () => {
+    const sent: { body: string }[] = []
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      sent.push({ body: init.body as string })
+      return tokenResponse("x")
+    })
+
+    await createTokenProvider({
+      ...OPTS,
+      fetch: fetchMock as any,
+    }).getToken()
+
+    const params = new URLSearchParams(sent[0].body)
+    expect(params.get("grant_type")).toBe("client_credentials")
+    expect(params.get("client_id")).toBe(OPTS.clientId)
+    expect(params.get("client_secret")).toBe(OPTS.clientSecret)
+    expect(params.get("scope")).toBe("openid agent:execute")
+  })
+
+  it("refreshes when cache has less than refreshThresholdSec remaining", async () => {
+    let nowMs = 1_000_000
+    let serial = 0
+    const fetchMock = vi.fn(async () => {
+      serial += 1
+      return tokenResponse(`tok-${serial}`, 60) // 60s lifetime
+    })
+
+    const provider = createTokenProvider({
+      ...OPTS,
+      refreshThresholdSec: 30,
+      fetch: fetchMock as any,
+      now: () => nowMs,
+    })
+
+    // First call fetches tok-1.
+    expect(await provider.getToken()).toBe("tok-1")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // Advance 10s — still plenty of runway. Cached.
+    nowMs += 10_000
+    expect(await provider.getToken()).toBe("tok-1")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // Advance past the refresh threshold (60s - 30s = 30s into life).
+    nowMs += 25_000
+    expect(await provider.getToken()).toBe("tok-2")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("coalesces concurrent callers into one in-flight fetch", async () => {
+    let resolve: (v: Response) => void = () => {}
+    const pending = new Promise<Response>((r) => {
+      resolve = r
+    })
+
+    const fetchMock = vi.fn(async () => pending)
+
+    const provider = createTokenProvider({
+      ...OPTS,
+      fetch: fetchMock as any,
+    })
+
+    // Fire three concurrent callers before the fetch resolves.
+    const [a, b, c] = [
+      provider.getToken(),
+      provider.getToken(),
+      provider.getToken(),
+    ]
+
+    // Exactly one fetch in flight.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolve(tokenResponse("shared-tok"))
+
+    const [ra, rb, rc] = await Promise.all([a, b, c])
+    expect(ra).toBe("shared-tok")
+    expect(rb).toBe("shared-tok")
+    expect(rc).toBe("shared-tok")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("surfaces Hydra error with status and body", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("invalid_client", {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+    )
+
+    const provider = createTokenProvider({
+      ...OPTS,
+      fetch: fetchMock as any,
+    })
+
+    await expect(provider.getToken()).rejects.toThrow(/401.*invalid_client/)
+  })
+
+  it("rejects malformed token responses", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ something: "else" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    )
+
+    const provider = createTokenProvider({
+      ...OPTS,
+      fetch: fetchMock as any,
+    })
+
+    await expect(provider.getToken()).rejects.toThrow(/access_token/)
+  })
+
+  it("re-fetches after an in-flight failure (not stuck in bad state)", async () => {
+    let serial = 0
+    const fetchMock = vi.fn(async () => {
+      serial += 1
+      if (serial === 1) return new Response("boom", { status: 500 })
+      return tokenResponse("recovered")
+    })
+
+    const provider = createTokenProvider({
+      ...OPTS,
+      fetch: fetchMock as any,
+    })
+
+    await expect(provider.getToken()).rejects.toThrow()
+    expect(await provider.getToken()).toBe("recovered")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/gateway/tests/index-identity.test.ts
+++ b/gateway/tests/index-identity.test.ts
@@ -8,7 +8,8 @@
  */
 
 import { describe, it, expect, afterEach } from "vitest"
-import { tryLoadIdentity } from "../src/index"
+import { setupHydraIntegration, tryLoadIdentity } from "../src/index"
+import { loadLocalIdentity } from "../src/bindu/identity/local"
 
 const SEED_VAR = "BINDU_GATEWAY_DID_SEED"
 const AUTHOR_VAR = "BINDU_GATEWAY_AUTHOR"
@@ -56,5 +57,57 @@ describe("tryLoadIdentity", () => {
     process.env[AUTHOR_VAR] = "ops@example.com"
     process.env[NAME_VAR] = "gateway"
     expect(() => tryLoadIdentity()).toThrow(/32 bytes/)
+  })
+})
+
+// -----------------------------------------------------------------------
+// setupHydraIntegration — partial-config fail-fast
+// -----------------------------------------------------------------------
+
+const ADMIN_VAR = "BINDU_GATEWAY_HYDRA_ADMIN_URL"
+const TOKEN_VAR = "BINDU_GATEWAY_HYDRA_TOKEN_URL"
+const SCOPE_VAR = "BINDU_GATEWAY_HYDRA_SCOPE"
+
+function clearHydraEnv() {
+  delete process.env[ADMIN_VAR]
+  delete process.env[TOKEN_VAR]
+  delete process.env[SCOPE_VAR]
+}
+
+describe("setupHydraIntegration", () => {
+  afterEach(() => {
+    clearIdentityEnv()
+    clearHydraEnv()
+  })
+
+  function mkIdentity() {
+    process.env[SEED_VAR] = Buffer.from(new Uint8Array(32)).toString("base64")
+    process.env[AUTHOR_VAR] = "ops@example.com"
+    process.env[NAME_VAR] = "gateway"
+    return loadLocalIdentity({ author: "ops@example.com", name: "gateway" })
+  }
+
+  it("returns undefined when no Hydra env vars are set", async () => {
+    clearHydraEnv()
+    const identity = mkIdentity()
+    expect(await setupHydraIntegration(identity)).toBeUndefined()
+  })
+
+  it("throws on partial config — admin set without token", async () => {
+    clearHydraEnv()
+    process.env[ADMIN_VAR] = "http://hydra:4445"
+    const identity = mkIdentity()
+    await expect(setupHydraIntegration(identity)).rejects.toThrow(
+      /Partial Hydra config/,
+    )
+  })
+
+  it("throws on partial config — token set without admin", async () => {
+    clearHydraEnv()
+    process.env[TOKEN_VAR] = "http://hydra:4444/oauth2/token"
+    const identity = mkIdentity()
+    await expect(setupHydraIntegration(identity)).rejects.toThrow(
+      /Partial Hydra config/,
+    )
   })
 })


### PR DESCRIPTION
Closes the manual-Hydra-registration step from Phase 1a. Set five env vars, start the gateway, everything else is automatic.

## What this adds

| Piece | File | What it does |
|---|---|---|
| Hydra admin client | `gateway/src/bindu/identity/hydra-admin.ts` | Idempotent GET-then-POST at `/admin/clients`. client_secret derived from seed (no disk state). |
| Token provider | `gateway/src/bindu/identity/hydra-token.ts` | In-memory token cache + proactive refresh + concurrent-caller coalescing |
| `did_signed` fallback | `gateway/src/bindu/auth/resolver.ts` | `tokenEnvVar` now optional — omitted → falls back to gateway's token provider |
| Bootstrap wiring | `gateway/src/index.ts` | `setupHydraIntegration(identity)` on boot: reads env, registers, creates provider |
| Docs | `.env.example`, `README.md` | Auto vs Manual mode, peer-config precedence, failure-mode table |

## End-to-end operator flow (auto mode)

```bash
export BINDU_GATEWAY_DID_SEED="$(python -c 'import os,base64;print(base64.b64encode(os.urandom(32)).decode())')"
export BINDU_GATEWAY_AUTHOR=ops@example.com
export BINDU_GATEWAY_NAME=gateway
export BINDU_GATEWAY_HYDRA_ADMIN_URL=http://hydra:4445
export BINDU_GATEWAY_HYDRA_TOKEN_URL=http://hydra:4444/oauth2/token

npm run dev
# → DID identity loaded: did:bindu:ops_at_example_com:gateway:...
# → public key (base58): 4zvwRjXUKGfvwn...
# → registering with Hydra at http://hydra:4445...
# → Hydra registration confirmed for did:bindu:...
```

Peer config now becomes:

```json
{ "url": "http://agent:3773", "auth": { "type": "did_signed" } }
```

No manual `hydra create oauth2-client`, no per-peer tokens stashed in env vars, no file on disk beyond the seed that was already required.

## Four commits, reviewable in order

1. **`cd7fab7` — Hydra admin client.** 334 lines. `ensureHydraClient` idempotent registration + `deriveClientSecret` derivation-from-seed. 9 tests covering GET 200 (no POST), GET 404 → POST (correct payload shape), GET 5xx / POST 4xx surfacing body, grant types override, trailing slash tolerance.

2. **`43a5a07` — OAuth token provider.** 310 lines. `createTokenProvider` with in-memory cache + proactive refresh + concurrent-caller coalescing. 7 tests covering cache hit, form body shape, controlled-clock refresh, stampede coalescing, Hydra 4xx surfacing, malformed response rejection, post-error recovery.

3. **`e95939f` — `did_signed` fallback.** 161 lines. `tokenEnvVar` optional; resolution order = peer env var > gateway provider > error. 3 new tests covering provider fallback, peer-scoped precedence, no-option error.

4. **`40b4953` — Bootstrap + docs.** 241 lines. `setupHydraIntegration(identity)` in main(), partial-Hydra-config fail-fast, `.env.example` + README rewrite with Auto/Manual split.

## Failure mode table (also in README)

| Scenario | When | Error |
|---|---|---|
| Seed malformed | Boot | `BINDU_GATEWAY_DID_SEED must decode to exactly 32 bytes` |
| Partial identity config | Boot | `Partial DID identity config — set all three or none` |
| Partial Hydra config | Boot | `Partial Hydra config — set both or neither` |
| Hydra admin unreachable | Boot | `Hydra admin GET /admin/clients/... returned 503: ...` |
| `did_signed` peer, no identity | First call | `did_signed peer requires a gateway LocalIdentity` |
| `did_signed` peer, no token source | First call | clear error naming both tokenEnvVar and BINDU_GATEWAY_HYDRA_TOKEN_URL |

Fail-fast-at-boot where possible; clear-error-at-call-time where config isn't testable until a peer is actually called.

## Test summary

**99 gateway tests pass** (77 baseline from Phase 1a + 22 new across four new files/sections).

## Deferred to later phases

- **Phase 1c** — frontend POC (localStorage + tweetnacl, per Decision 4)
- **Phase 1d** — Postman collection with the corrected signing pre-request script
- **Phase 1e** — deep docs in `docs/GATEWAY_DID_SETUP.md`
- **Future** — `/.well-known/did.json` endpoint on the gateway (A2A-native DID resolution — peers could skip Hydra introspection in favor of resolving the gateway's DID directly). Not needed for MVP since Hydra metadata carries the public key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hydra auto-registration for OAuth clients with automatic token refresh and caching.
  * Added optional "Auto" setup mode for DID signing that eliminates per-peer token configuration requirements.

* **Documentation**
  * Expanded setup guide documenting Auto and Manual federation modes for DID signing.
  * Added failure modes table with clear error messages for configuration issues.

* **Tests**
  * Added comprehensive test coverage for OAuth token management and client registration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->