### PR TITLE
feat(skills): private skills surface gated by Hydra auth + DID allowlist (closes #538)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Every row here links out to the guide that actually goes into it.
 | **x402 payments** | Flip a flag and the agent demands USDC before your handler ever sees the request. **5 chains pre-configured** — Base, Base Sepolia, Ethereum, Ethereum Sepolia, SKALE Europa — and any other EVM chain (Polygon, Avalanche, Arbitrum, …) takes one `extra_networks` entry. | [PAYMENT.md](docs/PAYMENT.md) |
 | **Push notifications** | The agent webhooks you when a task changes state. Stop polling. | [NOTIFICATIONS.md](docs/NOTIFICATIONS.md) |
 | **Skills system** | Declare what your agent can do; callers see it on the agent card before they spend a token asking. | [SKILLS.md](docs/SKILLS.md) |
+| **Private skills** | Keep your commercial skill descriptions out of the public catalog. Public crawlers see a generic "we do X" — allowlisted partner DIDs see your real menu at a second auth-gated endpoint. Useful when your skill descriptions ARE your product roadmap. | [PRIVATE_SKILLS.md](docs/PRIVATE_SKILLS.md) |
 | **Agent negotiation** | Two agents agree on price, latency, and SLA up front. No surprise bills. | [NEGOTIATION.md](docs/NEGOTIATION.md) |
 | **Storage** | Postgres for tasks and messages. Swap the backend if you've got a preference. | [STORAGE.md](docs/STORAGE.md) |
 | **Scheduler** | Redis-backed retries, timeouts, and recurring tasks. | [SCHEDULER.md](docs/SCHEDULER.md) |
@@ -226,6 +227,7 @@ If your model provider speaks the OpenAI or Anthropic API, it works — [OpenRou
 - [Calling a secured agent](docs/AUTHENTICATION.md) — the auth flow with DID signing and Hydra tokens, with a working Python client
 - [Cloud deployment](docs/runtime/quickstart.md) — `bindu deploy` walkthrough
 - [Gateway](docs/GATEWAY.md) — multi-agent orchestration
+- [Private skills](docs/PRIVATE_SKILLS.md) — hide your commercial menu from the public catalog; show it only to allowlisted partner DIDs
 - [gRPC architecture](docs/grpc/) — for anyone building a new language SDK
 - [Known issues](bugs/known-issues.md) — read this before you push to production
 - [Troubleshooting](docs/AUTHENTICATION.md#troubleshooting) — the errors you'll hit, and how to get past them

--- a/bindu/common/models.py
+++ b/bindu/common/models.py
@@ -185,6 +185,14 @@ class AgentManifest:
     enable_context_based_history: bool = False
     extra_data: dict[str, Any] = field(default_factory=dict)
 
+    # Private skills — visible only to callers whose DID is in `allowed_dids`.
+    # The public agent card endpoint (`/.well-known/agent.json`) shows only
+    # `skills`; the auth-gated private endpoint shows `skills + private_skills`.
+    # When both are empty, the private endpoint is not registered so the
+    # surface stays exactly as it was before this feature landed.
+    private_skills: list[Skill] = field(default_factory=list)
+    allowed_dids: list[str] = field(default_factory=list)
+
     # Global Webhook Configuration (for long-running tasks)
     global_webhook_url: str | None = None
     """Default webhook URL for all tasks when no task-specific webhook is registered.

--- a/bindu/penguin/bindufy.py
+++ b/bindu/penguin/bindufy.py
@@ -471,6 +471,20 @@ def _bindufy_core(
             caller_dir or Path.cwd(),
         )
 
+    # Private skills follow the same loader contract as the public ones — same
+    # file format, same on-disk layout, just kept apart so the public agent
+    # card endpoint never sees them. `allowed_dids` is the allowlist of caller
+    # DIDs that can read them through the auth-gated private endpoint.
+    private_skills_list = (
+        load_skills(
+            validated_config.get("private_skills") or [],
+            caller_dir or Path.cwd(),
+        )
+        if validated_config.get("private_skills")
+        else []
+    )
+    allowed_dids_list = list(validated_config.get("allowed_dids") or [])
+
     # Set agent metadata for DID document
     agent_url = (
         deployment_config.url if deployment_config else app_settings.network.default_url
@@ -527,6 +541,8 @@ def _bindufy_core(
         extra_metadata=validated_config["extra_metadata"],
         global_webhook_url=validated_config.get("global_webhook_url"),
         global_webhook_token=validated_config.get("global_webhook_token"),
+        private_skills=private_skills_list,
+        allowed_dids=allowed_dids_list,
     )
 
     # Log manifest creation

--- a/bindu/penguin/config_validator.py
+++ b/bindu/penguin/config_validator.py
@@ -36,6 +36,11 @@ class ConfigValidator:
         "version": __version__,
         "recreate_keys": False,
         "skills": [],
+        # Private skills surface — visible only to callers whose DID is on
+        # `allowed_dids`, served from /agent/private.json behind Hydra auth.
+        # Empty by default so existing agents keep their current behavior.
+        "private_skills": [],
+        "allowed_dids": [],
         "capabilities": {},
         "storage": {"type": "memory"},
         "scheduler": {"type": "memory"},

--- a/bindu/penguin/manifest.py
+++ b/bindu/penguin/manifest.py
@@ -229,6 +229,8 @@ def create_manifest(
     extra_metadata: dict[str, Any] | None = None,
     global_webhook_url: str | None = None,
     global_webhook_token: str | None = None,
+    private_skills: list[Skill] | None = None,
+    allowed_dids: list[str] | None = None,
 ) -> AgentManifest:
     """Create a protocol-compliant AgentManifest from any Python function.
 
@@ -300,6 +302,8 @@ def create_manifest(
     )
     _capabilities = capabilities if capabilities is not None else AgentCapabilities()
     _skills = skills if skills is not None else []
+    _private_skills = private_skills if private_skills is not None else []
+    _allowed_dids = allowed_dids if allowed_dids is not None else []
 
     # Create base manifest
     manifest = AgentManifest(
@@ -313,6 +317,8 @@ def create_manifest(
         agent_trust=_agent_trust,
         capabilities=_capabilities,
         skills=_skills,
+        private_skills=_private_skills,
+        allowed_dids=_allowed_dids,
         kind=kind,
         num_history_sessions=num_history_sessions,
         enable_system_message=enable_system_message,

--- a/bindu/server/applications.py
+++ b/bindu/server/applications.py
@@ -146,6 +146,7 @@ class BinduApplication(Starlette):
         self._storage: Storage | None = None
         self._scheduler: Scheduler | None = None
         self._agent_card_json_schema: bytes | None = None
+        self._private_agent_card_json_schema: bytes | None = None
         self._x402_ext = x402_ext
         self._payment_session_manager = None
         self._payment_requirements = None
@@ -187,6 +188,27 @@ class BinduApplication(Starlette):
             ["HEAD", "GET", "OPTIONS"],
             with_app=True,
         )
+
+        # Private agent card — same shape, includes `private_skills`, gated
+        # by Hydra middleware + the manifest's `allowed_dids` allowlist.
+        # Only register when the manifest actually declares a private surface
+        # so the route doesn't exist on agents that don't use the feature.
+        # Path is deliberately NOT under `/.well-known/*` because the auth
+        # middleware treats that glob as public.
+        # `getattr` with `or []` keeps this resilient to manifest stubs
+        # (tests use Mock(spec=...) snapshots that may pre-date the field).
+        if self.manifest and (
+            getattr(self.manifest, "private_skills", None)
+            or getattr(self.manifest, "allowed_dids", None)
+        ):
+            from .endpoints import private_agent_card_endpoint
+
+            self._add_route(
+                "/agent/private.json",
+                private_agent_card_endpoint,
+                ["HEAD", "GET", "OPTIONS"],
+                with_app=True,
+            )
 
         # Root endpoint - redirect GET to agent card, POST for A2A protocol
         from starlette.responses import RedirectResponse

--- a/bindu/server/endpoints/__init__.py
+++ b/bindu/server/endpoints/__init__.py
@@ -11,6 +11,7 @@
 
 from .a2a_protocol import agent_run_endpoint
 from .agent_card import agent_card_endpoint
+from .private_agent_card import private_agent_card_endpoint
 from .did_endpoints import did_resolve_endpoint
 from .negotiation import negotiation_endpoint
 from .payment_sessions import (
@@ -30,6 +31,7 @@ __all__ = [
     "agent_run_endpoint",
     # Agent Card
     "agent_card_endpoint",
+    "private_agent_card_endpoint",
     # DID Endpoints
     "did_resolve_endpoint",
     "did_info_endpoint",

--- a/bindu/server/endpoints/private_agent_card.py
+++ b/bindu/server/endpoints/private_agent_card.py
@@ -1,0 +1,165 @@
+"""Private agent-card endpoint, gated by Hydra auth + DID allowlist.
+
+Same shape as the public agent card, but the response includes the agent's
+``private_skills`` and is only returned to callers whose DID appears in
+``manifest.allowed_dids``.
+
+Two layers gate this endpoint:
+
+1. **Hydra middleware** (already in front of every non-public route) —
+   verifies the OAuth bearer + DID signature. If those fail, the request
+   never reaches this handler.
+2. **The allowlist check below** — even an authenticated DID is rejected
+   with 403 unless the operator added it to ``allowed_dids``.
+
+Endpoint path is deliberately NOT under ``/.well-known/`` because the
+``AuthSettings.public_endpoints`` glob ``/.well-known/*`` would skip
+auth entirely.
+"""
+
+from __future__ import annotations
+
+from time import time
+from typing import cast
+from uuid import UUID
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from bindu.common.protocol.types import AgentCard, AgentCapabilities, agent_card_ta
+from bindu.server.applications import BinduApplication
+from bindu.utils.logging import get_logger
+
+from .agent_card import (
+    A2A_PROTOCOL_VERSION,
+    DEFAULT_AGENT_DESCRIPTION,
+    DEFAULT_INPUT_MODES,
+    DEFAULT_OUTPUT_MODES,
+    _serialize_extensions,
+)
+from .utils import get_client_ip, handle_endpoint_errors
+
+logger = get_logger("bindu.server.endpoints.private_agent_card")
+
+
+def _create_private_agent_card(app: BinduApplication) -> AgentCard:
+    """Build the merged agent card (public + private skills).
+
+    Mirrors the public ``create_agent_card`` exactly except the skills
+    list combines ``manifest.skills`` and ``manifest.private_skills``.
+    Cached on the app so we only build it once.
+    """
+    if app.manifest is None:
+        raise ValueError("Application manifest is required to create agent card")
+
+    manifest = app.manifest
+
+    # Match the public agent_card.py shape exactly — `.append()` in a loop
+    # rather than a list comprehension. Same data, but the inferred type
+    # plays nicer with `AgentCard.skills: list[Skill]` invariance.
+    minimal_skills = []
+    for skill in list(manifest.skills) + list(manifest.private_skills):
+        minimal_skills.append(
+            {
+                "id": skill["id"],
+                "name": skill["name"],
+                "documentation_path": f"{app.url}/agent/skills/{skill['id']}",
+            }
+        )
+
+    agent_id = manifest.id if isinstance(manifest.id, UUID) else UUID(manifest.id)
+    capabilities = dict(manifest.capabilities)
+    _serialize_extensions(capabilities)
+
+    return AgentCard(
+        id=agent_id,
+        name=manifest.name,
+        description=manifest.description or DEFAULT_AGENT_DESCRIPTION,
+        url=app.url,
+        version=app.version,
+        protocol_version=A2A_PROTOCOL_VERSION,
+        skills=minimal_skills,
+        capabilities=cast(AgentCapabilities, capabilities),
+        kind=manifest.kind,
+        num_history_sessions=manifest.num_history_sessions,
+        extra_data=manifest.extra_data
+        or {"created": int(time()), "server_info": "bindu Agent Server"},
+        debug_mode=manifest.debug_mode,
+        debug_level=manifest.debug_level,
+        monitoring=manifest.monitoring,
+        telemetry=manifest.telemetry,
+        agent_trust=manifest.agent_trust,
+        default_input_modes=DEFAULT_INPUT_MODES,
+        default_output_modes=DEFAULT_OUTPUT_MODES,
+    )
+
+
+@handle_endpoint_errors("private agent card")
+async def private_agent_card_endpoint(
+    app: BinduApplication, request: Request
+) -> Response:
+    """Return the agent card with private_skills, for allowlisted DIDs only.
+
+    Flow:
+      1. Hydra middleware has already run — caller DID is on ``request.state.user``.
+      2. We refuse if (a) the manifest declares no private surface or
+         (b) the caller's DID isn't on the manifest's allowlist.
+      3. Otherwise return the merged card (public + private skills).
+    """
+    client_ip = get_client_ip(request)
+
+    if app.manifest is None:
+        return JSONResponse(
+            {"error": "Application manifest not initialized"}, status_code=503
+        )
+
+    # No private surface configured → this endpoint shouldn't even be
+    # reachable in practice (we don't register it), but be defensive.
+    if not app.manifest.private_skills and not app.manifest.allowed_dids:
+        return JSONResponse(
+            {"error": "Private skills not configured for this agent"},
+            status_code=404,
+        )
+
+    # Pull the caller DID that Hydra middleware stamped on the scope.
+    user_info: dict = getattr(request.state, "user", None) or {}
+    caller_did = user_info.get("client_id")
+
+    if not caller_did:
+        # Defensive: if Hydra is disabled but the route still hits, refuse.
+        logger.warning(
+            "private_catalog_access caller=<none> ip=%s result=denied reason=no_auth",
+            client_ip,
+        )
+        return JSONResponse(
+            {"error": "Authentication required for private agent card"},
+            status_code=401,
+        )
+
+    if caller_did not in app.manifest.allowed_dids:
+        logger.warning(
+            "private_catalog_access caller=%s ip=%s result=denied reason=not_in_allowlist",
+            caller_did,
+            client_ip,
+        )
+        return JSONResponse(
+            {"error": "DID not authorized for this agent's private skills"},
+            status_code=403,
+        )
+
+    # Cache the merged card on the app — same lazy pattern as the public one.
+    if app._private_agent_card_json_schema is None:
+        logger.debug("Generating private agent card schema")
+        app._private_agent_card_json_schema = agent_card_ta.dump_json(
+            _create_private_agent_card(app), by_alias=True
+        )
+
+    logger.info(
+        "private_catalog_access caller=%s ip=%s result=granted",
+        caller_did,
+        client_ip,
+    )
+    return Response(
+        content=app._private_agent_card_json_schema,
+        media_type="application/json",
+    )

--- a/docs/PRIVATE_SKILLS.md
+++ b/docs/PRIVATE_SKILLS.md
@@ -1,0 +1,279 @@
+# Keeping your skill menu private
+
+Your agent advertises its skills the moment it boots. Anyone hitting
+`/.well-known/agent.json` sees the full list — name, description,
+everything. That's perfect for an open research agent that wants to be
+found. It's a disaster for a commercial agent where the skill
+descriptions ARE the product.
+
+Picture you've built a compliance agent. Its real value isn't *"I do
+classification"* (everyone does classification). It's *"I classify HS
+codes for steel imports into the EU under CBAM transitional rules,
+using our internal cross-reference of emission factors and supplier
+tonnage."* That sentence is your roadmap. Sitting plaintext on a public
+URL, it's also your competitor's roadmap.
+
+What you want is two views of the same agent:
+
+- **A public view** — generic. "We do compliance." Routing gateways
+  can still find you ("send compliance work this way") without
+  learning what you actually do well.
+- **A partner view** — your real menu, but only to wallets you've
+  pre-approved.
+
+That's what `private_skills` + `allowed_dids` give you.
+
+## The five-second picture
+
+```
+Public web crawler                            Allowlisted partner agent
+       │                                              │
+       ▼                                              ▼
+ /.well-known/agent.json                       /agent/private.json
+       │                                              │
+       ▼                                              ▼
+  ┌────────┐                                  ┌───────────────────┐
+  │ skills │                                  │ skills            │
+  │  only  │   ← same agent, two surfaces →   │ + private_skills  │
+  └────────┘                                  └───────────────────┘
+```
+
+The split is **per-skill, in the agent's config**. Public skills go in
+`skills:`. Private skills go in `private_skills:`. The agent reads both,
+exposes only the public list on the well-known URL, and stands the
+private list up at a second URL behind a two-layer gate.
+
+## Turning it on — the smallest possible config
+
+Add three things to your existing agent config: two more skill paths,
+one allowlist of DIDs.
+
+```python
+config = {
+    "author": "you@example.com",
+    "name": "acme_compliance_agent",
+    "deployment": {"url": "http://localhost:3773"},
+
+    "skills": [
+        "skills/public-greet",
+        "skills/public-status",
+    ],
+
+    # ─── The new bit ───────────────────────────────────────────────
+    "private_skills": [
+        "skills/cbam-line-classify",
+        "skills/eudr-due-diligence",
+    ],
+    "allowed_dids": [
+        "did:bindu:partner-bank:agent:abc123",
+        "did:bindu:partner-customs-broker:agent:def456",
+    ],
+    # ───────────────────────────────────────────────────────────────
+}
+```
+
+On disk, public and private skills look identical — each one is a
+folder under `skills/` with a `skill.yaml` describing it. The split
+between public and private is purely a config-level decision. You can
+move a skill from public to private (or back) by editing two lines of
+config.
+
+When neither `private_skills` nor `allowed_dids` is set, **nothing
+changes**. The private endpoint isn't even registered. Existing agents
+are unaffected — this feature is opt-in.
+
+## How the gate actually works
+
+Two layers stand between an HTTP request and the private catalog:
+
+1. **Hydra middleware.** This is the same authentication layer Bindu
+   uses for paid endpoints today. It verifies the OAuth bearer token,
+   verifies the request was signed with the matching DID's private key,
+   and rejects unauth at 401. If the request makes it past this, we
+   know who's calling.
+
+2. **The allowlist.** Even an authenticated DID isn't automatically
+   trusted with your private catalog. The handler compares the caller's
+   DID against `manifest.allowed_dids`. If it's not in there, 403.
+
+In other words: knowing who you are isn't enough — you also have to be
+on the list.
+
+## Try every path
+
+Once the agent's running, hit it with `curl` and walk through what each
+state looks like. The runnable example at
+[`examples/private_skills_agent/`](../examples/private_skills_agent/)
+sets all this up — boot it with:
+
+```bash
+uv run python examples/private_skills_agent/acme_compliance_agent.py
+```
+
+### "I'm a random web crawler"
+
+```bash
+curl -s http://localhost:3773/.well-known/agent.json | jq '.skills[].id'
+```
+
+```
+"public-greet"
+"public-status"
+```
+
+Two skills. The CBAM and EUDR skills you configured don't appear. As
+far as the public web is concerned, this agent does some kind of
+greeting and reports status.
+
+### "I'm an outsider trying to peek behind the curtain"
+
+```bash
+curl -s -w "%{http_code}\n" http://localhost:3773/agent/private.json
+```
+
+```
+{"error":"Authentication required for private agent card"}
+401
+```
+
+The route exists (it's not 404 — that would tell you the feature isn't
+configured), but the handler refuses without auth.
+
+### "I have a valid DID, but I'm not your partner"
+
+If you point a Hydra-issued caller at the endpoint with a valid bearer
++ signed request, but the caller's DID isn't in `allowed_dids`, you
+get:
+
+```
+{"error":"DID not authorized for this agent's private skills"}
+403
+```
+
+And the server logs:
+
+```
+WARN  private_catalog_access caller=did:bindu:somebody-else:agent:xyz
+                              ip=10.0.0.7
+                              result=denied reason=not_in_allowlist
+```
+
+The signature was valid. The DID just isn't on the list. You won't be
+able to brute-force your way in — there's nothing to guess.
+
+### "I'm Bob, your allowlisted partner"
+
+When Bob's DID matches one of the entries in `allowed_dids`, the
+response is the merged catalog — same envelope as the public agent
+card, just with more skills:
+
+```json
+{
+  "id": "...",
+  "name": "acme_compliance_agent",
+  "skills": [
+    {"id": "public-greet",       "name": "greet"},
+    {"id": "public-status",      "name": "status"},
+    {"id": "cbam-line-classify", "name": "cbam-line-classify"},
+    {"id": "eudr-due-diligence", "name": "eudr-due-diligence"}
+  ]
+}
+```
+
+And the audit log records the access:
+
+```
+INFO  private_catalog_access caller=did:bindu:partner-bank:agent:abc123
+                             ip=10.0.0.5
+                             result=granted
+```
+
+Bob now knows what you can do for him. The web crawler still doesn't.
+
+## Operator workflow
+
+Most of the day-2 work with this feature is small. There's no key
+ceremony, no certificate rotation, no manifest re-encryption.
+
+**Onboarding a partner.** Get their DID. Add it to `allowed_dids` in
+your config. Restart the agent. Their next handshake succeeds.
+
+**Removing a partner.** Delete their DID from the list. Restart. Their
+next request fails at the allowlist check. No race window, no key to
+chase.
+
+**Audit trail.** Every authenticated request to `/agent/private.json`
+produces a structured log entry — `caller=`, `ip=`, `result=`,
+`reason=`. Grep for `private_catalog_access` to see exactly who's been
+looking and when. Useful for quarterly compliance reviews ("show me who
+saw our IP this period") and for spotting reconnaissance attempts.
+
+## When to use this — and when it's overkill
+
+**You probably want this if:**
+
+- Your agent is a commercial product where the skill descriptions
+  reveal your roadmap (compliance, financial signals, security
+  research, anything proprietary).
+- You're selling to partners under contracts that include "competitors
+  can't see our capabilities."
+- You want tier-based discovery — gold partners see the full menu;
+  trial users see only the public preview.
+
+**You don't need this if:**
+
+- Your agent is meant to be discovered. Open research, demo agents,
+  community tools — you WANT to be on the public catalog.
+- You're behind a corporate firewall and only your own agents can reach
+  the URL anyway.
+- You're early-stage and any discovery is good discovery.
+
+## What this doesn't protect against
+
+Be honest with yourself about the threat model. The auth-gated endpoint
+defends against:
+
+| Threat | Protected? |
+|---|---|
+| Random web crawler indexing your menu | **Yes** |
+| Unauthenticated peer hitting the private URL | **Yes** |
+| Authenticated peer whose DID isn't on your list | **Yes** |
+
+It does NOT defend against:
+
+| Threat | Why not |
+|---|---|
+| You (the operator) reading the private skills | They sit plaintext in your config file. You wrote them. |
+| An authorized partner re-publishing your catalog elsewhere | Once they've seen it, you can't take it back. Use partner agreements with NDAs to address this layer. |
+| Database backups containing skill descriptions | Same reason — the data is plaintext on disk by design. |
+| Operator-untrusted environments (multi-tenant PaaS) | If you can't trust whoever runs the server, this isn't enough. That's a different feature (encryption at rest with per-partner JWE envelopes) and a different conversation. |
+
+For self-hosted Bindu deployments, the gate is enough. For enterprise
+deployments under strict SOC2 controls, talk to us before shipping —
+the encryption-at-rest story is a Phase 2 that hasn't been built yet
+because nobody's asked for it.
+
+## Where to look in the code
+
+If you want to read the actual implementation:
+
+- The handler:
+  [`bindu/server/endpoints/private_agent_card.py`](../bindu/server/endpoints/private_agent_card.py)
+- Config plumbing (where `private_skills` and `allowed_dids` get
+  loaded): [`bindu/penguin/bindufy.py`](../bindu/penguin/bindufy.py)
+  (search for `private_skills`)
+- Manifest fields:
+  [`bindu/common/models.py`](../bindu/common/models.py) (`AgentManifest`)
+- Tests, which double as the most accurate spec:
+  [`tests/unit/server/endpoints/test_private_agent_card.py`](../tests/unit/server/endpoints/test_private_agent_card.py)
+- A runnable example:
+  [`examples/private_skills_agent/`](../examples/private_skills_agent/)
+
+## Related
+
+- [`SKILLS.md`](./SKILLS.md) — the underlying skill system that both
+  public and private skills are built on.
+- [`AUTHENTICATION.md`](./AUTHENTICATION.md) — how the Hydra-based
+  auth layer that gates this endpoint works.
+- [`bugs/known-issues.md`](../bugs/known-issues.md) — current
+  limitations across Bindu.

--- a/examples/private_skills_agent/README.md
+++ b/examples/private_skills_agent/README.md
@@ -1,0 +1,161 @@
+# Private skills — ACME Compliance example
+
+This example shows how to keep your agent's commercially-sensitive skills
+out of the public catalog while still letting authorized partner agents
+discover them.
+
+## The story
+
+You've built a compliance agent. Its real value isn't "I do classification"
+(everyone does that) — it's the specific things you do well: CBAM line
+classification under EU transitional rules, EUDR due-diligence statements
+for cocoa/coffee/timber. Those skill descriptions are essentially your
+product roadmap. Anyone scraping bindufied agents on the open web shouldn't
+be reading your menu.
+
+What you want is two views of the same agent:
+
+- **Public** — generic. "We do compliance." That's it.
+- **Partner** — your full menu, but only to wallets you've allowlisted.
+
+That's what `private_skills` + `allowed_dids` give you.
+
+## How the config splits public from private
+
+```python
+config = {
+    "skills": [
+        "skills/public-greet",     # ← in /.well-known/agent.json
+        "skills/public-status",    # ← in /.well-known/agent.json
+    ],
+    "private_skills": [
+        "skills/cbam-line-classify",      # ← only in /agent/private.json
+        "skills/eudr-due-diligence",      # ← only in /agent/private.json
+    ],
+    "allowed_dids": [
+        "did:bindu:partner-bank:agent:abc123",
+        "did:bindu:partner-customs-broker:agent:def456",
+    ],
+}
+```
+
+The folder layout follows the same pattern as Bindu's other skill loading
+— one directory per skill, each with a `skill.yaml`. The split between
+public and private is purely a config-level decision; on disk the four
+skill folders look identical.
+
+## Run it
+
+```bash
+uv run python examples/private_skills_agent/acme_compliance_agent.py
+```
+
+The agent boots on `http://localhost:3773`. No API keys required — the
+handler is an echo so you can focus on the paywall shape.
+
+## Try every path
+
+### 1. Public catalog — anyone gets this
+
+```bash
+curl -s http://localhost:3773/.well-known/agent.json | jq '.skills[].id'
+```
+
+```
+"public-greet"
+"public-status"
+```
+
+The two private skills are nowhere. A web crawler hitting this URL learns
+that ACME Compliance is "a compliance agent" and nothing more.
+
+### 2. Private catalog, no auth — refused
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3773/agent/private.json
+```
+
+```
+401
+```
+
+Body: `{"error": "Authentication required for private agent card"}`.
+
+### 3. Private catalog, authenticated but not allowlisted — refused
+
+If you point a Hydra-issued caller at the endpoint with a valid bearer +
+DID signature but the caller's DID isn't in `allowed_dids`, you get **403**:
+
+```
+{"error": "DID not authorized for this agent's private skills"}
+```
+
+### 4. Private catalog, allowlisted partner — full menu
+
+When the caller's DID matches one of the allowlist entries, the response
+is the merged catalog:
+
+```json
+{
+  "skills": [
+    {"id": "public-greet",       "name": "greet",                ...},
+    {"id": "public-status",      "name": "status",               ...},
+    {"id": "cbam-line-classify", "name": "cbam-line-classify",   ...},
+    {"id": "eudr-due-diligence", "name": "eudr-due-diligence",   ...}
+  ]
+}
+```
+
+Same envelope as the public agent card; just longer.
+
+## Server-side log line
+
+Every authenticated request to `/agent/private.json` produces a structured
+log entry — so you have an audit trail for compliance reviews:
+
+```
+INFO  private_catalog_access caller=did:bindu:partner-bank:agent:abc123 ip=10.0.0.5 result=granted
+WARN  private_catalog_access caller=did:bindu:somebody-else:agent:xyz   ip=10.0.0.7 result=denied reason=not_in_allowlist
+```
+
+Grep for `private_catalog_access` in your agent logs to see who's been
+looking.
+
+## Adding or removing a partner
+
+Add a partner: append their DID to `allowed_dids` in your config, restart
+the agent. They can hit the endpoint immediately.
+
+Remove a partner: delete the entry, restart. Their next handshake fails
+at the allowlist check. There's no key rotation to coordinate — the
+allowlist is the whole gate.
+
+## What this does NOT protect against
+
+Be honest with yourself about the threat model. The auth-gated endpoint
+defends against:
+
+- Random web crawlers indexing your menu — yes ✓
+- Unauthenticated peers discovering the catalog — yes ✓
+- Authenticated peers without the right DID — yes ✓
+
+It does NOT defend against:
+
+- The operator (you) reading the private skills — you have the config file
+- An authorized partner re-publishing the catalog — handle this with
+  partner agreements, not crypto
+- Database backups containing skill descriptions — the skills sit
+  plaintext in your config, so anything that reads your filesystem reads
+  the skills
+
+If you need "the server itself can't read these," that's a different
+feature (JWE encryption at rest) and a different conversation. For most
+deployments — including the one in this example — the gate is enough.
+
+## Where to look in the code
+
+- Handler: [`bindu/server/endpoints/private_agent_card.py`](../../bindu/server/endpoints/private_agent_card.py)
+- Config plumbing: [`bindu/penguin/config_validator.py`](../../bindu/penguin/config_validator.py)
+  (search for `private_skills`)
+- Tests, which double as the most accurate spec:
+  [`tests/unit/server/endpoints/test_private_agent_card.py`](../../tests/unit/server/endpoints/test_private_agent_card.py)

--- a/examples/private_skills_agent/acme_compliance_agent.py
+++ b/examples/private_skills_agent/acme_compliance_agent.py
@@ -1,0 +1,80 @@
+"""ACME Compliance — example of an agent with private skills.
+
+This example exists to show the shape of the `private_skills` +
+`allowed_dids` config. It does NOT call an LLM; the handler is a
+deliberately boring echo so you can run it without any API key.
+
+What the example demonstrates:
+
+  GET /.well-known/agent.json    → "greet" and "status" only
+                                   (the public catalog)
+  GET /agent/private.json        → 401 without auth
+                                   → 403 with auth but non-allowlisted DID
+                                   → 200 with merged catalog when DID is
+                                     on the allowlist (greet + status +
+                                     cbam-line-classify + eudr-due-diligence)
+
+Run it:
+
+    $ uv run python examples/private_skills_agent/acme_compliance_agent.py
+
+Then hit it with curl:
+
+    $ curl -s http://localhost:3773/.well-known/agent.json | jq .skills
+
+    $ curl -s -o /dev/null -w "%{http_code}\\n" http://localhost:3773/agent/private.json
+    401
+
+(For the 200 case you need a Hydra-issued bearer + DID signature; see
+docs/AUTHENTICATION.md. The unit tests in
+tests/unit/server/endpoints/test_private_agent_card.py cover the
+authenticated branch with a stub middleware.)
+"""
+
+from bindu.penguin.bindufy import bindufy
+
+
+def handler(messages):
+    """Echo the last message back. The point of the example is the
+    PAYWALL shape on /agent/private.json, not what the handler does."""
+    last = messages[-1].get("content", "") if messages else ""
+    return f"acme_compliance_agent: received '{last}'"
+
+
+config = {
+    "author": "acme.compliance@example.com",
+    "name": "acme_compliance_agent",
+    "description": (
+        "ACME Compliance — demo agent for the private-skills surface. "
+        "Public catalog shows generic 'greet' + 'status'; the real product "
+        "(CBAM / EUDR) lives behind /agent/private.json."
+    ),
+    "deployment": {
+        "url": "http://localhost:3773",
+        "expose": False,
+    },
+    "skills": [
+        "skills/public-greet",
+        "skills/public-status",
+    ],
+    # ─── The new bit ──────────────────────────────────────────────
+    "private_skills": [
+        "skills/cbam-line-classify",
+        "skills/eudr-due-diligence",
+    ],
+    "allowed_dids": [
+        # Replace with the actual DIDs of your partner agents.
+        # Each entry here is a partner that gets to see the full
+        # /agent/private.json response.
+        "did:bindu:partner-bank:agent:abc123",
+        "did:bindu:partner-customs-broker:agent:def456",
+    ],
+    # ──────────────────────────────────────────────────────────────
+    "storage": {"type": "memory"},
+    "scheduler": {"type": "memory"},
+    "debug_mode": False,
+}
+
+
+if __name__ == "__main__":
+    bindufy(config, handler)

--- a/examples/private_skills_agent/skills/cbam-line-classify/skill.yaml
+++ b/examples/private_skills_agent/skills/cbam-line-classify/skill.yaml
@@ -1,0 +1,29 @@
+id: cbam-line-classify
+name: cbam-line-classify
+version: 1.0.0
+author: acme.compliance@example.com
+description: |
+  PROPRIETARY — visible only to allowlisted partner DIDs.
+
+  Classify HS codes for steel imports into the EU under CBAM transitional
+  rules. Produces line-item embedded-emission estimates from supplier mill
+  certificates plus our internal cross-reference of EU-published emission
+  factors and supplier-historical tonnage data.
+
+  This skill represents the agent's core commercial value. Exposing it in
+  the public catalog (/.well-known/agent.json) would let competitors
+  reverse-engineer our product surface. Hence it lives in `private_skills`
+  and only flows through /agent/private.json to DIDs on the allowlist.
+tags:
+  - private
+  - compliance
+  - cbam
+  - eu
+  - steel
+input_modes:
+  - application/json
+output_modes:
+  - application/json
+examples:
+  - "Classify this batch of steel imports under CBAM"
+  - "What's the embedded carbon estimate for these line items?"

--- a/examples/private_skills_agent/skills/eudr-due-diligence/skill.yaml
+++ b/examples/private_skills_agent/skills/eudr-due-diligence/skill.yaml
@@ -1,0 +1,28 @@
+id: eudr-due-diligence
+name: eudr-due-diligence
+version: 1.0.0
+author: acme.compliance@example.com
+description: |
+  PROPRIETARY — visible only to allowlisted partner DIDs.
+
+  Generate due-diligence statements for cocoa / coffee / timber imports
+  under EU regulation 2023/1115 (EUDR). Geolocates plot polygons from
+  supplier-provided KML/GeoJSON, cross-checks against our deforestation-
+  risk index, and produces the JSON envelope the Information System
+  expects.
+
+  Like the CBAM skill, this is core commercial IP. Lives in private_skills
+  so the public agent card never advertises the capability.
+tags:
+  - private
+  - compliance
+  - eudr
+  - eu
+  - due-diligence
+input_modes:
+  - application/json
+output_modes:
+  - application/json
+examples:
+  - "Generate EUDR statement for this batch of coffee"
+  - "Check these supplier plots for deforestation risk"

--- a/examples/private_skills_agent/skills/public-greet/skill.yaml
+++ b/examples/private_skills_agent/skills/public-greet/skill.yaml
@@ -1,0 +1,17 @@
+id: public-greet
+name: greet
+version: 1.0.0
+author: acme.compliance@example.com
+description: |
+  Public-facing greeting skill. Available to anyone who hits the agent.
+  Used to confirm the agent is alive and reachable.
+tags:
+  - public
+  - introduction
+input_modes:
+  - application/json
+output_modes:
+  - text/plain
+examples:
+  - "hi"
+  - "are you there?"

--- a/examples/private_skills_agent/skills/public-status/skill.yaml
+++ b/examples/private_skills_agent/skills/public-status/skill.yaml
@@ -1,0 +1,18 @@
+id: public-status
+name: status
+version: 1.0.0
+author: acme.compliance@example.com
+description: |
+  Public status / health endpoint. Returns generic information about the
+  service tier. Doesn't reveal what the agent actually does — that's in
+  the private catalog behind /agent/private.json.
+tags:
+  - public
+  - status
+input_modes:
+  - application/json
+output_modes:
+  - application/json
+examples:
+  - "are you online?"
+  - "what tier are you?"

--- a/tests/unit/server/endpoints/test_private_agent_card.py
+++ b/tests/unit/server/endpoints/test_private_agent_card.py
@@ -1,0 +1,249 @@
+"""Tests for the private agent-card endpoint (allowlist gate)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from bindu.server.endpoints.private_agent_card import private_agent_card_endpoint
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — a minimal app + a fake auth middleware that stamps caller DID
+# onto request.state (which is exactly what the real Hydra middleware does).
+# ---------------------------------------------------------------------------
+
+
+class _StubAuthMiddleware(BaseHTTPMiddleware):
+    """Stand-in for the Hydra middleware.
+
+    Real Hydra middleware verifies bearer + DID signature and stamps
+    ``scope["state"]["user"] = {"client_id": "did:..."}``. Here we read a
+    test-only ``X-Test-DID`` header to control what the handler sees, so
+    each test case can drive caller identity without doing real OAuth.
+    """
+
+    async def dispatch(self, request, call_next):
+        test_did = request.headers.get("X-Test-DID")
+        if test_did:
+            request.scope.setdefault("state", {})
+            request.scope["state"]["user"] = {"client_id": test_did}
+        return await call_next(request)
+
+
+def _make_manifest(
+    *,
+    skills: list[dict] | None = None,
+    private_skills: list[dict] | None = None,
+    allowed_dids: list[str] | None = None,
+) -> MagicMock:
+    """Build a manifest stub that quacks like the real AgentManifest enough
+    for the endpoint to produce a card."""
+    m = MagicMock()
+    m.id = uuid4()
+    m.name = "test_agent"
+    m.description = "test"
+    # Use `is None` instead of `or` so callers can pass [] to mean "really empty"
+    # (vs "use defaults"). The 404-on-no-private-surface test needs this.
+    m.skills = (
+        [{"id": "public-1", "name": "Public Skill"}] if skills is None else skills
+    )
+    m.private_skills = (
+        [
+            {"id": "private-1", "name": "Private Skill A"},
+            {"id": "private-2", "name": "Private Skill B"},
+        ]
+        if private_skills is None
+        else private_skills
+    )
+    m.allowed_dids = (
+        ["did:bindu:alice:agent:1"] if allowed_dids is None else allowed_dids
+    )
+    m.kind = "agent"
+    m.num_history_sessions = 0
+    m.extra_data = {}
+    m.debug_mode = False
+    m.debug_level = 1
+    m.monitoring = False
+    m.telemetry = True
+    m.agent_trust = None
+    m.capabilities = {}
+    return m
+
+
+def _build_app(manifest, agent_url: str = "http://test"):
+    """Spin up a tiny Starlette app with the stub auth + private endpoint."""
+    app_mock = MagicMock()
+    app_mock.manifest = manifest
+    app_mock.url = agent_url
+    app_mock.version = "1.0.0"
+    app_mock._private_agent_card_json_schema = None
+
+    async def handler(request: Request):
+        return await private_agent_card_endpoint(app_mock, request)
+
+    return Starlette(
+        routes=[Route("/agent/private.json", handler, methods=["GET"])],
+        middleware=[
+            __import__("starlette.middleware", fromlist=["Middleware"]).Middleware(
+                _StubAuthMiddleware
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistGate:
+    """The middleware authenticates; the manifest's `allowed_dids` decides
+    whether that authenticated caller actually gets the catalog."""
+
+    def test_caller_in_allowlist_gets_merged_card(self):
+        manifest = _make_manifest(
+            allowed_dids=["did:bindu:alice:agent:1", "did:bindu:bob:agent:2"]
+        )
+        client = TestClient(_build_app(manifest))
+
+        r = client.get(
+            "/agent/private.json",
+            headers={"X-Test-DID": "did:bindu:alice:agent:1"},
+        )
+
+        assert r.status_code == 200
+        body = r.json()
+        skill_ids = {s["id"] for s in body["skills"]}
+        # Both public and private skills come through
+        assert "public-1" in skill_ids
+        assert "private-1" in skill_ids
+        assert "private-2" in skill_ids
+
+    def test_caller_not_in_allowlist_gets_403(self):
+        manifest = _make_manifest(allowed_dids=["did:bindu:alice:agent:1"])
+        client = TestClient(_build_app(manifest))
+
+        r = client.get(
+            "/agent/private.json",
+            headers={"X-Test-DID": "did:bindu:eve:attacker:1"},
+        )
+
+        assert r.status_code == 403
+        assert "not authorized" in r.json()["error"].lower()
+
+    def test_no_caller_did_at_all_gets_401(self):
+        # If the auth middleware didn't run (or didn't stamp a DID), we
+        # refuse with 401. In production the Hydra middleware would
+        # already have returned 401 — this is the defensive backstop.
+        manifest = _make_manifest()
+        client = TestClient(_build_app(manifest))
+
+        r = client.get("/agent/private.json")  # no X-Test-DID header
+
+        assert r.status_code == 401
+        assert "authentication" in r.json()["error"].lower()
+
+
+class TestMergedCardShape:
+    """When the gate opens, the response should look like the public agent
+    card with extra skills — same envelope, longer skills list."""
+
+    def test_merged_card_includes_all_skills(self):
+        manifest = _make_manifest(
+            skills=[
+                {"id": "p1", "name": "Public 1"},
+                {"id": "p2", "name": "Public 2"},
+            ],
+            private_skills=[
+                {"id": "x1", "name": "Private 1"},
+            ],
+            allowed_dids=["did:bindu:alice:agent:1"],
+        )
+        client = TestClient(_build_app(manifest))
+
+        r = client.get(
+            "/agent/private.json",
+            headers={"X-Test-DID": "did:bindu:alice:agent:1"},
+        )
+
+        assert r.status_code == 200
+        skills = r.json()["skills"]
+        assert len(skills) == 3
+        # Order: public first, private appended
+        assert [s["id"] for s in skills] == ["p1", "p2", "x1"]
+
+    def test_documentation_path_uses_agent_url(self):
+        manifest = _make_manifest(allowed_dids=["did:bindu:alice:agent:1"])
+        client = TestClient(_build_app(manifest, agent_url="https://acme.com"))
+
+        r = client.get(
+            "/agent/private.json",
+            headers={"X-Test-DID": "did:bindu:alice:agent:1"},
+        )
+
+        # AgentCard serializes with camelCase aliases on the wire — the
+        # field is `documentation_path` on the model but `documentationPath`
+        # in the JSON envelope.
+        for skill in r.json()["skills"]:
+            assert skill["documentationPath"].startswith(
+                "https://acme.com/agent/skills/"
+            )
+
+
+class TestEndpointSafety:
+    """Edge cases that shouldn't crash the handler."""
+
+    def test_manifest_with_no_private_surface_returns_404(self):
+        # Defensive: we don't normally register the route in this case,
+        # but if something else routed here, refuse rather than leak.
+        manifest = _make_manifest(private_skills=[], allowed_dids=[])
+        client = TestClient(_build_app(manifest))
+
+        r = client.get(
+            "/agent/private.json",
+            headers={"X-Test-DID": "did:bindu:alice:agent:1"},
+        )
+
+        assert r.status_code == 404
+
+
+class TestManifestFieldPlumbing:
+    """The bindufy config → AgentManifest path must carry the new fields
+    through. This is the boring integration cousin of the wire-level tests
+    above."""
+
+    def test_manifest_default_has_empty_private_surface(self):
+        # If the operator doesn't set them, both default to empty list
+        # (not None), so consumers can iterate without None-checks.
+        from bindu.common.models import AgentManifest
+        import dataclasses
+
+        fields_by_name = {f.name: f for f in dataclasses.fields(AgentManifest)}
+        ps = fields_by_name["private_skills"]
+        ad = fields_by_name["allowed_dids"]
+        # default_factory presence is what matters
+        assert ps.default_factory is list
+        assert ad.default_factory is list
+
+    def test_config_validator_accepts_the_new_keys(self):
+        from bindu.penguin.config_validator import ConfigValidator
+
+        out = ConfigValidator.validate_and_process(
+            {
+                "author": "you@example.com",
+                "name": "test",
+                "deployment": {"url": "http://localhost:3773"},
+                "private_skills": ["skills/example"],
+                "allowed_dids": ["did:bindu:bob:agent:1"],
+            }
+        )
+
+        assert out["private_skills"] == ["skills/example"]
+        assert out["allowed_dids"] == ["did:bindu:bob:agent:1"]


### PR DESCRIPTION
Closes #538.

## Summary

Implements the simpler of the two designs we sketched in the issue discussion — an **auth-gated second endpoint** instead of JWE encryption at rest. Same threat coverage for everything except *"the operator doesn't trust the server itself,"* which isn't a real concern for self-hosted Bindu deployments today. If that threat model becomes real later (enterprise SOC2, multi-tenant PaaS), the JWE Phase 2 is a separate follow-up.

## How it works

Agent config gets two new optional keys:

\`\`\`python
"private_skills": [...],   # same loader as `skills`
"allowed_dids":   [...],   # which DIDs may see them
\`\`\`

Endpoints — no behavior change for existing agents:

| Path | What it shows | Who can hit it |
|---|---|---|
| \`/.well-known/agent.json\` | \`skills\` only (public) | Anyone |
| \`/agent/private.json\` *(new)* | \`skills + private_skills\` | Allowlisted DIDs only |

The private route is **deliberately not under \`/.well-known/\`** — \`AuthSettings.public_endpoints\` has a \`/.well-known/*\` glob that skips auth entirely, which would defeat the whole point.

## Two-layer gate

1. **Hydra middleware** (already in front of every non-public route) — verifies bearer + DID signature; rejects unauth at 401.
2. **Allowlist check in the handler** — even an authenticated DID gets 403 unless the operator added it to \`manifest.allowed_dids\`.

Opt-in only: when neither \`private_skills\` nor \`allowed_dids\` is set, the route isn't registered at all. Existing \`.well-known/agent.json\` payload is byte-for-byte identical.

## Files

| File | Change |
|---|---|
| \`bindu/common/models.py\` | \`AgentManifest\` gains \`private_skills\` + \`allowed_dids\` (default empty list; placed with other default-valued fields so dataclass ordering survives) |
| \`bindu/penguin/manifest.py\` | \`create_manifest\` accepts both, forwards |
| \`bindu/penguin/bindufy.py\` | Loads \`config["private_skills"]\` via the same \`load_skills\` helper |
| \`bindu/penguin/config_validator.py\` | Adds both to DEFAULTS |
| \`bindu/server/endpoints/private_agent_card.py\` *(new, 163 lines)* | Handler that builds the merged card and returns it, with the allowlist + auth checks |
| \`bindu/server/endpoints/__init__.py\` | Re-exports |
| \`bindu/server/applications.py\` | Conditionally registers route; \`getattr\` for Mock(spec=...) test stubs that pre-date the field |
| \`tests/unit/server/endpoints/test_private_agent_card.py\` *(new, 8 tests)\` | End-to-end via stub auth middleware that mirrors Hydra's \`request.state.user\` stamping |

## What did NOT change

- No new dependency (no JWE library, no extra crypto)
- No DID document change — works with the existing Ed25519 key
- Public agent card endpoint is unchanged

## Verified

- **988 unit + integration tests pass** (980 baseline + 8 new)
- **ty: 0 diagnostics**, ruff clean, pre-commit clean (no \`--no-verify\`)
- End-to-end smoke: agent with \`private_skills\` configured, public \`.well-known/agent.json\` shows only the public skill, private endpoint returns 401 without auth

## Follow-ups that ride on this gate (each ~30-60 min, not in this PR)

- Structured audit log of private-catalog accesses
- Hot-reload of \`allowed_dids\` via an admin endpoint
- Per-skill allowlists (Bob sees A+B, Carol sees A+B+C)
- Time-bound entries (\`expires_at\` on each allowlist entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Private skills support with allowlist-based access and a gated private agent-card endpoint (/agent/private.json)

* **Tests**
  * Comprehensive unit tests for auth gating, 401/403/404 cases, merged public+private card shape, and manifest defaults

* **Documentation**
  * README and new PRIVATE_SKILLS guide with examples, curl checks, operator workflows, logs, and threat model

* **Examples**
  * Runnable example agent and several example skill manifests (public and private)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/540)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->