### PR TITLE
chore(funding): add GetBindu org to sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,8 +1,8 @@
 # GitHub Sponsors configuration for Bindu
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
 
-# GitHub Sponsors username
-github: [raahulrahl]
+# GitHub Sponsors (org + maintainers)
+github: [GetBindu, raahulrahl]
 
 # Open Collective
 open_collective: getbindu


### PR DESCRIPTION
## Summary
- Add `GetBindu` org to `.github/FUNDING.yml` so the repo Sponsor button routes through the org profile alongside the maintainer (`raahulrahl`) and existing Open Collective (`getbindu`).

## Test plan
- [ ] Merge to `main` and confirm the Sponsor button on the repo lists GetBindu, raahulrahl, and Open Collective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Sponsors configuration to support multiple sponsorship options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->