### PR TITLE
ci: add Magika AI file-type scan (warn-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,66 @@ jobs:
       - name: Verify example dependencies
         working-directory: examples/typescript-openai-agent
         run: npm install
+
+  # ──────────────────────────────────────────────────────────────
+  # Magika scan — AI file-type detection on changed files.
+  # Warn-only: reports to the job summary, never blocks CI.
+  # ──────────────────────────────────────────────────────────────
+  magika-scan:
+    name: Magika File-Type Scan
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need history to diff against the base ref
+
+      - name: Install Magika
+        run: pipx install magika
+
+      - name: Compute changed files
+        id: changed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            base="origin/$BASE_REF"
+          else
+            base="HEAD~1"
+          fi
+          git diff --name-only --diff-filter=AM "$base"...HEAD \
+            | grep -Ev '^(sdks/typescript/src/generated/|bindu/grpc/generated/|node_modules/|dist/|\.venv/)' \
+            > changed.txt || true
+          count=$(wc -l < changed.txt | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Changed files ($count):"
+          cat changed.txt
+
+      - name: Run Magika on changed files
+        if: steps.changed.outputs.count != '0'
+        run: |
+          : > to_scan.txt
+          while IFS= read -r f; do
+            [ -f "$f" ] && echo "$f" >> to_scan.txt
+          done < changed.txt
+
+          if [ ! -s to_scan.txt ]; then
+            echo "No existing files to scan (changes were all deletions)."
+            exit 0
+          fi
+
+          {
+            echo "### Magika File-Type Scan"
+            echo ""
+            echo "Scanned $(wc -l < to_scan.txt | tr -d ' ') changed file(s)."
+            echo ""
+            echo '```'
+            xargs -a to_scan.txt -d '\n' magika
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds a new `magika-scan` job to [.github/workflows/ci.yml](.github/workflows/ci.yml) that runs Google's [Magika](https://github.com/google/magika) AI file-type detector on files changed in each PR / push to `main`.
- Posts the detection table to the GitHub Actions job summary — scanners can eyeball the output for files masquerading as something they're not (e.g. a binary hiding behind a `.md` extension).
- Warn-only today: `continue-on-error: true` at the job level means it never blocks a merge. Once the false-positive rate proves low, we can flip that off and add a mismatch-detection step to make it a hard gate.

### Scope & exclusions
- Scans **changed files only**, diffed against `origin/<base_ref>` for PRs, `HEAD~1` for pushes. Cheap even on large repos.
- Skips generated / vendored paths: `sdks/typescript/src/generated/`, `bindu/grpc/generated/`, `node_modules/`, `dist/`, `.venv/`.

## Test plan
- [ ] Open this PR — confirm the `Magika File-Type Scan` job runs and renders a table in the run summary.
- [ ] Verify excluded paths (e.g. a change under `bindu/grpc/generated/`) are filtered out of `changed.txt`.
- [ ] Confirm the job's failure (simulated by a bad install) does not fail the overall workflow.
- [ ] After ~1 week of clean runs on real PRs, consider promoting to blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with automated file-type detection on changed files. The system generates quality reports and insights to support code quality assurance, configured as non-blocking to ensure uninterrupted CI success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->