### PR TITLE
feat(gateway): self-publish DID document at /.well-known/did.json

### DIFF
--- a/gateway/src/api/did-route.ts
+++ b/gateway/src/api/did-route.ts
@@ -1,0 +1,88 @@
+import type { Context as HonoContext } from "hono"
+import type { LocalIdentity } from "../bindu/identity/local"
+
+/**
+ * GET /.well-known/did.json — the gateway's self-published DID document.
+ *
+ * Lets any A2A peer resolve the gateway's DID to the Ed25519 public key
+ * without round-tripping through Hydra admin. Matches the shape W3C DID
+ * Core + the Bindu agent extension publish:
+ *
+ *   {
+ *     "@context":       [w3c, getbindu],
+ *     "id":             "did:bindu:...",
+ *     "authentication": [{ id, type, controller, publicKeyBase58 }]
+ *   }
+ *
+ * Deliberately omits ``created``. The gateway's identity is env-driven
+ * and stateless — there's no persisted "first published" moment to
+ * report. Emitting the process start time or current-now would mislead
+ * clients into thinking the key was rotated at that moment. W3C DID
+ * Core v1 has ``created`` as optional; absence is valid.
+ *
+ * Deliberately unauthenticated. Well-known endpoints are public by
+ * spec — the whole point is that anyone can resolve the DID without
+ * credentials.
+ */
+
+const CONTEXT = [
+  "https://www.w3.org/ns/did/v1",
+  "https://getbindu.com/ns/v1",
+] as const
+
+/** Verification method shape — one entry per usable public key. */
+export interface GatewayVerificationMethod {
+  readonly id: string
+  readonly type: "Ed25519VerificationKey2020"
+  readonly controller: string
+  readonly publicKeyBase58: string
+}
+
+/** The gateway's DID document. See module docstring for why ``created`` is absent. */
+export interface GatewayDidDocument {
+  readonly "@context": readonly string[]
+  readonly id: string
+  readonly authentication: readonly GatewayVerificationMethod[]
+}
+
+/**
+ * Build the DID document from an identity. Pure — safe to call once at
+ * boot and cache the result for the life of the process.
+ */
+export function buildDidDocument(identity: LocalIdentity): GatewayDidDocument {
+  return {
+    "@context": CONTEXT,
+    id: identity.did,
+    authentication: [
+      {
+        id: `${identity.did}#key-1`,
+        type: "Ed25519VerificationKey2020",
+        controller: identity.did,
+        publicKeyBase58: identity.publicKeyBase58,
+      },
+    ],
+  }
+}
+
+/**
+ * Build the Hono handler. Serializes the document once, returns the
+ * same bytes on every request — the content doesn't change for the
+ * lifetime of the process, so caching the serialization saves a tiny
+ * amount of per-request work and (more importantly) guarantees
+ * byte-stability if a client hashes the response.
+ *
+ * Content-Type is ``application/did+json`` per W3C DID Core — not
+ * plain ``application/json``. Some DID resolvers check the media type.
+ */
+export function buildDidHandler(identity: LocalIdentity) {
+  const document = buildDidDocument(identity)
+  const body = JSON.stringify(document)
+  return (c: HonoContext) =>
+    c.body(body, 200, {
+      "Content-Type": "application/did+json",
+      // 5-minute cache. The key doesn't rotate without a gateway
+      // restart, so short TTL is just defensive against bad caches
+      // holding forever. Peers that need certainty still hit us fresh.
+      "Cache-Control": "public, max-age=300",
+    })
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -19,6 +19,7 @@ import * as BinduClient from "./bindu/client"
 import * as Server from "./server"
 import * as Planner from "./planner"
 import { buildPlanHandler } from "./api/plan-route"
+import { buildDidHandler } from "./api/did-route"
 import {
   loadLocalIdentity,
   type LocalIdentity,
@@ -247,6 +248,18 @@ export async function main(): Promise<{ close: () => Promise<void> }> {
   )
 
   app.post("/plan", planHandler)
+
+  // Self-publish the gateway's DID document so A2A peers can resolve
+  // ``did:bindu:<gateway>`` to its Ed25519 public key without needing
+  // Hydra admin access. Only registered when an identity is loaded —
+  // a gateway without a DID has nothing to publish here, and a 404
+  // correctly says so.
+  if (identity) {
+    app.get("/.well-known/did.json", buildDidHandler(identity))
+    console.log(
+      `[bindu-gateway] publishing DID document at /.well-known/did.json`,
+    )
+  }
 
   const { port, hostname } = cfg.gateway.server
   const httpServer = serve({ fetch: app.fetch, port, hostname })

--- a/gateway/src/server/index.ts
+++ b/gateway/src/server/index.ts
@@ -6,9 +6,11 @@ import { Service as ConfigService } from "../config"
  * Hono application factory.
  *
  * Routes:
- *   GET  /health          — liveness + basic version info
- *   POST /plan            — wired in Day 9 (api/plan-route.ts)
- *   GET  /plan/:sid/...   — Phase 2 resume / replay
+ *   GET  /health                  — liveness + basic version info
+ *   GET  /.well-known/did.json    — self-published DID doc, when a gateway
+ *                                   identity is loaded (api/did-route.ts)
+ *   POST /plan                    — wired in Day 9 (api/plan-route.ts)
+ *   GET  /plan/:sid/...           — Phase 2 resume / replay
  *
  * This module only provides the app shell + `/health`. Route handlers live
  * in `src/api/` so they can own their own request validation + SSE wiring.

--- a/gateway/tests/api/did-route.test.ts
+++ b/gateway/tests/api/did-route.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for GET /.well-known/did.json — the gateway's self-published
+ * DID document.
+ *
+ * Contract the peers depend on:
+ *
+ *   1. Document has a valid W3C DID Core shape (``@context``, ``id``,
+ *      ``authentication``) with Bindu's extension namespace.
+ *   2. ``id`` exactly matches the gateway's loaded DID — peers compare
+ *      this against the DID they resolved.
+ *   3. ``publicKeyBase58`` exactly matches what outbound DID-signed
+ *      requests would be signed against. If these drift, verification
+ *      fails on the peer side with ``crypto_mismatch``.
+ *   4. Content-Type is ``application/did+json`` per W3C DID Core —
+ *      plain ``application/json`` is tolerated by most resolvers but
+ *      stricter ones reject it.
+ *   5. ``created`` is deliberately absent — see api/did-route.ts for
+ *      the rationale. This test guards the decision so it's not
+ *      re-introduced accidentally.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { Hono } from "hono"
+import {
+  buildDidDocument,
+  buildDidHandler,
+} from "../../src/api/did-route"
+import { loadLocalIdentity } from "../../src/bindu/identity/local"
+
+const TEST_ENV = "TEST_DID_ROUTE_SEED"
+
+function setSeedEnv(b64: string | undefined) {
+  if (b64 === undefined) delete process.env[TEST_ENV]
+  else process.env[TEST_ENV] = b64
+}
+
+function makeIdentity() {
+  // 32 zero bytes — deterministic test seed. Matches the cross-language
+  // fixture in identity-local.test.ts so a failure here and a failure
+  // there point at the same drift.
+  setSeedEnv(Buffer.from(new Uint8Array(32)).toString("base64"))
+  return loadLocalIdentity({
+    author: "ops@example.com",
+    name: "gateway",
+    seedEnvVar: TEST_ENV,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// buildDidDocument — pure shape
+// ---------------------------------------------------------------------------
+
+describe("buildDidDocument", () => {
+  afterEach(() => setSeedEnv(undefined))
+
+  it("has the W3C DID Core + Bindu @context", () => {
+    const doc = buildDidDocument(makeIdentity())
+    expect(doc["@context"]).toEqual([
+      "https://www.w3.org/ns/did/v1",
+      "https://getbindu.com/ns/v1",
+    ])
+  })
+
+  it("id equals the identity DID exactly", () => {
+    const id = makeIdentity()
+    const doc = buildDidDocument(id)
+    expect(doc.id).toBe(id.did)
+  })
+
+  it("authentication has exactly one Ed25519VerificationKey2020 entry", () => {
+    const doc = buildDidDocument(makeIdentity())
+    expect(doc.authentication).toHaveLength(1)
+    const method = doc.authentication[0]
+    expect(method.type).toBe("Ed25519VerificationKey2020")
+  })
+
+  it("verification method id is `${did}#key-1`", () => {
+    const id = makeIdentity()
+    const doc = buildDidDocument(id)
+    expect(doc.authentication[0].id).toBe(`${id.did}#key-1`)
+  })
+
+  it("verification method controller is the DID itself (self-controlled)", () => {
+    const id = makeIdentity()
+    const doc = buildDidDocument(id)
+    expect(doc.authentication[0].controller).toBe(id.did)
+  })
+
+  it("publicKeyBase58 equals identity.publicKeyBase58 byte-exact", () => {
+    const id = makeIdentity()
+    const doc = buildDidDocument(id)
+    expect(doc.authentication[0].publicKeyBase58).toBe(id.publicKeyBase58)
+  })
+
+  it("does not emit ``created`` (stateless gateway, no persisted birth time)", () => {
+    const doc = buildDidDocument(makeIdentity()) as unknown as Record<string, unknown>
+    expect(doc.created).toBeUndefined()
+  })
+
+  it("is deterministic — same identity produces identical documents", () => {
+    const id = makeIdentity()
+    expect(buildDidDocument(id)).toEqual(buildDidDocument(id))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildDidHandler — HTTP behavior
+// ---------------------------------------------------------------------------
+
+describe("buildDidHandler — HTTP response shape", () => {
+  afterEach(() => setSeedEnv(undefined))
+
+  function mountApp() {
+    const id = makeIdentity()
+    const app = new Hono()
+    app.get("/.well-known/did.json", buildDidHandler(id))
+    return { app, identity: id }
+  }
+
+  it("200 on the well-known path", async () => {
+    const { app } = mountApp()
+    const res = await app.request("/.well-known/did.json")
+    expect(res.status).toBe(200)
+  })
+
+  it("Content-Type is application/did+json", async () => {
+    const { app } = mountApp()
+    const res = await app.request("/.well-known/did.json")
+    expect(res.headers.get("content-type")).toContain("application/did+json")
+  })
+
+  it("Cache-Control is set (5-minute public cache)", async () => {
+    const { app } = mountApp()
+    const res = await app.request("/.well-known/did.json")
+    const cc = res.headers.get("cache-control") ?? ""
+    expect(cc).toContain("public")
+    expect(cc).toContain("max-age=300")
+  })
+
+  it("response body parses as JSON and matches buildDidDocument output", async () => {
+    const { app, identity } = mountApp()
+    const res = await app.request("/.well-known/did.json")
+    const body = await res.json()
+    expect(body).toEqual(buildDidDocument(identity))
+  })
+
+  it("repeated requests return byte-identical bodies (safe to hash/cache)", async () => {
+    const { app } = mountApp()
+    const a = await (await app.request("/.well-known/did.json")).text()
+    const b = await (await app.request("/.well-known/did.json")).text()
+    expect(a).toBe(b)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Peer-resolution contract — what an A2A peer will actually do with this
+// ---------------------------------------------------------------------------
+
+describe("peer-resolution contract", () => {
+  afterEach(() => setSeedEnv(undefined))
+
+  it("a peer can round-trip: fetch doc → extract pubkey → matches identity's key", async () => {
+    const id = makeIdentity()
+    const app = new Hono()
+    app.get("/.well-known/did.json", buildDidHandler(id))
+
+    // Simulates what a DID-enforced peer does when it needs to verify
+    // a signature from this gateway: resolve the DID, pull the key,
+    // and use it. The key is what signatures get verified against —
+    // this is the invariant that must not drift.
+    const res = await app.request("/.well-known/did.json")
+    const doc = (await res.json()) as {
+      authentication: Array<{ publicKeyBase58: string }>
+    }
+    const pubkeyFromDoc = doc.authentication[0].publicKeyBase58
+
+    expect(pubkeyFromDoc).toBe(id.publicKeyBase58)
+  })
+})


### PR DESCRIPTION
## Summary

Gateway now serves its own DID document at `GET /.well-known/did.json`, giving A2A peers a Hydra-independent path to resolve `did:bindu:<gateway>` to its Ed25519 public key.

Before this PR the only way to verify a signature from the gateway was to query Hydra admin for the client's `metadata.public_key`. That tightly couples every DID-signed peer to our Hydra deployment. With this endpoint, a peer can resolve via the standard well-known pattern — the same way it would resolve any agent's DID document.

## What changed

- **`gateway/src/api/did-route.ts`** — pure `buildDidDocument(identity)` + Hono `buildDidHandler(identity)`. Serialization cached once at handler build — the document doesn't change for the life of the process, so repeat requests get byte-identical bodies (safe for clients that hash).
- **`gateway/src/index.ts`** — wires the route after `/plan`, **only when an identity is loaded**. A gateway without DID signing has nothing to publish; a 404 accurately says so.
- **`gateway/src/server/index.ts`** — docstring updated to list the new route.
- **`gateway/tests/api/did-route.test.ts`** — 14 tests covering shape, Content-Type, cache headers, determinism, and the peer-resolution contract (pubkey round-trip).

## Shape decisions worth calling out

- **`@context`**: `[w3c-did-v1, getbindu-ns-v1]` — matches the Python agent's DID document so resolvers work across both.
- **`authentication[0].type`**: `Ed25519VerificationKey2020` — W3C standard value; Bindu's signing is Ed25519 throughout.
- **`controller`**: self-referential (the DID controls its own key). Future multi-sig or delegation can extend this without breaking the current contract.
- **`publicKeyBase58`**: byte-identical to `identity.publicKeyBase58`. If these drift, peer verification fails with `crypto_mismatch`. Test asserts exact equality.
- **`created` deliberately omitted.** The gateway's identity is env-driven and stateless — there's no persisted "first published" moment to report. Emitting `Date.now()` or process start time would mislead clients into thinking the key was rotated at that moment. W3C DID Core v1 has `created` as optional; absence is valid. A test guards this so the field isn't accidentally added later.

## HTTP response properties

- **Status**: 200 when identity loaded; route doesn't exist → 404 otherwise
- **Content-Type**: `application/did+json` per W3C DID Core (stricter resolvers reject `application/json`)
- **Cache-Control**: `public, max-age=300` — short TTL as defense against misbehaving caches. Restarts with a new seed are uncommon enough that 5 min is fine; critical peers can still bypass cache.
- **Unauthenticated**: well-known endpoints are public by spec

## Test plan

- [x] `npx vitest run tests/api/did-route.test.ts` → **14/14 pass**
- [x] `npx tsc --noEmit` → no errors in modified files
- [x] Cross-language parity: pubkey round-trip (doc → extract → identity.publicKeyBase58) asserted exact
- [ ] Manual smoke with a live gateway: `curl http://localhost:<port>/.well-known/did.json | jq` (operator test, out of CI scope)

## Relation to other Phase 1 work

- [#472](https://github.com/GetBindu/Bindu/pull/472) (gateway DID primitive) ✅ merged — this PR builds on `LocalIdentity`
- [#473](https://github.com/GetBindu/Bindu/pull/473) (Hydra auto-reg) ✅ merged — this PR doesn't replace Hydra, it adds an A2A-native alternative
- [#474](https://github.com/GetBindu/Bindu/pull/474) (frontend POC) — open; orthogonal
- [#475](https://github.com/GetBindu/Bindu/pull/475) (docs rewrite) — open; references the W3C DID-doc pattern that this PR now actually ships for the gateway
- **This PR** — adds peer-resolvable identity surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new endpoint at `/.well-known/did.json` to publish gateway identity documents with HTTP caching enabled (5-minute max-age) for secure peer identity verification and cryptographic key discovery.

* **Tests**
  * Added comprehensive test coverage for DID document generation, JSON response validation, HTTP caching behavior, and end-to-end peer resolution testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->