### PR TITLE
test: align lifecycle + notifications tests with code on main

### DIFF
--- a/tests/unit/server/workers/test_manifest_worker.py
+++ b/tests/unit/server/workers/test_manifest_worker.py
@@ -99,7 +99,12 @@ class TestManifestWorker:
 
         await worker._notify_lifecycle(task_id, context_id, "completed", True)
 
-        mock_callback.assert_called_once_with(task_id, context_id, "completed", True)
+        # Notifier is called with the 5-arg shape (task_id, context_id, state,
+        # final, status_message) introduced in 270f4b94. status_message defaults
+        # to None when _notify_lifecycle is called without one.
+        mock_callback.assert_called_once_with(
+            task_id, context_id, "completed", True, None
+        )
 
     @pytest.mark.asyncio
     async def test_notify_lifecycle_without_callback(self):

--- a/tests/unit/utils/test_notifications.py
+++ b/tests/unit/utils/test_notifications.py
@@ -65,46 +65,10 @@ class TestNotificationService:
         with pytest.raises(ValueError, match="must include a network location"):
             service.validate_config(config)
 
-    def test_validate_config_blocks_loopback(self):
-        """Test validation blocks loopback addresses."""
-        service = NotificationService()
-        config = cast(
-            PushNotificationConfig, {"id": uuid4(), "url": "http://localhost/webhook"}
-        )
-
-        with patch(
-            "socket.getaddrinfo", return_value=[("", "", "", "", ("127.0.0.1", 0))]
-        ):
-            with pytest.raises(ValueError, match="blocked address range"):
-                service.validate_config(config)
-
-    def test_validate_config_blocks_private_network(self):
-        """Test validation blocks private network addresses."""
-        service = NotificationService()
-        config = cast(
-            PushNotificationConfig, {"id": uuid4(), "url": "http://192.168.1.1/webhook"}
-        )
-
-        with patch(
-            "socket.getaddrinfo", return_value=[("", "", "", "", ("192.168.1.1", 0))]
-        ):
-            with pytest.raises(ValueError, match="blocked address range"):
-                service.validate_config(config)
-
-    def test_validate_config_blocks_link_local(self):
-        """Test validation blocks link-local addresses."""
-        service = NotificationService()
-        config = cast(
-            PushNotificationConfig,
-            {"id": uuid4(), "url": "http://169.254.169.254/webhook"},
-        )
-
-        with patch(
-            "socket.getaddrinfo",
-            return_value=[("", "", "", "", ("169.254.169.254", 0))],
-        ):
-            with pytest.raises(ValueError, match="blocked address range"):
-                service.validate_config(config)
+    # SSRF allowlist was intentionally dropped in 270f4b94 ("drop SSRF
+    # allowlist"); the previous test_validate_config_blocks_{loopback,
+    # private_network,link_local} cases asserted the old blocking
+    # behavior and were removed alongside it.
 
     def test_validate_config_hostname_resolution_fails(self):
         """Test validation handles hostname resolution failure."""


### PR DESCRIPTION
## Summary

CI has been red on `main` since 2026-05-16 (commit [`270f4b94`](https://github.com/GetBindu/Bindu/commit/270f4b94) "drop SSRF allowlist") because four unit tests weren't updated alongside the code change. Tests-only PR, no production behavior change.

- **`test_notify_lifecycle_with_callback`** — the lifecycle notifier signature grew from 4 to 5 args (`status_message` added). Mock assertion updated to expect the trailing `None`.
- **`test_validate_config_blocks_{loopback,private_network,link_local}`** — the SSRF allowlist these tests exercised was intentionally removed in `270f4b94`. The three obsolete tests are deleted with a short comment in their place so the next reader doesn't add them back.

## Test plan

- [x] `uv run pytest tests/unit/server/workers/test_manifest_worker.py::TestManifestWorker::test_notify_lifecycle_with_callback tests/unit/utils/test_notifications.py` — 14 passed locally
- [ ] CI Unit Tests (3.12) + (3.13) go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated lifecycle notification test to verify status message parameter is now included in notifications
  * Removed Server-Side Request Forgery (SSRF) validation tests; validation no longer enforced

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->