### PR TITLE
docs(readme): make chain support concrete

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 Here's the situation. You built an agent. It works. But to actually let it loose — talk to other agents, prove who it is, take money for the work — you'd be on the hook for a lot of boring plumbing. A DID library to integrate. An OAuth flow to set up. Payment middleware. An HTTP layer that follows whatever protocol the rest of the agent world is using.
 
-Bindu is all of that plumbing, behind one function call. You wrap your handler with `bindufy()`, and a few seconds later your agent is online with its own cryptographic identity, speaking [A2A](https://github.com/a2aproject/A2A) (the protocol other agents already use), and ready to demand USDC on Base before it does any work ([x402](https://github.com/coinbase/x402)). Your handler stays as small as `(messages) -> response`. The framework inside the handler — Agno, LangChain, CrewAI, your own thing — Bindu doesn't care.
+Bindu is all of that plumbing, behind one function call. You wrap your handler with `bindufy()`, and a few seconds later your agent is online with its own cryptographic identity, speaking [A2A](https://github.com/a2aproject/A2A) (the protocol other agents already use), and ready to demand USDC on any EVM chain before it does any work ([x402](https://github.com/coinbase/x402)). Your handler stays as small as `(messages) -> response`. The framework inside the handler — Agno, LangChain, CrewAI, your own thing — Bindu doesn't care.
 
 There are SDKs for Python, TypeScript, and Kotlin, and they all share the same gRPC core. The language is a choice; the protocol and identity are the same either way. When you're ready to go deeper, the [docs](https://docs.getbindu.com) are the next stop.
 
@@ -151,7 +151,7 @@ Every row here links out to the guide that actually goes into it.
 | **A2A JSON-RPC** | The protocol other agents already speak. `message/send`, `tasks/get`, `message/stream` on port 3773. | — |
 | **DID identity** | Every response your agent sends is signed with an Ed25519 key. Callers verify with a W3C DID — there's no shared secret to leak. | [DID.md](docs/DID.md) |
 | **OAuth2 via Hydra** | Scoped tokens (`agent:read`, `agent:write`, `agent:execute`) instead of one bearer that opens every door. | [AUTHENTICATION.md](docs/AUTHENTICATION.md) |
-| **x402 payments** | Flip a flag and the agent demands USDC on Base before your handler ever sees the request. | [PAYMENT.md](docs/PAYMENT.md) |
+| **x402 payments** | Flip a flag and the agent demands USDC before your handler ever sees the request. **5 chains pre-configured** — Base, Base Sepolia, Ethereum, Ethereum Sepolia, SKALE Europa — and any other EVM chain (Polygon, Avalanche, Arbitrum, …) takes one `extra_networks` entry. | [PAYMENT.md](docs/PAYMENT.md) |
 | **Push notifications** | The agent webhooks you when a task changes state. Stop polling. | [NOTIFICATIONS.md](docs/NOTIFICATIONS.md) |
 | **Skills system** | Declare what your agent can do; callers see it on the agent card before they spend a token asking. | [SKILLS.md](docs/SKILLS.md) |
 | **Agent negotiation** | Two agents agree on price, latency, and SLA up front. No surprise bills. | [NEGOTIATION.md](docs/NEGOTIATION.md) |


### PR DESCRIPTION
Two small edits — both in places where the README previously said "USDC on Base", quietly understating what x402 v2 + extra_networks actually delivers today:

* Intro paragraph: "USDC on Base" → "USDC on any EVM chain". A reader scanning the first 200 words now knows multi-chain is the default posture, not an afterthought.
* Features table x402 row: spells out the 5 chains shipped pre-configured (Base mainnet/Sepolia, Ethereum mainnet/Sepolia, SKALE Europa) and points at extra_networks as the extension hook for Polygon / Avalanche / Arbitrum / anything else.

Numbers verified against
bindu/server/applications.py::_create_payment_requirements (friendly_to_caip2 built-ins: 4 distinct chains) and bindu/settings.py::X402Settings.extra_networks
(default: skale-europa).

## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**:
- **Why it matters**:
- **What changed**:
- **What did NOT change** (scope boundary):

## Change Type (select all that apply)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Server / API endpoints
- [ ] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [ ] CLI / utilities
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-Visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/credentials handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Database schema/migration changes? (`Yes/No`)
- Authentication/authorization changes? (`Yes/No`)
- **If any `Yes`, explain risk + mitigation**:

## Verification

### Environment

- OS:
- Python version:
- Storage backend:
- Scheduler backend:

### Steps to Test

1.
2.
3.

### Expected Behavior

-

### Actual Behavior

-

## Evidence (attach at least one)

- [ ] Failing test before + passing after
- [ ] Test output / logs
- [ ] Screenshot / recording
- [ ] Performance metrics (if relevant)

## Human Verification (required)

What you personally verified (not just CI):

- **Verified scenarios**:
- **Edge cases checked**:
- **What you did NOT verify**:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Database migration needed? (`Yes/No`)
- **If yes, exact upgrade steps**:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. If none, write `None`.

- **Risk**:
  - **Mitigation**:

## Checklist

- [ ] Tests pass (`uv run pytest`)
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [ ] Documentation updated (if needed)
- [ ] Security impact assessed
- [ ] Human verification completed
- [ ] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded x402 payments to support USDC demands across multiple EVM chains
  * Five networks now pre-configured for streamlined payment processing
  * Added guidance for configuring additional EVM networks

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/536)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->