### PR TITLE
docs(examples): add hermes-agent example

### DIFF
--- a/examples/hermes_agent/.env.example
+++ b/examples/hermes_agent/.env.example
@@ -1,0 +1,10 @@
+# Model provider — pick one the chosen HERMES_BINDU_MODEL understands.
+OPENROUTER_API_KEY=          # pragma: allowlist secret
+# ANTHROPIC_API_KEY=         # pragma: allowlist secret
+# OPENAI_API_KEY=            # pragma: allowlist secret
+
+# Adapter settings (all optional; defaults shown).
+# HERMES_BINDU_MODEL=anthropic/claude-sonnet-4.6
+# HERMES_BINDU_TIER=read          # read | sandbox | full
+# HERMES_BINDU_URL=http://localhost:3773
+# HERMES_BINDU_NAME=hermes

--- a/examples/hermes_agent/README.md
+++ b/examples/hermes_agent/README.md
@@ -1,0 +1,93 @@
+# Hermes-Agent via Bindu
+
+Run [hermes-agent](https://github.com/NousResearch/hermes-agent) — a full tool-
+using coding/research agent — as a Bindu A2A microservice. You get Hermes's
+tool loop (web search, file ops, code execution, browser, MCP, etc.) behind
+Bindu's DID identity, A2A protocol, OAuth2, and x402 payments.
+
+The adapter that does the wrapping lives in the hermes-agent repo as the
+`[bindu]` optional extra. This example is a thin pointer.
+
+## Requirements
+
+- Python 3.12+
+- [uv](https://docs.astral.sh/uv/)
+- A model API key — `OPENROUTER_API_KEY` (or whichever provider your model uses)
+
+## Run
+
+```bash
+cd examples/hermes_agent
+cp .env.example .env && vim .env        # set your model key
+
+uv pip install 'hermes-agent[bindu]'
+python hermes_simple_example.py
+```
+
+Equivalent one-liner via the Hermes CLI:
+
+```bash
+uv run hermes bindu serve
+```
+
+## Safety tiers
+
+A bindufied Hermes can expose powerful local tools. Pick the tier matching
+your deployment:
+
+| `HERMES_BINDU_TIER` | Toolset | When to use |
+|---|---|---|
+| `read` (default) | web search + extract | Public / tunneled deployments |
+| `sandbox` | adds filesystem + `execute_code` | Trusted caller, local FS |
+| `full` | everything incl. terminal, browser | Localhost-only, private |
+
+**Do not combine `full` with a public tunnel** — that's RCE-as-a-service.
+
+## Fire-and-pull (quick demo)
+
+All IDs must be real UUIDs. `tasks/get` keys off `taskId` (not `id`). See the
+authoritative [openapi.yaml](https://github.com/raahulrahl/docs/blob/main/openapi.yaml)
+for the complete JSON-RPC surface (`tasks/list`, `tasks/cancel`,
+`contexts/list`, push notifications, `message/stream`, …).
+
+```bash
+uuid() { uuidgen | tr 'A-Z' 'a-z'; }
+RID=$(uuid); MID=$(uuid); CID=$(uuid); TID=$(uuid)
+
+# Fire
+curl -s -X POST http://localhost:3773/ -H 'Content-Type: application/json' \
+  -d "{
+    \"jsonrpc\":\"2.0\",\"method\":\"message/send\",\"id\":\"$RID\",
+    \"params\":{
+      \"message\":{
+        \"role\":\"user\",
+        \"parts\":[{\"kind\":\"text\",\"text\":\"summarize https://getbindu.com in one sentence\"}],
+        \"kind\":\"message\",
+        \"messageId\":\"$MID\",\"contextId\":\"$CID\",\"taskId\":\"$TID\"
+      },
+      \"configuration\":{\"acceptedOutputModes\":[\"application/json\"]}
+    }
+  }" | jq
+
+# Pull — loop until state is completed / failed / input-required
+curl -s -X POST http://localhost:3773/ -H 'Content-Type: application/json' \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"tasks/get\",\"id\":\"$(uuid)\",\"params\":{\"taskId\":\"$TID\"}}" \
+  | jq '.result | {state: .status.state, text: .artifacts[0].parts[0].text}'
+```
+
+## How it fits together
+
+```
+curl ─► Bindu HTTP (:3773) ─► ManifestWorker ─► handler(messages) ─► AIAgent.chat()
+                                                                       │
+                                                                       └─► Hermes tool loop
+```
+
+The handler keeps **one shared `AIAgent`** per process so Anthropic prompt
+caching stays valid across turns. Bindu feeds the full history; Hermes only
+sees the newest user message (Bindu is the source of truth for history,
+Hermes owns the live model state for caching). Every artifact text is
+DID-signed on the way out.
+
+See [`bindu_adapter/README.md`](https://github.com/NousResearch/hermes-agent/tree/main/bindu_adapter)
+in the hermes-agent repo for deeper details.

--- a/examples/hermes_agent/hermes_simple_example.py
+++ b/examples/hermes_agent/hermes_simple_example.py
@@ -1,0 +1,56 @@
+"""Hermes-Agent via Bindu.
+
+Bindufies the Hermes `AIAgent` as an A2A microservice with DID identity,
+OAuth2-ready HTTP on port 3773, optional FRP tunnel, and x402 payments.
+
+The adapter lives inside the hermes-agent repo under `bindu_adapter/` and
+ships with the `[bindu]` optional extra. This example is just a pointer
+that defers to it.
+
+Usage:
+    # From a Python 3.12+ environment:
+    uv pip install 'hermes-agent[bindu]'
+    python examples/hermes_agent/hermes_simple_example.py
+
+    # Or use the CLI shortcut (same thing):
+    uv run hermes bindu serve
+
+Environment:
+    OPENROUTER_API_KEY  (or ANTHROPIC_API_KEY, whichever the chosen model needs)
+    HERMES_BINDU_MODEL  default "anthropic/claude-sonnet-4.6"
+    HERMES_BINDU_TIER   "read" (default) | "sandbox" | "full"
+    HERMES_BINDU_URL    default "http://localhost:3773"
+
+Tiers gate the toolset so a tunneled deployment is safe by default:
+    read    — web search + web extract only
+    sandbox — adds filesystem read/write and execute_code
+    full    — everything (terminal, browser, MCP). Local-only.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    try:
+        from bindu_adapter.serve import run
+    except ImportError:
+        sys.stderr.write(
+            "hermes-agent is not installed with the [bindu] extra.\n"
+            "Install it on Python 3.12+:\n"
+            "    uv pip install 'hermes-agent[bindu]'\n"
+        )
+        sys.exit(1)
+
+    run(
+        model=os.getenv("HERMES_BINDU_MODEL"),
+        tier=os.getenv("HERMES_BINDU_TIER"),
+        url=os.getenv("HERMES_BINDU_URL"),
+        name=os.getenv("HERMES_BINDU_NAME", "hermes"),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `examples/hermes_agent/` — a thin pointer example that runs [hermes-agent](https://github.com/NousResearch/hermes-agent) as a bindufied A2A microservice. The real wrapping code lives in hermes-agent's `bindu_adapter/` module (shipped as its `[bindu]` optional extra); this example just calls into it.

## Why

Bindu's existing `examples/` cover Agno, LangChain, DSPy, LangGraph, and AG2. Adding a Hermes example surfaces a different class of agent — a full tool-using coding / research agent with ~20 toolsets (web, file, terminal, browser, MCP, code execution) — on Bindu, demonstrating the framework holds up beyond single-shot LLM calls.

## What's in the PR

| File | Role |
|---|---|
| `hermes_simple_example.py` | Import-and-delegate to `bindu_adapter.run()`, friendly ImportError if the extra isn't installed |
| `README.md` | Install + fire/pull demo using the real OpenAPI shape (UUID ids, `taskId` field on `tasks/get`), safety-tier table, link to the adapter docs |
| `.env.example` | Provider key placeholders + adapter tuning knobs |

Layout and tone follow `examples/beginner/agno_simple_example.py` so discovery stays consistent.

## Verification

Tested locally with `anthropic/claude-3.5-haiku` via OpenRouter:

```
$ uv run hermes bindu serve
…
$ curl POST / message/send …  # → state: submitted, task_id: …
$ curl POST / tasks/get {taskId:…}  # → state: completed in 1 poll
```

Final artifact came back DID-signed in ~2s.

## Notes for reviewers

- The adapter itself ships from hermes-agent (companion PR in that repo — link in thread once I open it). This example requires `hermes-agent[bindu]` installed on Python 3.12+.
- No changes to Bindu core — this is pure `examples/` addition.
- README's curl demo uses `taskId` (not `id`) for `tasks/get`, matching the authoritative [openapi.yaml](https://github.com/raahulrahl/docs/blob/main/openapi.yaml). The repo-root Bindu README still shows `id` — may want a follow-up to align that.

## Test plan

- [ ] `uv pip install 'hermes-agent[bindu]'` on Python 3.12+
- [ ] `python examples/hermes_agent/hermes_simple_example.py` starts the server on :3773
- [ ] `GET /.well-known/agent.json` returns 200 with a `hermes` card
- [ ] Fire a `message/send` with a UUID taskId → `state: submitted`
- [ ] Pull with `tasks/get {"taskId": …}` → eventually `state: completed` with DID-signed artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup guide for running the Hermes agent as a microservice, including prerequisites, installation steps, and usage examples.
  * Added configuration example file with environment variable placeholders for API key setup and optional adapter settings.
  * Documented configurable safety tiers with security warnings.
  * Included JSON-RPC API workflow examples demonstrating agent interaction patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->