### PR TITLE
fix(frontend): resolve race condition causing agent response to disappear

### DIFF
--- a/frontend/src/routes/conversation/[id]/+page.svelte
+++ b/frontend/src/routes/conversation/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { pendingMessage } from "$lib/stores/pendingMessage";
 	import { isAborted } from "$lib/stores/isAborted";
-	import { onMount } from "svelte";
+	import { onMount, tick } from "svelte";
 	import { page } from "$app/state";
 	import { beforeNavigate, invalidateAll } from "$app/navigation";
 	import { base } from "$app/paths";
@@ -400,7 +400,14 @@
 			$loading = false;
 			pending = false;
 			clearReply();
-			isWritingMessage = false; // Reset guard
+			// Await a tick so Svelte flushes the content assignment
+			// (messageToWriteTo.content = update.text) into the DOM BEFORE
+			// we drop the isWritingMessage guard. Without this, the $effect
+			// that syncs `messages = data.messages` fires immediately after
+			// the guard drops, overwriting the locally-set agent response
+			// with stale server data — making the response invisible until refresh.
+			await tick();
+			isWritingMessage = false; // Reset guard after Svelte has flushed reactive updates
 			// No invalidateAll() - causes reload loop. UI updates reactively.
 		}
 	}
@@ -433,8 +440,17 @@
 			return;
 		}
 
+		// For the Bindu agent model we use direct client-side API polling
+		// (sendAgentMessage), which never persists FinalAnswer updates to the DB.
+		// isConversationStreaming() would therefore always return true for agent
+		// messages, falsely triggering the BackgroundGenerationPoller which calls
+		// invalidate(UrlDependency.Conversation) and wipes locally-written content.
+		// Skip background generation tracking entirely for the agent model.
+		const currentModelOnMount = findCurrentModel(data.models, data.oldModels, data.model);
+		const isAgentModel = currentModelOnMount?.id === 'bindu' || currentModelOnMount?.name === 'bindu';
+
 		// Only check streaming if not already loading (prevents re-trigger on reload)
-		if (!$loading && isConversationStreaming(messages)) {
+		if (!$loading && !isAgentModel && isConversationStreaming(messages)) {
 			addBackgroundGeneration({ id: page.params.id!, startedAt: Date.now() });
 			$loading = true;
 		}
@@ -465,7 +481,13 @@
 	const settings = useSettingsStore();
 	let messages = $state(data.messages);
 	$effect(() => {
-		messages = data.messages;
+		// Only sync from server data when we are NOT actively writing a message.
+		// During a write the messages array is mutated locally; overwriting it with
+		// stale server data (triggered by a background-poller invalidation) would
+		// wipe the live response before the UI can display it.
+		if (!isWritingMessage) {
+			messages = data.messages;
+		}
 	});
 
 	function isConversationStreaming(msgs: Message[]): boolean {
@@ -483,15 +505,25 @@
 	}
 
 	$effect(() => {
-		const streaming = isConversationStreaming(messages);
-		if (streaming) {
-			$loading = true;
-		} else if (!pending) {
-			$loading = false;
-		}
+		// Skip the streaming heuristic for the Bindu agent model.
+		// Agent messages never have FinalAnswer persisted in the DB
+		// (the agent uses direct client-side polling), so
+		// isConversationStreaming() would always return true and keep
+		// $loading=true long after the response has been displayed.
+		const currentModelEffect = findCurrentModel(data.models, data.oldModels, data.model);
+		const isAgentModelEffect = currentModelEffect?.id === 'bindu' || currentModelEffect?.name === 'bindu';
 
-		if (!streaming && browser) {
-			removeBackgroundGeneration(page.params.id!);
+		if (!isAgentModelEffect) {
+			const streaming = isConversationStreaming(messages);
+			if (streaming) {
+				$loading = true;
+			} else if (!pending) {
+				$loading = false;
+			}
+
+			if (!streaming && browser) {
+				removeBackgroundGeneration(page.params.id!);
+			}
 		}
 	});
 


### PR DESCRIPTION
## Summary


Agent responses were intermittently not visible in the UI after being received. The message content was set locally via `messageToWriteTo.content = update.text`, but a reactive `$effect` in `+page.svelte` sometimes overwrote it with stale server data before the DOM finished updating.

## Root Cause

In Svelte 5 runes mode, the `finally` block in `writeMessage` reset `isWritingMessage = false` synchronously after the `for await` loop completed. This immediately unblocked the `$effect`:

```svelte
$effect(() => {
    if (!isWritingMessage) {
        messages = data.messages; // <- stale server data!
    }
});
```

Because agent responses use direct client-side polling (`sendAgentMessage`) and are **never persisted to the DB**, `data.messages` remains stale. The effect fired before Svelte had a chance to commit the content mutation to the DOM, replacing `messages` with old server data and clearing the response from view.

## Fix

Added `await tick()` before resetting `isWritingMessage` in the `finally` block:

```svelte
await tick(); // flush reactive DOM updates first
isWritingMessage = false;
```

`tick()` is Svelte's built-in mechanism to wait until all pending reactive updates are committed to the DOM before continuing. This ensures the content assignment is visible to the user before the guard drops.

## Testing

- Ran the web scraping agent example (`web_scraping_agent.py`)
- - Sent a message; response appeared in ~15s **without any page refresh**
- - No regression observed for standard (non-agent) model conversations
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where locally-written messages could be overwritten by incoming server updates
  * Improved the stability of the loading indicator for specific AI agent models, preventing it from becoming stuck
  * Enhanced message synchronization to better preserve in-progress responses when users are actively writing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->