### PR TITLE
fix(bindu-communication): silence detect-secrets false positives breaking CI

### DIFF
--- a/bindu-communication/server/db.ts
+++ b/bindu-communication/server/db.ts
@@ -459,12 +459,14 @@ export type SettingsField =
 	| "pipedreamClientSecret"
 	| "pipedreamEnvironment";
 
+// Column names, not secret values — detect-secrets matches the
+// "api_key" / "secret" substrings. Marked as false-positives inline.
 const SETTINGS_COLUMNS: Record<SettingsField, string> = {
-	openrouterApiKey: "openrouter_api_key",
-	openrouterModel: "openrouter_model",
+	openrouterApiKey: "openrouter_api_key", // pragma: allowlist secret
+	openrouterModel: "openrouter_model", // pragma: allowlist secret
 	pipedreamProjectId: "pipedream_project_id",
 	pipedreamClientId: "pipedream_client_id",
-	pipedreamClientSecret: "pipedream_client_secret",
+	pipedreamClientSecret: "pipedream_client_secret", // pragma: allowlist secret
 	pipedreamEnvironment: "pipedream_environment",
 };
 
@@ -515,8 +517,8 @@ export function readSettings(): SettingsRow {
 }
 
 /** Upsert any subset of fields. Missing fields are left untouched —
- * the SQL uses COALESCE so passing { openrouterApiKey: "new" } only
- * overwrites that one column. */
+ * the SQL uses COALESCE so passing a single field updates only that
+ * one column. */
 export function writeSettings(partial: Partial<Record<SettingsField, string>>): SettingsRow {
 	const now = new Date().toISOString();
 	upsertSettings.run({

--- a/bindu-communication/server/index.ts
+++ b/bindu-communication/server/index.ts
@@ -581,7 +581,7 @@ function loadPrivateKey(): crypto.KeyObject | null {
 }
 
 const BASE58_ALPHABET =
-	"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+	"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"; // pragma: allowlist secret
 
 function base58Encode(bytes: Buffer): string {
 	let n = 0n;


### PR DESCRIPTION
## Summary
Both **CI on main** and **Release on 2026.20.7** failed at the `Run pre-commit checks` step. Four false positives, all in code that landed via #544:

| Line | Match | Reality |
| --- | --- | --- |
| `server/index.ts:584` | Base64 high entropy | Bitcoin base58 alphabet literal |
| `server/db.ts:463` | Secret Keyword | SQL column name `"openrouter_api_key"` |
| `server/db.ts:467` | Secret Keyword | SQL column name `"openrouter_model"` |
| `server/db.ts:518` | Secret Keyword | JSDoc example string that looked like an assignment |

Added inline `// pragma: allowlist secret` comments (the existing pattern, see `docs/postman-did-signing.js`) and reworded the JSDoc example. Verified locally with `pre-commit run detect-secrets --all-files`.

## Test plan
- [x] `pre-commit run --files server/{index,db}.ts` — Passed
- [x] `pre-commit run detect-secrets --all-files` — Passed
- [ ] CI on this PR — should now pass the pre-commit step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code comments and formatting for improved maintainability. No functional changes to user-facing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->