### PR TITLE
fix: Unimplemented Task Pause/Resume Functionality in Base Worker

### DIFF
--- a/bindu/server/workers/base.py
+++ b/bindu/server/workers/base.py
@@ -27,6 +27,7 @@ from typing import Any, AsyncIterator
 
 import anyio
 from opentelemetry.trace import get_tracer, use_span
+from datetime import datetime
 
 from bindu.server.scheduler import TaskOperation
 
@@ -247,7 +248,47 @@ class Worker(ABC):
         - Update task to 'suspended' state
         - Release resources while preserving context
         """
-        raise NotImplementedError("Pause operation not yet implemented")
+        task_id = self._normalize_uuid(params["task_id"])
+
+        # Load task and prepare metadata
+        task = await self.storage.load_task(task_id)
+        if not task:
+            logger.warning(f"Pause requested for unknown task {task_id}")
+            return
+
+        metadata = dict(task.get("metadata") or {})
+
+        # Allow subclasses to capture rich execution state
+        checkpoint = None
+        capture = getattr(self, "capture_execution_state", None)
+        if callable(capture):
+            try:
+                maybe = capture(task_id)
+                if hasattr(maybe, "__await__"):
+                    checkpoint = await maybe
+                else:
+                    checkpoint = maybe
+            except Exception:
+                logger.exception("capture_execution_state hook failed")
+
+        metadata["suspended"] = True
+        metadata["suspended_at"] = datetime.utcnow().isoformat() + "Z"
+        if checkpoint is not None:
+            # Checkpoint must be JSON-serializable; storage implementations
+            # may enforce further constraints.
+            metadata["suspended_checkpoint"] = checkpoint
+
+        # Allow subclass hook to release resources (best-effort)
+        on_pause = getattr(self, "on_pause", None)
+        if callable(on_pause):
+            try:
+                maybe = on_pause(task_id)
+                if hasattr(maybe, "__await__"):
+                    await maybe
+            except Exception:
+                logger.exception("on_pause hook failed")
+
+        await self.storage.update_task(task_id, state="suspended", metadata=metadata)
 
     async def _handle_resume(self, params: TaskIdParams) -> None:
         """Handle resume operation.
@@ -257,4 +298,40 @@ class Worker(ABC):
         - Update task to 'resumed' state
         - Continue from last checkpoint
         """
-        raise NotImplementedError("Resume operation not yet implemented")
+        task_id = self._normalize_uuid(params["task_id"])
+
+        task = await self.storage.load_task(task_id)
+        if not task:
+            logger.warning(f"Resume requested for unknown task {task_id}")
+            return
+
+        metadata = dict(task.get("metadata") or {})
+
+        checkpoint = metadata.get("suspended_checkpoint")
+
+        # Allow subclass to restore execution state
+        restore = getattr(self, "restore_execution_state", None)
+        if callable(restore):
+            try:
+                maybe = restore(task_id, checkpoint)
+                if hasattr(maybe, "__await__"):
+                    await maybe
+            except Exception:
+                logger.exception("restore_execution_state hook failed")
+
+        # Allow subclass hook to re-acquire resources
+        on_resume = getattr(self, "on_resume", None)
+        if callable(on_resume):
+            try:
+                maybe = on_resume(task_id)
+                if hasattr(maybe, "__await__"):
+                    await maybe
+            except Exception:
+                logger.exception("on_resume hook failed")
+
+        # Clean up suspended metadata and mark resumed
+        metadata.pop("suspended", None)
+        metadata.pop("suspended_checkpoint", None)
+        metadata["resumed_at"] = datetime.utcnow().isoformat() + "Z"
+
+        await self.storage.update_task(task_id, state="resumed", metadata=metadata)

--- a/docs/SCHEDULER.md
+++ b/docs/SCHEDULER.md
@@ -187,3 +187,18 @@ export REDIS_URL="redis://localhost:6379"
 2. Restart agent
 
 3. Tasks in Redis queue remain but won't be processed
+
+## Pause / Resume Support
+
+Bindu workers now support pausing and resuming long-running tasks. When a pause
+is requested the worker will persist a lightweight checkpoint into the task
+metadata and transition the task to the `suspended` state. This allows the
+runtime to release resources while preserving progress. A subsequent resume
+operation restores the checkpoint (via a worker-provided hook when available)
+and transitions the task to the `resumed` state to continue execution.
+
+Notes:
+- Storage implementations persist the checkpoint in task `metadata.suspended_checkpoint`.
+- Worker implementations may provide `capture_execution_state`, `restore_execution_state`,
+  `on_pause` and `on_resume` hooks for richer behavior.
+- The scheduler exposes `pause_task` and `resume_task` operations to drive these transitions.

--- a/tests/unit/test_workers.py
+++ b/tests/unit/test_workers.py
@@ -1,0 +1,76 @@
+import datetime
+import uuid
+
+import anyio
+import pytest
+
+from bindu.server.workers.base import Worker
+
+
+class SimpleStorage:
+    def __init__(self, task):
+        self.task = task
+        self.last_update = None
+
+    async def load_task(self, task_id, history_length=None):
+        if self.task["id"] == task_id:
+            return self.task
+        return None
+
+    async def update_task(self, task_id, state, new_artifacts=None, new_messages=None, metadata=None):
+        self.task["status"]["state"] = state
+        self.task["status"]["timestamp"] = datetime.datetime.utcnow().isoformat() + "Z"
+        if metadata is not None:
+            self.task["metadata"] = metadata
+        self.last_update = {"state": state, "metadata": metadata}
+        return self.task
+
+
+class TestWorker(Worker):
+    async def run_task(self, params):
+        pass
+
+    async def cancel_task(self, params):
+        pass
+
+    def build_message_history(self, history):
+        return []
+
+    def build_artifacts(self, result):
+        return []
+
+    async def capture_execution_state(self, task_id):
+        await anyio.sleep(0)
+        return {"cursor": 123}
+
+    async def restore_execution_state(self, task_id, checkpoint):
+        # record restore call
+        self._restored = checkpoint
+
+
+@pytest.mark.anyio
+async def test_pause_resume_cycle():
+    tid = uuid.uuid4()
+    ctx = uuid.uuid4()
+    task = {
+        "id": tid,
+        "context_id": ctx,
+        "kind": "task",
+        "status": {"state": "working", "timestamp": "2026-05-01T00:00:00Z"},
+        "metadata": {},
+    }
+
+    storage = SimpleStorage(task)
+    worker = TestWorker(scheduler=None, storage=storage)
+
+    # Pause
+    await worker._handle_pause({"task_id": tid})
+    assert storage.last_update["state"] == "suspended"
+    assert storage.last_update["metadata"].get("suspended") is True
+    assert "suspended_checkpoint" in storage.last_update["metadata"]
+
+    # Resume
+    await worker._handle_resume({"task_id": tid})
+    assert storage.last_update["state"] == "resumed"
+    assert storage.last_update["metadata"].get("suspended") is None
+    assert "resumed_at" in storage.last_update["metadata"]


### PR DESCRIPTION
I implemented pause/resume, added tests, and updated docs.

What I changed
- Code: Implemented `_handle_pause` and `_handle_resume` in base.py
  - Persists a checkpoint into task metadata when available via a `capture_execution_state` hook.
  - Calls optional `on_pause` / `on_resume` hooks if provided by subclasses.
  - Updates task state to `suspended` / `resumed` and records timestamps.
- Tests: Added test_workers.py covering pause → resume cycle with an in-memory storage and a test `Worker`.
- Docs: Appended a short Pause/Resume section to SCHEDULER.md.





Notes and assumptions
- The base Worker implementation is intentionally generic: it uses optional hooks `capture_execution_state(task_id)`, `restore_execution_state(task_id, checkpoint)`, `on_pause(task_id)`, and `on_resume(task_id)` that concrete workers may implement to provide rich checkpoint/restore behavior. If no hooks exist, a lightweight suspended marker and timestamps are stored so the scheduler/ops can reason about suspended tasks.
- Checkpoint values are written into `task.metadata.suspended_checkpoint` and should be JSON-serializable per your storage backend constraints.


closes #522


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pause and resume capabilities for long-running tasks with automatic state management and optional custom hooks for execution control.

* **Documentation**
  * Added scheduler documentation for pause/resume operations and task state transitions.

* **Tests**
  * Added unit tests for pause and resume task handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->