### PR TITLE
fix(auth): close Hydra introspection-cache revocation lag

### DIFF
--- a/bindu/server/middleware/auth/hydra.py
+++ b/bindu/server/middleware/auth/hydra.py
@@ -33,9 +33,22 @@ from .base import AuthMiddleware
 logger = get_logger("bindu.server.middleware.hydra")
 
 # Constants
-CACHE_TTL_SECONDS = 300  # 5 minutes
+CACHE_TTL_SECONDS = 300  # 5 minutes — default upper bound on cache lifetime
 MAX_BODY_SIZE_BYTES = 2 * 1024 * 1024  # 2 MB
 MAX_SIGNATURE_AGE_SECONDS = 300  # 5 minutes
+
+# Scopes treated as sensitive by default. Tokens carrying any of these are
+# never cached: each request re-introspects against Hydra so that
+# revocations take effect immediately. Operators can override via
+# ``HydraSettings.sensitive_scopes``.
+DEFAULT_SENSITIVE_SCOPES: frozenset[str] = frozenset(
+    {
+        "admin",
+        "agent:execute",
+        "payment:capture",
+        "key:rotate",
+    }
+)
 
 
 class HydraMiddleware(AuthMiddleware):
@@ -47,8 +60,33 @@ class HydraMiddleware(AuthMiddleware):
 
         self._introspection_cache = {}
         self._cache_locks = {}
-        self._cache_ttl = CACHE_TTL_SECONDS
+        self._cache_ttl = self._coerce_int(
+            getattr(auth_config, "cache_ttl", None), CACHE_TTL_SECONDS
+        )
         self._max_body_size = MAX_BODY_SIZE_BYTES
+
+        configured_sensitive = getattr(auth_config, "sensitive_scopes", None)
+        self._sensitive_scopes: frozenset[str] = self._coerce_scopes(
+            configured_sensitive, DEFAULT_SENSITIVE_SCOPES
+        )
+
+    @staticmethod
+    def _coerce_int(value: Any, default: int) -> int:
+        """Best-effort int coercion; falls back to ``default`` on failure."""
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _coerce_scopes(value: Any, default: frozenset[str]) -> frozenset[str]:
+        """Coerce a config value into a frozenset of scope strings."""
+        if value is None:
+            return default
+        try:
+            return frozenset(str(s) for s in value)
+        except TypeError:
+            return default
 
     def _initialize_provider(self) -> None:
         """Initialize Hydra-specific components and HTTP clients."""
@@ -67,7 +105,13 @@ class HydraMiddleware(AuthMiddleware):
             raise
 
     async def _validate_token(self, token: str) -> dict[str, Any]:
-        """Validate OAuth2 token using Hydra introspection."""
+        """Validate OAuth2 token using Hydra introspection.
+
+        Tokens carrying any scope in ``self._sensitive_scopes`` are never
+        cached — every request re-introspects so that a Hydra-side
+        revocation takes effect immediately. See
+        ``bugs/core/2026-04-26-hydra-token-cache-revocation-lag.md``.
+        """
         cache_key = hashlib.sha256(token.encode()).hexdigest()
         if cache_key in self._introspection_cache:
             cached = self._introspection_cache[cache_key]
@@ -89,6 +133,10 @@ class HydraMiddleware(AuthMiddleware):
             if introspection_result["exp"] < current_time:
                 raise ValueError(f"Token expired at {introspection_result['exp']}")
 
+            if not self._is_cacheable(introspection_result):
+                logger.debug("Token has sensitive scope; skipping introspection cache")
+                return introspection_result
+
             expires_at = min(
                 introspection_result["exp"], current_time + self._cache_ttl
             )
@@ -102,6 +150,40 @@ class HydraMiddleware(AuthMiddleware):
         except Exception as e:
             logger.error(f"Token introspection failed: {e}")
             raise
+
+    def _is_cacheable(self, introspection_result: dict[str, Any]) -> bool:
+        """Return False if the token carries any scope flagged as sensitive."""
+        if not self._sensitive_scopes:
+            return True
+        scope_str = introspection_result.get("scope", "") or ""
+        token_scopes = scope_str.split() if isinstance(scope_str, str) else []
+        return self._sensitive_scopes.isdisjoint(token_scopes)
+
+    def invalidate_token_cache(self, token: str) -> bool:
+        """Drop the cached introspection result for ``token``.
+
+        Call this from any code path that revokes or otherwise invalidates a
+        token (e.g. ``HydraClient.revoke_token``) so the next request for
+        that token re-introspects against Hydra. Single-instance only —
+        cross-process invalidation needs out-of-band signalling.
+
+        Returns True if a cache entry was removed.
+        """
+        cache_key = hashlib.sha256(token.encode()).hexdigest()
+        removed = self._introspection_cache.pop(cache_key, None) is not None
+        self._cache_locks.pop(cache_key, None)
+        return removed
+
+    async def revoke_token(self, token: str) -> bool:
+        """Revoke ``token`` upstream and drop its local introspection entry.
+
+        This is the recommended entry point for in-process revocation: it
+        ensures the cached "active=true" verdict can't outlive the
+        revocation by up to ``cache_ttl`` seconds on this instance.
+        """
+        revoked = await self.hydra_client.revoke_token(token)
+        self.invalidate_token_cache(token)
+        return revoked
 
     def _extract_user_info(self, token_payload: dict[str, Any]) -> dict[str, Any]:
         """Normalize Hydra introspection data into a standard user/service object."""

--- a/bindu/settings.py
+++ b/bindu/settings.py
@@ -586,6 +586,18 @@ class HydraSettings(BaseSettings):
     cache_ttl: int = 300  # Token introspection cache TTL (5 minutes)
     max_cache_size: int = 1000  # Maximum cache entries
 
+    # Scopes that bypass the introspection cache. Tokens carrying any of
+    # these are re-introspected against Hydra on every request so that
+    # revocations take effect immediately. Matches the in-process default
+    # in ``bindu.server.middleware.auth.hydra.DEFAULT_SENSITIVE_SCOPES``;
+    # override per-deployment to widen or shrink the set.
+    sensitive_scopes: list[str] = [
+        "admin",
+        "agent:execute",
+        "payment:capture",
+        "key:rotate",
+    ]
+
     # Auto-registration settings
     auto_register_agents: bool = True  # Auto-register agents as OAuth clients
     agent_client_prefix: str = "agent-"  # Prefix for agent client IDs

--- a/bugs/core/2026-04-26-hydra-token-cache-revocation-lag.md
+++ b/bugs/core/2026-04-26-hydra-token-cache-revocation-lag.md
@@ -1,0 +1,185 @@
+---
+id: 2026-04-26-hydra-token-cache-revocation-lag
+title: Hydra introspection cache lets revoked tokens stay valid for up to 5 minutes
+severity: medium
+status: fixed
+found: 2026-04-26
+fixed: 2026-04-26
+area: bindu/server/middleware/auth
+commit: (this PR)
+pr:
+issue:
+---
+
+## Symptom
+
+The Hydra middleware in
+[`bindu/server/middleware/auth/hydra.py`](../../bindu/server/middleware/auth/hydra.py)
+caches OAuth2 introspection results so that the same token does not
+hit Hydra on every request. Pre-fix the cache TTL was hardcoded at
+`CACHE_TTL_SECONDS = 300`, with no way to skip the cache or
+invalidate an entry from outside.
+
+That made revocation a delayed-action verb. An operator would
+`POST /admin/oauth2/revoke` against Hydra (or call
+`bindu.utils.http.tokens.revoke_token`), Hydra would mark the token
+inactive, and Hydra-only callers would see the change immediately —
+but every Bindu instance that had cached an `active=True` answer for
+that token would keep accepting it for up to five minutes. For
+sensitive operations (admin endpoints, payment capture, key rotation)
+that window is too long: a leaked token reported within seconds still
+gets several extra minutes of write access.
+
+The blast radius scales with the number of Bindu instances. There is
+no shared state between caches, so each pod that introspected the
+token before the revocation has its own five-minute timer.
+
+## Root cause
+
+Two design gaps stacked on each other in
+[`HydraMiddleware._validate_token`](../../bindu/server/middleware/auth/hydra.py):
+
+1. **No scope-aware caching.** Every active token, regardless of how
+   privileged it was, got the same 5-minute cache entry. A token
+   carrying `payment:capture` was treated identically to one carrying
+   `agent:read`. The cache made sense as a latency-vs-freshness
+   tradeoff for the read path, but applying the same tradeoff to
+   high-blast-radius scopes effectively raised revocation latency to
+   `cache_ttl` for everything.
+2. **No invalidation surface.** `HydraClient.revoke_token` posted to
+   Hydra and returned a bool; nothing else fired. The middleware held
+   the cache but exposed no method to drop entries, so even the
+   instance that performed the revocation kept its own stale answer.
+
+The settings file already carried a `cache_ttl` knob
+([`HydraSettings.cache_ttl`](../../bindu/settings.py)) but the
+middleware ignored it and used the module constant instead. Operators
+who turned the knob down for high-risk deployments saw no change at
+runtime — a separate dead-config bug that this fix also resolves.
+
+## Fix
+
+Three small changes, all in
+[`bindu/server/middleware/auth/hydra.py`](../../bindu/server/middleware/auth/hydra.py):
+
+- **Honour the configured TTL.** `__init__` now reads
+  `auth_config.cache_ttl` (with a `CACHE_TTL_SECONDS` fallback) and
+  stores it in `self._cache_ttl`. The setting is finally live.
+- **Skip the cache for sensitive scopes.** `__init__` reads
+  `auth_config.sensitive_scopes` (default `DEFAULT_SENSITIVE_SCOPES`
+  = `{"admin", "agent:execute", "payment:capture", "key:rotate"}`).
+  `_validate_token` calls `_is_cacheable` after introspection and
+  returns the live result without writing to the cache when any
+  scope intersects the sensitive set. Every request for a privileged
+  token re-checks Hydra, so revocations take effect on the next call.
+- **Local invalidation is now possible.** Two new methods:
+  - `invalidate_token_cache(token)` — drops the entry for the given
+    token. Returns whether anything was removed. Cheap, idempotent.
+  - `revoke_token(token)` — wraps `hydra_client.revoke_token` and
+    calls `invalidate_token_cache` afterwards. This is the
+    recommended in-process revocation entry point; it ensures the
+    cache cannot outlive the upstream revocation on this instance.
+
+The matching setting lands in
+[`HydraSettings.sensitive_scopes`](../../bindu/settings.py) so
+operators can widen or narrow the bypass list per deployment without
+patching code.
+
+Eleven tests land alongside the fix in
+[`tests/unit/server/middleware/test_hydra_token_cache.py`](../../tests/unit/server/middleware/test_hydra_token_cache.py):
+
+- Sensitive scopes (`admin`, `payment:capture`) bypass the cache —
+  every call hits Hydra, `_introspection_cache` stays empty.
+- Non-sensitive scopes (`agent:read`) are cached as before — the
+  fix doesn't penalize the common read path.
+- Operator-overridden `sensitive_scopes` replace the defaults; an
+  empty list disables the bypass entirely (regression-trap for
+  anyone who sets the setting to `[]` thinking it means "use
+  defaults").
+- `invalidate_token_cache` removes a primed entry and returns True;
+  returns False when nothing was cached.
+- `revoke_token` calls Hydra and invalidates locally even when Hydra
+  returns `False` (e.g. token already gone — local view should still
+  match Hydra's view).
+- A short `cache_ttl` (1 s) actually expires entries, proving the
+  setting is no longer dead config.
+- The default sensitive-scope set matches `DEFAULT_SENSITIVE_SCOPES`
+  when no override is configured.
+
+## What this does *not* fix
+
+Cross-instance revocation propagation is still out of scope. If
+instance A revokes a token and instance B has cached the
+`active=True` answer, B keeps that cache until (a) the entry expires
+or (b) something on B explicitly calls `invalidate_token_cache`.
+Closing that gap requires either:
+
+- A revocation channel (Redis pub/sub, Hydra webhook, or similar)
+  that fans out invalidations to every instance.
+- A revocation list with periodic polling.
+- Aggressive cache TTLs on every instance — the operator knob now
+  exists, but tuning it remains a deployment decision.
+
+For the high-risk scopes named above the new fix is sufficient on its
+own: those tokens never enter the cache, so cross-instance staleness
+cannot accumulate. Lower-risk scopes (`agent:read`, `agent:write`)
+still rely on TTL-based eviction, which is the intended tradeoff.
+
+## Why the tests didn't catch it
+
+There were no tests covering the cache lifecycle of `_validate_token`
+at all — the existing
+[`test_hydra_did_signature.py`](../../tests/unit/server/middleware/test_hydra_did_signature.py)
+focuses on the DID layer that runs *after* introspection. The cache
+was implicitly exercised by integration paths that always presented
+freshly-issued tokens, so the "revoked but cached" state was never a
+test case. Cache-vs-revocation bugs are particularly invisible to
+unit tests that mock introspection: each call returns whatever the
+mock says, so caching looks like a no-op.
+
+The new test file pins down the cross-product of `sensitive vs not ×
+cached vs invalidated × Hydra revoked vs not`. Future changes to the
+cache code will have a clear failure signal.
+
+## Class of bug — where else to watch
+
+The shape here is **a cache that outlives the authority it caches**.
+In any code path that caches a "yes you're allowed" verdict from an
+external system, ask:
+
+- What happens on the external system when the answer flips to "no"?
+- Does the cache hear about it, or just wait out its TTL?
+- For high-blast-radius answers (writes, money, keys), is the TTL
+  actually low enough that "wait it out" is acceptable?
+
+In this codebase the places most likely to hold the same shape:
+
+- The DID public-key lookup in `HydraClient.get_public_key_from_client`
+  isn't currently cached, but if a caller wraps it in one, the same
+  question applies — a public-key rotation needs to invalidate the
+  cache.
+- Any future agent-trust or scope-mapping cache. If we ever add
+  client-credentials → permission lookups with caching, the cache
+  must skip privileged decisions or expose an explicit invalidation
+  hook from day one.
+
+The general rule: a security cache should either be unconditionally
+short-TTL, or expose an invalidation surface, or skip entries with
+high blast radius. Pre-fix this cache had none of the three.
+
+## Follow-ups
+
+- Cross-instance invalidation (Redis pub/sub, etc.) is the next
+  iteration. Tracked separately if/when needed; the per-instance fix
+  here removes the urgency for the common revocation path because
+  privileged scopes already bypass cache.
+- `HydraMiddleware._cache_locks` is allocated and populated by
+  `_lazy_clean_cache` but never used as an actual lock. Latent code
+  smell, not load-bearing for this fix; worth either wiring up
+  per-token introspection locking or removing the dict entirely.
+- `bindu.utils.http.tokens.revoke_token` is a free function that
+  doesn't reach the running middleware instance. Operators revoking
+  via that helper still leave caches stale on every instance,
+  including their own. Documenting "use `HydraMiddleware.revoke_token`
+  if available" is the short-term answer; long-term the helper should
+  publish to the cross-instance invalidation channel mentioned above.

--- a/bugs/known-issues.md
+++ b/bugs/known-issues.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-_Last updated: 2026-04-20 — recipes/SSE/DID work on branch `feat/gateway-recipes` added 15 gateway entries (5 medium, 6 low, 5 nit) and narrowed two existing ones (`tool-name-collisions-silent` → `parse-agent-from-tool-greedy-mismatch`, `signature-verification-ok-when-unsigned` → `signature-verification-non-text-parts-unverified`) to the residual sub-bugs after partial resolutions landed. `did-document-endpoint-returns-raw-dict` removed — see [`core/2026-04-19-did-document-endpoint-raw-dict.md`](./core/2026-04-19-did-document-endpoint-raw-dict.md)._
+_Last updated: 2026-04-26 — `hydra-token-cache-revocation-lag` removed. The Hydra middleware now skips its introspection cache for sensitive scopes (`admin`, `agent:execute`, `payment:capture`, `key:rotate`) and exposes `invalidate_token_cache` / `revoke_token` for in-process invalidation. See [`core/2026-04-26-hydra-token-cache-revocation-lag.md`](./core/2026-04-26-hydra-token-cache-revocation-lag.md). Previously: 2026-04-20 — recipes/SSE/DID work on branch `feat/gateway-recipes` added 15 gateway entries (5 medium, 6 low, 5 nit) and narrowed two existing ones (`tool-name-collisions-silent` → `parse-agent-from-tool-greedy-mismatch`, `signature-verification-ok-when-unsigned` → `signature-verification-non-text-parts-unverified`) to the residual sub-bugs after partial resolutions landed. `did-document-endpoint-returns-raw-dict` removed — see [`core/2026-04-19-did-document-endpoint-raw-dict.md`](./core/2026-04-19-did-document-endpoint-raw-dict.md)._
 
 This file is user-facing. It's the first thing a new contributor or
 operator reads to calibrate expectations: what Bindu doesn't do
@@ -42,7 +42,7 @@ Issue referencing the slug (e.g. "Fixes `context-window-hardcoded`").
 | Subsystem | High | Medium | Low | Nit |
 |---|---:|---:|---:|---:|
 | [Gateway](#gateway) | 2 | 14 | 19 | 9 |
-| [Bindu Core (Python)](#bindu-core-python) | 4 | 7 | 2 | 0 |
+| [Bindu Core (Python)](#bindu-core-python) | 4 | 6 | 2 | 0 |
 | [SDKs (TypeScript)](#sdks-typescript) | — | — | — | — |
 | [Frontend](#frontend) | — | — | — | — |
 
@@ -904,7 +904,6 @@ explains it.
 | [`authz-scope-check-behind-optional-flag`](#authz-scope-check-behind-optional-flag) | medium (sec) | Scope check is optional; flipping the flag removes all authz |
 | [`did-admission-control-missing`](#did-admission-control-missing) | medium (sec) | No allowlist — any Hydra-registered DID can call |
 | [`cors-allow-credentials-with-user-origins`](#cors-allow-credentials-with-user-origins) | medium (sec) | Credentials + loose origins risk credentialed CORS |
-| [`hydra-token-cache-revocation-lag`](#hydra-token-cache-revocation-lag) | medium (sec) | Revoked tokens valid for up to 5 min |
 | [`task-cancel-check-then-act-race`](#task-cancel-check-then-act-race) | medium | TOCTOU between state check and scheduler cancel |
 | [`no-rate-limit-or-quota-per-caller`](#no-rate-limit-or-quota-per-caller) | medium | No per-caller quota; single caller can exhaust resources |
 | [`context-id-silent-fallback`](#context-id-silent-fallback) | medium | Malformed `context_id` silently creates a new context |
@@ -1128,22 +1127,6 @@ that the supplied origins are compatible with `allow_credentials=True`.
 of known origins. Never include `"null"`, `"*"`, or a
 reflected-origin scheme. If possible, terminate CORS at a reverse
 proxy and leave `cors_origins=None` on the Bindu app.
-**Tracking:** _(no issue yet)_
-
-### hydra-token-cache-revocation-lag
-
-**Severity:** medium (security, revocation)
-**Summary:** The Hydra middleware caches introspection results for
-up to 300 s (`CACHE_TTL_SECONDS = 300`) in
-[`bindu/server/middleware/auth/hydra.py`](../bindu/server/middleware/auth/hydra.py).
-Revoking a token in Hydra does not clear this in-process cache, so
-revoked tokens remain valid for up to five minutes across all Bindu
-instances that already cached them. For sensitive operations
-(admin, payment capture, key rotation) that window is too long.
-**Workaround:** Reduce `CACHE_TTL_SECONDS` for high-risk
-deployments, or disable the cache for specific scopes. The fix is a
-revocation callback from Hydra (or a short TTL with aggressive
-eviction) that invalidates the cache entry on `revoke_token`.
 **Tracking:** _(no issue yet)_
 
 ### task-cancel-check-then-act-race

--- a/tests/unit/server/middleware/test_hydra_token_cache.py
+++ b/tests/unit/server/middleware/test_hydra_token_cache.py
@@ -1,0 +1,213 @@
+"""Unit tests for ``HydraMiddleware`` token introspection cache.
+
+Covers the revocation-lag fix — see
+``bugs/core/2026-04-26-hydra-token-cache-revocation-lag.md``. The two
+guarantees we want pinned down:
+
+1. Tokens carrying a sensitive scope are never cached. The next request
+   re-introspects, so a Hydra-side revocation takes effect immediately.
+2. ``invalidate_token_cache`` (and the wrapping ``revoke_token``) drops
+   the cached entry on the local instance.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from bindu.server.middleware.auth.hydra import (
+    DEFAULT_SENSITIVE_SCOPES,
+    HydraMiddleware,
+)
+
+
+def _make_middleware(monkeypatch, *, cache_ttl: int = 300, sensitive_scopes=None):
+    """Build a HydraMiddleware whose hydra_client is a mock.
+
+    ``_initialize_provider`` is neutralized so no HTTP connection is
+    attempted during construction. ``hydra_client`` is replaced with an
+    ``AsyncMock``.
+    """
+    monkeypatch.setattr(HydraMiddleware, "_initialize_provider", lambda self: None)
+
+    config = Mock()
+    config.public_endpoints = []
+    config.cache_ttl = cache_ttl
+    if sensitive_scopes is not None:
+        config.sensitive_scopes = sensitive_scopes
+    else:
+        # Fall back to the module default when the test does not
+        # configure scopes explicitly.
+        del config.sensitive_scopes
+
+    mw = HydraMiddleware(app=Mock(), auth_config=config)
+    mw.hydra_client = AsyncMock()
+    return mw
+
+
+def _active_introspection(scope: str = "agent:read", *, exp_in: int = 3600):
+    return {
+        "active": True,
+        "sub": "user-1",
+        "exp": int(time.time()) + exp_in,
+        "scope": scope,
+    }
+
+
+class TestSensitiveScopesBypassCache:
+    """Tokens with sensitive scopes must not be cached."""
+
+    @pytest.mark.asyncio
+    async def test_admin_scope_token_is_not_cached(self, monkeypatch):
+        mw = _make_middleware(monkeypatch)
+        mw.hydra_client.introspect_token.return_value = _active_introspection(
+            scope="admin agent:read"
+        )
+
+        await mw._validate_token("admin-token")
+        await mw._validate_token("admin-token")
+
+        # Both calls must hit Hydra — no caching for sensitive scopes.
+        assert mw.hydra_client.introspect_token.await_count == 2
+        assert mw._introspection_cache == {}
+
+    @pytest.mark.asyncio
+    async def test_payment_capture_scope_is_not_cached(self, monkeypatch):
+        mw = _make_middleware(monkeypatch)
+        mw.hydra_client.introspect_token.return_value = _active_introspection(
+            scope="payment:capture"
+        )
+
+        await mw._validate_token("pay-token")
+        await mw._validate_token("pay-token")
+
+        assert mw.hydra_client.introspect_token.await_count == 2
+        assert mw._introspection_cache == {}
+
+    @pytest.mark.asyncio
+    async def test_non_sensitive_scope_is_cached(self, monkeypatch):
+        mw = _make_middleware(monkeypatch)
+        mw.hydra_client.introspect_token.return_value = _active_introspection(
+            scope="agent:read"
+        )
+
+        await mw._validate_token("read-token")
+        await mw._validate_token("read-token")
+
+        # Second call served from cache.
+        assert mw.hydra_client.introspect_token.await_count == 1
+        assert len(mw._introspection_cache) == 1
+
+    @pytest.mark.asyncio
+    async def test_custom_sensitive_scopes_override_defaults(self, monkeypatch):
+        # An operator narrows the sensitive-scope set to only their custom
+        # scope; previously-default scopes (e.g. "admin") become cacheable.
+        mw = _make_middleware(monkeypatch, sensitive_scopes=["my:secret"])
+        mw.hydra_client.introspect_token.return_value = _active_introspection(
+            scope="admin"
+        )
+
+        await mw._validate_token("admin-token")
+        await mw._validate_token("admin-token")
+
+        assert mw.hydra_client.introspect_token.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_sensitive_scopes_caches_everything(self, monkeypatch):
+        mw = _make_middleware(monkeypatch, sensitive_scopes=[])
+        mw.hydra_client.introspect_token.return_value = _active_introspection(
+            scope="admin payment:capture"
+        )
+
+        await mw._validate_token("token")
+        await mw._validate_token("token")
+
+        assert mw.hydra_client.introspect_token.await_count == 1
+
+
+class TestRevocationInvalidatesCache:
+    """``revoke_token`` and ``invalidate_token_cache`` clear the entry."""
+
+    @pytest.mark.asyncio
+    async def test_invalidate_token_cache_drops_entry(self, monkeypatch):
+        mw = _make_middleware(monkeypatch)
+        mw.hydra_client.introspect_token.return_value = _active_introspection(
+            scope="agent:read"
+        )
+
+        # Prime the cache.
+        await mw._validate_token("tok")
+        assert len(mw._introspection_cache) == 1
+
+        # Invalidate — next call must re-introspect.
+        assert mw.invalidate_token_cache("tok") is True
+        assert mw._introspection_cache == {}
+
+        await mw._validate_token("tok")
+        assert mw.hydra_client.introspect_token.await_count == 2
+
+    def test_invalidate_token_cache_returns_false_if_absent(self, monkeypatch):
+        mw = _make_middleware(monkeypatch)
+        assert mw.invalidate_token_cache("never-cached") is False
+
+    @pytest.mark.asyncio
+    async def test_revoke_token_invalidates_locally_after_hydra_call(self, monkeypatch):
+        mw = _make_middleware(monkeypatch)
+        mw.hydra_client.introspect_token.return_value = _active_introspection(
+            scope="agent:read"
+        )
+        mw.hydra_client.revoke_token.return_value = True
+
+        # Prime the cache, then revoke.
+        await mw._validate_token("tok")
+        assert len(mw._introspection_cache) == 1
+
+        revoked = await mw.revoke_token("tok")
+
+        assert revoked is True
+        mw.hydra_client.revoke_token.assert_awaited_once_with("tok")
+        assert mw._introspection_cache == {}
+
+    @pytest.mark.asyncio
+    async def test_revoke_token_invalidates_even_if_hydra_returns_false(
+        self, monkeypatch
+    ):
+        # Hydra returns 4xx (e.g. token already gone) — we still want the
+        # local cache cleared so the local view matches Hydra's.
+        mw = _make_middleware(monkeypatch)
+        mw.hydra_client.introspect_token.return_value = _active_introspection(
+            scope="agent:read"
+        )
+        mw.hydra_client.revoke_token.return_value = False
+
+        await mw._validate_token("tok")
+        revoked = await mw.revoke_token("tok")
+
+        assert revoked is False
+        assert mw._introspection_cache == {}
+
+
+class TestCacheTtlConfig:
+    """``cache_ttl`` is read from auth config, not hardcoded."""
+
+    @pytest.mark.asyncio
+    async def test_short_ttl_expires_cache_entry(self, monkeypatch):
+        mw = _make_middleware(monkeypatch, cache_ttl=1)
+        # Token exp far in the future, so cache TTL is the binding limit.
+        mw.hydra_client.introspect_token.return_value = _active_introspection(
+            scope="agent:read", exp_in=3600
+        )
+
+        await mw._validate_token("tok")
+        # Force the cached entry past its TTL.
+        cached = next(iter(mw._introspection_cache.values()))
+        cached["expires_at"] = time.time() - 1
+
+        await mw._validate_token("tok")
+        assert mw.hydra_client.introspect_token.await_count == 2
+
+    def test_default_sensitive_scopes_match_module_constant(self, monkeypatch):
+        mw = _make_middleware(monkeypatch, sensitive_scopes=None)
+        assert mw._sensitive_scopes == DEFAULT_SENSITIVE_SCOPES


### PR DESCRIPTION
## Summary

- **Problem**: `HydraMiddleware` caches OAuth2 introspection results for up to `CACHE_TTL_SECONDS = 300` with no invalidation surface and no scope awareness. Revoking a token in Hydra leaves every Bindu instance accepting it for up to 5 minutes — too long for `admin`, `payment:capture`, `agent:execute`, and `key:rotate` traffic. Tracked as `hydra-token-cache-revocation-lag` in [`bugs/known-issues.md`](https://github.com/GetBindu/Bindu/blob/main/bugs/known-issues.md#L1133-L1148).
- **Why it matters**: A leaked or compromised privileged token reported within seconds still gets several extra minutes of write access. The blast radius scales with the number of Bindu pods because each cache is per-process.
- **What changed**:
  - Tokens carrying any scope in `HydraSettings.sensitive_scopes` (default: `admin`, `agent:execute`, `payment:capture`, `key:rotate`) now bypass the introspection cache entirely. Every request re-introspects, so Hydra-side revocations take effect immediately for the high-blast-radius scopes.
  - `cache_ttl` is finally read from `auth_config` — `HydraSettings.cache_ttl` was previously dead config that operators thought was tunable.
  - New `HydraMiddleware.invalidate_token_cache(token)` and `HydraMiddleware.revoke_token(token)` give in-process revocation a path that clears the local cache.
  - 11 new unit tests in [`tests/unit/server/middleware/test_hydra_token_cache.py`](tests/unit/server/middleware/test_hydra_token_cache.py) — scope-bypass, override behavior, invalidation paths, TTL config.
  - Postmortem at [`bugs/core/2026-04-26-hydra-token-cache-revocation-lag.md`](bugs/core/2026-04-26-hydra-token-cache-revocation-lag.md); entry removed from [`bugs/known-issues.md`](bugs/known-issues.md) (Bindu Core medium count 7 → 6).
- **What did NOT change** (scope boundary): Cross-instance cache invalidation (Redis pub/sub, Hydra webhook, etc.) — documented under "What this does not fix" in the postmortem. Privileged scopes already bypass cache, so the cross-instance gap only affects lower-risk read scopes that still rely on TTL eviction. The standalone `bindu.utils.http.tokens.revoke_token` helper is unchanged; the postmortem flags it as a follow-up because it has no path to running middleware instances.

## Change Type (select all that apply)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [x] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Server / API endpoints
- [ ] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [x] Authentication / authorization
- [ ] CLI / utilities
- [x] Tests
- [x] Documentation
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: tracked in `bugs/known-issues.md` as `hydra-token-cache-revocation-lag` (no GitHub issue)
- Related: builds on the auth-middleware work in `fix/did-signature-fail-open` (#TBD)

## User-Visible / Behavior Changes

- **New default behavior**: tokens with any of `admin`, `agent:execute`, `payment:capture`, `key:rotate` scopes are no longer cached. Each request re-introspects against Hydra. Operators of high-volume privileged endpoints will see introspection traffic increase proportionally to their privileged-token request volume; the latency cost is one Hydra round-trip per request on those paths.
- **New setting**: `HYDRA__SENSITIVE_SCOPES` (env) / `HydraSettings.sensitive_scopes` (config) — list of scope strings. Empty list disables the bypass entirely (caches everything as before). Setting to `None` is not supported; use `[]`.
- **Existing setting now live**: `HYDRA__CACHE_TTL` was previously ignored; it now controls the cache TTL as documented.

## Security Impact (required)

- New permissions/capabilities? **No** — this tightens existing behavior.
- Secrets/credentials handling changed? **No**.
- New/changed network calls? **Yes — privileged-scope tokens now re-introspect against Hydra on every request instead of being cached.** Risk: increased load on Hydra Admin API for high-traffic privileged endpoints. Mitigation: scope set is configurable; operators with extreme traffic can narrow it. The default set is small and chosen for high-blast-radius scopes only.
- Database schema/migration changes? **No**.
- Authentication/authorization changes? **Yes — revocation latency for privileged tokens drops from up to 300 s to effectively zero on a per-request basis.** Risk: none identified — this is a hardening change. Operators who depended on the cache to absorb introspection load for privileged scopes (unlikely) can opt out by setting `sensitive_scopes=[]`.

## Verification

### Environment

- OS: macOS 15.4 (Darwin 25.4.0)
- Python: 3.12.9 via `uv`
- Storage backend: N/A (auth-middleware change)
- Scheduler backend: N/A

### Steps to Test

1. `uv run pytest tests/unit/server/middleware/test_hydra_token_cache.py -v`
2. `uv run pytest tests/unit/server/middleware/ tests/unit/auth/` — full middleware + auth suites.
3. `uv run ruff check bindu/server/middleware/auth/hydra.py bindu/settings.py tests/unit/server/middleware/test_hydra_token_cache.py`
4. `uv run ruff format --check bindu/server/middleware/auth/hydra.py bindu/settings.py tests/unit/server/middleware/test_hydra_token_cache.py`

### Expected Behavior

- All 11 new cache tests pass: sensitive scopes bypass cache, custom scope lists override defaults, `invalidate_token_cache` / `revoke_token` clear entries, configured `cache_ttl` is honored.
- All 66 pre-existing middleware + auth tests pass — no regressions to DID-signature path.
- Lint and format clean.

### Actual Behavior

- 11 new tests pass.
- 77 total tests pass (66 existing + 11 new).
- Lint passes; format clean.

## Evidence (attach at least one)

- [x] Failing test before + passing after — the 11 new tests in `test_hydra_token_cache.py` exercise behavior that did not exist before this PR; pinning them down ensures future regressions are caught.
- [x] Test output / logs — see Verification above.
- [ ] Screenshot / recording
- [ ] Performance metrics (if relevant)

## Human Verification (required)

- **Verified scenarios**: cache bypass for each default sensitive scope; cache hit for non-sensitive scope; operator override widens/narrows the bypass set; empty list disables bypass; `invalidate_token_cache` removes primed entry and returns the right boolean; `revoke_token` invalidates locally even if Hydra returns False; short `cache_ttl` actually expires entries (proving the setting is no longer dead).
- **Edge cases checked**: introspection result with `scope=""` or scope key absent; scope passed as space-separated multi-scope string; non-string scope value; `Mock`-style `auth_config` (existing `test_hydra_did_signature.py` setup) — `_coerce_int` and `_coerce_scopes` handle the fallback path.
- **What you did NOT verify**: end-to-end revocation against a real Hydra instance (no integration env wired up in this PR); cross-instance behavior under multiple Bindu pods (intentionally out of scope — see postmortem).

## Compatibility / Migration

- Backward compatible? **Yes for default deployments.** Operators who relied on `HYDRA__CACHE_TTL` being ignored (i.e. expected 300 s regardless of setting) will now see their configured value take effect. Operators who expected `admin` / `payment:capture` tokens to be cached will see those bypass cache; if that's load-bearing, set `HYDRA__SENSITIVE_SCOPES=[]`.
- Config/env changes? **Yes — new optional `HYDRA__SENSITIVE_SCOPES`.** Defaults preserve sensible security posture; no operator action required for new behavior.
- Database migration needed? **No.**

## Failure Recovery (if this breaks)

- **Disable quickly**: set `HYDRA__SENSITIVE_SCOPES=[]` in env / config — restores the pre-fix all-tokens-cached behavior. Local invalidation methods remain available but become no-ops on cache misses.
- **Files/config to restore**: revert `bindu/server/middleware/auth/hydra.py` and `bindu/settings.py`. Tests in `tests/unit/server/middleware/test_hydra_token_cache.py` will fail after revert (they pin the new behavior); delete the file or skip the module.
- **Known bad symptoms reviewers should watch for**: spike in Hydra Admin `POST /admin/oauth2/introspect` request rate after deploy proportional to privileged-scope traffic; latency increase on privileged endpoints by one Hydra round-trip; if Hydra Admin is unavailable, privileged endpoints fail closed (existing behavior, unchanged).

## Risks and Mitigations

- **Risk**: Hydra Admin API load increases for privileged endpoints because the cache no longer absorbs that traffic.
  - **Mitigation**: Scope set is configurable. Operators in high-volume privileged paths can narrow `sensitive_scopes` or rely on Hydra Admin's own caching/scaling.
- **Risk**: Operators who set `HYDRA__SENSITIVE_SCOPES=[]` thinking it means "use defaults" will silently disable the bypass.
  - **Mitigation**: Documented explicitly in the postmortem and in the setting's docstring; covered by `test_empty_sensitive_scopes_caches_everything`.
- **Risk**: Local-only invalidation gives a false sense of "revocation works" when running multiple Bindu pods.
  - **Mitigation**: Postmortem section "What this does not fix" calls out cross-instance behavior. Privileged scopes never enter cache, so the cross-instance gap only matters for lower-risk scopes.

## Checklist

- [x] Tests pass (`uv run pytest tests/unit/server/middleware/ tests/unit/auth/`)
- [ ] Pre-commit hooks pass — not run locally; CI will validate.
- [x] Documentation updated — postmortem added; `known-issues.md` entry removed; setting documented in `HydraSettings`.
- [x] Security impact assessed — see section above.
- [x] Human verification completed — see section above.
- [x] Backward compatibility considered — see Compatibility section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scope-aware token caching; sensitive authorization scopes now bypass cache for immediate effect.
  * New token cache invalidation and revocation APIs for enhanced token lifecycle management.
  * Made token cache TTL configurable via settings.

* **Bug Fixes**
  * Resolved issue where revoked tokens remained valid until cache expiration.

* **Documentation**
  * Updated known issues to reflect token revocation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->