### PR TITLE
feat(x402): add SKALE network settings to X402Settings

### DIFF
--- a/bindu/settings.py
+++ b/bindu/settings.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 from pydantic import Field, computed_field, BaseModel, HttpUrl, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import AliasChoices
-from typing import Literal
+from typing import ClassVar, Literal
 
 
 class ProjectSettings(BaseSettings):
@@ -284,6 +284,10 @@ class ObservabilitySettings(BaseSettings):
 class X402Settings(BaseSettings):
     """x402 payments configuration settings."""
 
+    SKALE_SUPPORTED_NETWORKS: ClassVar[frozenset[str]] = frozenset(
+        {"eip155:2046399126", "skale-europa"}
+    )
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_prefix="X402__",
@@ -381,8 +385,7 @@ class X402Settings(BaseSettings):
     @classmethod
     def validate_skale_network(cls, value: str) -> str:
         """Validate the SKALE network identifier against supported mappings."""
-        supported_networks = {"eip155:2046399126", "skale-europa"}
-        if value not in supported_networks:
+        if value not in cls.SKALE_SUPPORTED_NETWORKS:
             raise ValueError(
                 "skale_network must be one of: eip155:2046399126, skale-europa"
             )

--- a/bindu/settings.py
+++ b/bindu/settings.py
@@ -3,7 +3,10 @@
 This module defines the configuration settings for the application using pydantic models.
 """
 
-from pydantic import Field, computed_field, BaseModel, HttpUrl
+import re
+from urllib.parse import urlparse
+
+from pydantic import Field, computed_field, BaseModel, HttpUrl, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import AliasChoices
 from typing import Literal
@@ -293,6 +296,21 @@ class X402Settings(BaseSettings):
     pay_to_env: str = "X402_PAY_TO"
     max_timeout_seconds: int = 600
 
+    # SKALE facilitator endpoint
+    skale_facilitator_url: str = "https://facilitator.dirtroad.dev"
+
+    # SKALE Europa Hub network identifier
+    skale_network: str = "eip155:2046399126"
+
+    # Bridged USDC on SKALE Europa Hub
+    skale_payment_token: str = "0x2aebcdc4f9f9149a50422fff86198cb0939ea165"
+
+    # Human-readable token name
+    skale_payment_token_name: str = "Bridged USDC (SKALE Europa)"
+
+    # Default payment amount in USDC micro-units
+    skale_default_amount: int = Field(default=10000, gt=0, le=10**18)
+
     # Extension URI
     extension_uri: str = "https://github.com/google-a2a/a2a-x402/v0.1"
 
@@ -340,7 +358,58 @@ class X402Settings(BaseSettings):
             "https://rpc.ankr.com/eth",  # Ankr public
             "https://ethereum.public.blockpi.network/v1/rpc/public",  # BlockPI
         ],
+        "eip155:2046399126": [
+            "https://mainnet.skalenodes.com/v1/elated-tan-skat",
+            "https://2046399126.rpc.thirdweb.com",
+        ],
+        "skale-europa": [
+            "https://mainnet.skalenodes.com/v1/elated-tan-skat",
+            "https://2046399126.rpc.thirdweb.com",
+        ],
     }
+
+    @field_validator("skale_facilitator_url")
+    @classmethod
+    def validate_skale_facilitator_url(cls, value: str) -> str:
+        """Validate that the SKALE facilitator URL uses HTTPS."""
+        parsed = urlparse(value)
+        if parsed.scheme != "https" or not parsed.netloc:
+            raise ValueError("skale_facilitator_url must use HTTPS")
+        return value
+
+    @field_validator("skale_network")
+    @classmethod
+    def validate_skale_network(cls, value: str) -> str:
+        """Validate the SKALE network identifier against supported mappings."""
+        supported_networks = {"eip155:2046399126", "skale-europa"}
+        if value not in supported_networks:
+            raise ValueError(
+                "skale_network must be one of: eip155:2046399126, skale-europa"
+            )
+        if value.startswith("eip155:") and not re.fullmatch(r"eip155:\d+", value):
+            raise ValueError("skale_network must match the format 'eip155:<numeric>'")
+        return value
+
+    @field_validator("skale_payment_token")
+    @classmethod
+    def validate_skale_payment_token(cls, value: str) -> str:
+        """Validate the SKALE payment token address format."""
+        if not re.fullmatch(r"0x[a-fA-F0-9]{40}", value):
+            raise ValueError(
+                "skale_payment_token must be a 0x-prefixed 40-hex-character address"
+            )
+        return value
+
+    @field_validator("skale_payment_token_name")
+    @classmethod
+    def validate_skale_payment_token_name(cls, value: str) -> str:
+        """Validate the SKALE payment token display name."""
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("skale_payment_token_name must not be empty")
+        if len(cleaned) > 100:
+            raise ValueError("skale_payment_token_name must be 100 characters or fewer")
+        return cleaned
 
 
 class AgentSettings(BaseSettings):

--- a/bindu/settings.py
+++ b/bindu/settings.py
@@ -6,7 +6,14 @@ This module defines the configuration settings for the application using pydanti
 import re
 from urllib.parse import urlparse
 
-from pydantic import Field, computed_field, BaseModel, HttpUrl, field_validator
+from pydantic import (
+    Field,
+    computed_field,
+    BaseModel,
+    HttpUrl,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import AliasChoices
 from typing import ClassVar, Literal
@@ -413,6 +420,22 @@ class X402Settings(BaseSettings):
         if len(cleaned) > 100:
             raise ValueError("skale_payment_token_name must be 100 characters or fewer")
         return cleaned
+
+    @model_validator(mode="after")
+    def validate_skale_network_mappings(self) -> "X402Settings":
+        """Ensure SKALE allowlist and RPC mappings stay in sync."""
+        missing = sorted(
+            network
+            for network in self.SKALE_SUPPORTED_NETWORKS
+            if network not in self.rpc_urls_by_network
+            or not self.rpc_urls_by_network[network]
+        )
+        if missing:
+            raise ValueError(
+                "Missing RPC URL mappings for SKALE networks: "
+                + ", ".join(missing)
+            )
+        return self
 
 
 class AgentSettings(BaseSettings):


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: Bindu’s `X402Settings` did not expose a clean, validated SKALE-specific configuration surface, and the earlier branch accumulated unrelated changes beyond the intended scope.
- **Why it matters**: SKALE/x402 setup should be configurable through settings only, with malformed values failing early at settings load instead of later during payment flow or RPC connection setup.
- **What changed**: Added SKALE-specific x402 settings in `bindu/settings.py`, added validation for those fields, and added a secondary SKALE RPC endpoint so the existing fallback logic can actually fail over.
- **What did NOT change** (scope boundary): No middleware behavior changes, no facilitator logic changes, no payment validation changes, no storage/auth changes, and no unrelated settings refactors.

## Change Type (select all that apply)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Server / API endpoints
- [x] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [ ] CLI / utilities
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #507
- Related #526

## User-Visible / Behavior Changes

Added new optional `X402Settings` fields:
- `skale_facilitator_url`
- `skale_network`
- `skale_payment_token`
- `skale_payment_token_name`
- `skale_default_amount`

Also added SKALE RPC mappings for:
- `eip155:2046399126`
- `skale-europa`

Invalid SKALE settings values now fail at settings load instead of failing later at runtime.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/credentials handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Database schema/migration changes? (`Yes/No`) No
- Authentication/authorization changes? (`Yes/No`) No
- **If any `Yes`, explain risk + mitigation**: None

## Verification

### Environment

- OS: Windows 11
- Python version: 3.12.9
- Storage backend: Not applicable
- Scheduler backend: Not applicable

### Steps to Test

1. Start from `main` and apply this branch.
2. Confirm `bindu/settings.py` loads with the new SKALE x402 fields present in `X402Settings`.
3. Confirm SKALE config validation exists and `rpc_urls_by_network` contains both SKALE keys with fallback URLs.

### Expected Behavior

- `X402Settings` exposes the new SKALE configuration fields.
- Invalid SKALE settings values fail early at settings load.
- SKALE RPC mapping includes more than one endpoint for failover.
- Existing Base/Ethereum mappings remain unaffected.

### Actual Behavior

- Verified the new SKALE settings fields, validators, and RPC fallback mappings are present in `bindu/settings.py`.
- Existing x402 settings structure remains unchanged outside the SKALE additions.

## Evidence (attach at least one)

- [ ] Failing test before + passing after
- [x] Test output / logs
- [ ] Screenshot / recording
- [ ] Performance metrics (if relevant)

## Human Verification (required)

What you personally verified (not just CI):

- **Verified scenarios**: Verified the branch contains only the intended `X402Settings` SKALE additions and validation logic in `bindu/settings.py`.
- **Edge cases checked**: Checked invalid network/token/name/amount cases are guarded by validation logic, and confirmed both SKALE RPC keys have fallback endpoints.
- **What you did NOT verify**: Did not verify live facilitator interaction or full end-to-end SKALE payment flow in this PR, since this change is settings-surface only.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Database migration needed? (`Yes/No`) No
- **If yes, exact upgrade steps**: Existing users do not need to change anything. SKALE users can optionally configure the new `X402Settings` fields.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR or stop using the new SKALE-specific settings.
- Files/config to restore: `bindu/settings.py`
- Known bad symptoms reviewers should watch for: Unexpected settings-loading errors if downstream configuration provides malformed SKALE values.

## Risks and Mitigations

List only real risks for this PR. If none, write `None`.

- **Risk**: SKALE metadata values (network identifier / RPC URLs / token address) may need future adjustment if upstream ecosystem details change.
  - **Mitigation**: Kept the PR narrowly scoped to settings so values can be updated easily without touching middleware or payment logic.

## Checklist

- [ ] Tests pass (`uv run pytest`)
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [ ] Documentation updated (if needed)
- [x] Security impact assessed
- [x] Human verification completed
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SKALE network support for payments, including facilitator endpoint, network selection, default token, display name, and default amount.
* **Bug Fixes / Validation**
  * Enforced HTTPS facilitator URL, validated network identifiers and token address/name formats and bounds, and ensured RPC mappings stay in sync with the SKALE allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->