### PR TITLE
fix(i18n): correct mermaid diagram syntax in all README translations

### DIFF
--- a/i18n/README.bn.md
+++ b/i18n/README.bn.md
@@ -227,7 +227,7 @@ flowchart TD
     C --> D3
     C --> D4
 
-    D4 --> E[A2A Signed Response"]
+    D4 --> E[A2A Signed Response]
 ```
 
 `bindufy()` একটি পাতলা মোড়ক। আপনার হ্যান্ডলার বিশুদ্ধ থাকে - `(messages) -> response`। Bindu পরিচয়, প্রোটোকল, অথ, পেমেন্ট, স্টোরেজ, এবং শিডিউলিং মালিক।

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -227,7 +227,7 @@ flowchart TD
     C --> D3
     C --> D4
 
-    D4 --> E[A2A Signed Response"]
+    D4 --> E[A2A Signed Response]
 ```
 
 `bindufy()` ist ein dünner Wrapper. Ihr Handler bleibt rein - `(messages) -> response`. Bindu besitzt Identität, Protokoll, Auth, Zahlungen, Speicherung und Planung.

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -227,7 +227,7 @@ flowchart TD
     C --> D3
     C --> D4
 
-    D4 --> E[A2A Signed Response"]
+    D4 --> E[A2A Signed Response]
 ```
 
 `bindufy()` es un wrapper delgado. Tu handler permanece puro - `(messages) -> response`. Bindu posee identidad, protocolo, auth, pagos, almacenamiento y programación.

--- a/i18n/README.fr.md
+++ b/i18n/README.fr.md
@@ -247,7 +247,7 @@
       C --> D3
       C --> D4
 
-      D4 --> E[A2A Signed Response"]
+      D4 --> E[A2A Signed Response]
   ```
 
   `bindufy()` est un wrapper mince. Votre handler reste pur - `(messages) -> response`. Bindu possède l'identité, le protocole, l'auth, les paiements, le stockage et la planification.

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -227,7 +227,7 @@ flowchart TD
     C --> D3
     C --> D4
 
-    D4 --> E[A2A Signed Response"]
+    D4 --> E[A2A Signed Response]
 ```
 
 `bindufy()` एक पतला रैपर है। आपका हैंडलर शुद्ध रहता है - `(messages) -> response`। Bindu पहचान, प्रोटोकॉल, auth, भुगतान, भंडारण और शेड्यूलिंग का मालिक है।

--- a/i18n/README.nl.md
+++ b/i18n/README.nl.md
@@ -227,7 +227,7 @@ flowchart TD
     C --> D3
     C --> D4
 
-    D4 --> E[A2A Signed Response"]
+    D4 --> E[A2A Signed Response]
 ```
 
 `bindufy()` is een dunne wrapper. Uw handler blijft puur - `(messages) -> response`. Bindu bezit identiteit, protocol, auth, betaling, opslag en planning.

--- a/i18n/README.ta.md
+++ b/i18n/README.ta.md
@@ -227,7 +227,7 @@ flowchart TD
     C --> D3
     C --> D4
 
-    D4 --> E[A2A Signed Response"]
+    D4 --> E[A2A Signed Response]
 ```
 
 `bindufy()` ஒரு மெல்லிய wrapper. உங்கள் handler தூய்மையாக இருக்கும் - `(messages) -> response`. Bindu அடையாளம், நெறிமுறை, auth, கட்டணம், சேமிப்பு மற்றும் திட்டமிடலை சொந்தமாக்கிறது.

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -227,7 +227,7 @@ flowchart TD
     C --> D3
     C --> D4
 
-    D4 --> E[A2A Signed Response"]
+    D4 --> E[A2A Signed Response]
 ```
 
 `bindufy()` 是一个薄包装器。您的 handler 保持纯净 - `(messages) -> response`。Bindu 拥有身份、协议、auth、支付、存储和调度。


### PR DESCRIPTION
Fixed extra quote in mermaid node causing GitHub rendering errors. Changed `E[A2A Signed Response"]` to `E[A2A Signed Response]` in:
- Hindi (hi)
- Dutch (nl)
- Tamil (ta)
- Chinese (zh)
- Bengali (bn)
- German (de)
- Spanish (es)
- French (fr)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Mermaid diagram rendering across multiple language versions by removing extraneous characters from diagram labels, ensuring diagrams display correctly for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->