### PR TITLE
fix(ci): trufflehog gates only on verified secrets, not unknown

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -19,4 +19,14 @@ jobs:
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26  # v3.95.2
         with:
-          extra_args: --results=verified,unknown
+          # Build-fail only on VERIFIED secrets — ones TruffleHog could
+          # authenticate against the real service. Previously we also
+          # failed on "unknown" hits, which produced ~25 false positives
+          # from example DSNs in docker-compose.hydra.yml, kratos /
+          # hydra config samples, *.env.example, and README examples,
+          # against just 2 real verified hits. That made every PR red
+          # and trained reviewers to ignore the check.
+          # An "unknown" hit is still worth investigating, but locally
+          # (`trufflehog git file://. --results=verified,unknown`), not
+          # as a CI gate.
+          extra_args: --results=verified


### PR DESCRIPTION
## Summary

Drop \`,unknown\` from the TruffleHog \`extra_args\` so the secret-scanner build gate only fails on **verified** hits (TruffleHog could authenticate the secret against the real service).

This was triggered by investigating why every Dependabot bump (#514–#518) was showing red TruffleHog despite passing every other check. Turned out two things were true:

1. TruffleHog was correctly catching **2 verified Auth0 client_secrets** still reachable in git history (commit \`e28e3417\` from Oct 2025 — files were removed at HEAD but live on in history; secrets still authenticate against Auth0 as of today). Rotation is a separate operational task and is being handled.

2. TruffleHog was also being asked to report \`unknown\` hits — strings that look like secrets but couldn't be verified. The repo has **25** of those, all in dev-config example DSNs:

| Where | Count | What |
|---|---|---|
| \`docker-compose.hydra.yml\` | 8 | Dev Postgres URLs for Hydra (\`hydra:secret@postgres-hydra\`) |
| \`bindu/server/storage/README.md\` | 4 | Doc examples |
| \`config/hydra/hydra.yml\` + \`config/kratos/kratos.yml\` | 4 | Sample configs |
| \`*.env.example\` files | 4 | Placeholder DSNs |
| Other (release notes, READMEs) | 5 | Doc examples |

Signal-to-noise: **2 / 27 = 7%**. Every PR going red on this check trained reviewers to ignore TruffleHog entirely.

## Change

One line:

\`\`\`yaml
# Before
extra_args: --results=verified,unknown
# After
extra_args: --results=verified
\`\`\`

Plus a comment block explaining why, so the next person who looks at the workflow knows what was tried and why we backed off.

## After this PR

- Verified hits still fail the build (the case we care about).
- Unverified hits still get logged as warnings (still visible in run output) but don't gate.
- 7% signal becomes 100% signal.
- Anyone who wants the wider net can run it locally: \`trufflehog git file://. --results=verified,unknown\`.

## Not in this PR (separate operational work)

- Rotating the leaked Auth0 client_secret.
- Deciding whether to rewrite git history to scrub commit \`e28e3417\` (likely "accept now that the secret is dead" for cost reasons).
- Once rotation completes, add a \`historical-auth0-leak-commit-e28e3417\` entry to \`bugs/known-issues.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD security verification to enforce stricter secret detection checks in the continuous integration pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/539)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->