### PR TITLE
fix(deps): patch 16 Dependabot alerts (+ examples README sweep)

### DIFF
--- a/examples/news-summarizer/README.md
+++ b/examples/news-summarizer/README.md
@@ -1,93 +1,33 @@
-# News Summarizer Agent 🌻
+# News Summarizer
 
-A Bindu agent that searches and summarizes latest news on **any topic**
-using local Ollama
+Local-LLM news research. Agno + Ollama (`llama3.2`) + DuckDuckGo. Hand it a topic, get back the top three headlines, a one-line summary of each, and overall sentiment. Nothing leaves your machine — no OpenRouter call, no API key.
 
-## What Makes This Different?
+## Setup
 
-Unlike the existing `summarizer` agent which summarizes text YOU provide,
-this agent **actively searches the web** for latest news on any topic
-and returns structured summaries with sentiment analysis.
-
-## Features
-
-- Real-time web search via DuckDuckGo
-- Local LLM via Ollama (free, private, no data sent anywhere)
-- Structured output: headlines + summaries + sentiment
-- Works for any topic: cricket, tech, finance, politics
-
-## Prerequisites
-
-- Python 3.12+
-- [Ollama](https://ollama.ai) running locally with llama3.2 model
-- uv package manager
-
-## Quick Start
-
-### 1. Install Ollama and pull the model
 ```bash
-ollama pull llama3.2
+brew install ollama
+ollama serve &                  # daemonised; once-per-boot
+ollama pull llama3.2            # ~2GB, one-time download
+uv sync --extra agents
 ```
 
-### 2. Set up environment
+If Ollama isn't running on `http://localhost:11434`, the agent boots fine but the first task fails with `Failed to connect to Ollama`.
+
+## Run
+
 ```bash
-cp .env.example .env
+uv run examples/news-summarizer/news_agent.py
+# http://localhost:3773
 ```
 
-### 3. Run the agent
-```bash
-# From Bindu root directory
-python examples/news-summarizer/news_agent.py
-```
+## Talk to it
 
-### 4. Test it
+With `AUTH__ENABLED=false`:
+
 ```bash
-curl -X POST http://localhost:3773/ \
+curl -sS http://localhost:3773/ \
   -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "message/send",
-    "params": {
-      "message": {
-        "role": "user",
-        "parts": [{"kind": "text", "text": "Give me latest cricket news"}],
-        "kind": "message",
-        "messageId": "550e8400-e29b-41d4-a716-446655440001",
-        "contextId": "550e8400-e29b-41d4-a716-446655440002",
-        "taskId": "550e8400-e29b-41d4-a716-446655440003"
-      },
-      "configuration": {"acceptedOutputModes": ["application/json"]}
-    },
-    "id": "550e8400-e29b-41d4-a716-446655440000"
-  }'
+  -d '{"jsonrpc":"2.0","method":"message/send","id":"1","params":{"message":{"role":"user","parts":[{"kind":"text","text":"cricket news"}],"kind":"message","messageId":"m1","contextId":"c1","taskId":"t1"}}}'
 ```
 
-Then fetch the result:
-```bash
-curl -X POST http://localhost:3773/ \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "tasks/get",
-    "params": {
-      "taskId": "550e8400-e29b-41d4-a716-446655440003"
-    },
-    "id": "550e8400-e29b-41d4-a716-446655440000"
-  }'
-```
-
-## Example Output
-```
-Top 3 Headlines:
-1. Australia's T20 World Cup Failure Could Affect Olympic Cricket Bid
-2. Former Cricket Captains Urge Pakistan to Improve Imran Khan's Prison Conditions
-3. T20 World Cup: How to Watch Afghanistan vs. Canada in the US
-
-Overall Sentiment: Neutral
-```
-
-## Future Improvements
-
-- Postgres storage for persistent task results
-- Streaming responses for real-time output
-- Multi-language news support
+Then `tasks/get` with the same `taskId`. The artifact text is the structured summary (headlines + sentiment). With auth on, sign each body with the agent's DID key — see [`docs/AUTH.md`](../../docs/AUTH.md).

--- a/examples/premium-advisor/README.md
+++ b/examples/premium-advisor/README.md
@@ -1,285 +1,36 @@
-# Premium Market Insight Advisor
+# Premium Advisor
 
-A premium Bindu agent that provides high-value market insights and financial analysis with X402 payment gating. This example demonstrates how to create paid agents using Bindu's payment infrastructure.
+The smallest possible example of an x402-paywalled agent: 0.01 USDC on Base Sepolia per question, and you get a market-insight reply only after the payment lands. Agno + OpenRouter behind the gate.
 
-## What is This?
-
-This is a **premium market insight advisor** that:
-- Provides proprietary deep-chain market analysis
-- Offers investment recommendations and risk assessments
-- Requires X402 payment (0.01 USDC) per interaction
-- Uses Agno framework with OpenRouter's `openai/gpt-oss-120b` model
-- Demonstrates payment-gated AI services
-
-## Features
-
-- **X402 Payment Integration**: Secure payment processing (0.01 USDC per query)
-- **Market Analysis**: Deep-chain analysis of blockchain projects
-- **Investment Insights**: Actionable recommendations with risk assessments
-- **Developer Activity Tracking**: Analysis of project fundamentals
-- **Premium Content**: High-value insights that justify the cost
-- **Agno Framework**: Modern AI agent architecture
-
-## Quick Start
-
-### Prerequisites
-- Python 3.12+
-- OpenRouter API key
-- uv package manager
-- Bindu installed in project root
-- USDC on Base Sepolia for testing payments
-
-### 1. Set Environment Variables
-
-Create `.env` file in `examples/premium-advisor/`:
+## Setup
 
 ```bash
-cp .env.example .env
-# Edit .env and add your OpenRouter API key
+export OPENROUTER_API_KEY=<get one at https://openrouter.ai/keys>
+uv sync --extra agents
 ```
 
+To actually pay the agent you need a wallet with Base Sepolia USDC. The configured `pay_to_address` in `premium_advisor.py` is a demo dummy — edit it before pointing real money at it.
+
+## Run
+
 ```bash
-OPENROUTER_API_KEY=your_openrouter_api_key_here
+uv run examples/premium-advisor/premium_advisor.py
+# http://localhost:3773
 ```
 
-### 2. Install Dependencies
+## Talk to it
+
+A request without payment headers gets a 402 with the price quote:
 
 ```bash
-# From Bindu root directory
-uv sync
-```
-
-### 3. Start the Premium Advisor
-
-```bash
-# From Bindu root directory
-cd examples/premium-advisor
-uv run python premium_advisor.py
-```
-
-The agent will start on `http://localhost:3773`
-
-### 4. Test the Agent
-
-Open your browser to `http://localhost:3773/docs` and use the chat interface, or:
-
-```bash
-curl -X POST http://localhost:3773/ \
+curl -i http://localhost:3773/ \
   -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "message/send",
-    "params": {
-      "message": {
-        "role": "user",
-        "parts": [{"kind": "text", "text": "What are the best investment opportunities right now?"}],
-        "kind": "message",
-        "messageId": "msg-001",
-        "contextId": "ctx-001",
-        "taskId": "task-001"
-      },
-      "configuration": {"acceptedOutputModes": ["application/json"]}
-    },
-    "id": "1"
-  }'
+  -d '{"jsonrpc":"2.0","method":"message/send","id":"1","params":{"message":{"role":"user","parts":[{"kind":"text","text":"Is now a good time to buy ETH?"}],"kind":"message","messageId":"m1","contextId":"c1","taskId":"t1"}}}'
+# HTTP/1.1 402 Payment Required
+# {"x402Version":2,"error":"X-PAYMENT header required",
+#  "accepts":[{"amount":"10000","asset":"0x036CbD53842c5426634e7929541eC2318f3dCF7e", ...}]}
 ```
 
-## Architecture
+That 402 IS the working state — the paywall is doing its job. To actually unblock the agent, sign a USDC transfer and resend with `X-PAYMENT: <signed-payload>`. The x402 spec is at <https://github.com/coinbase/x402>; bindu's payment middleware lives at `bindu/server/middleware/x402/`.
 
-### File Structure
-
-- **`premium_advisor.py`** - Main Agno agent with X402 payment integration
-- **`skills/premium-market-insight-skill/`** - Bindu skill definition
-- **`.env.example`** - Environment variable template
-- **`README.md`** - This documentation
-
-### Agent Configuration
-
-Single payment option (current example code):
-
-```python
-config = {
-    "author": "premium.advisor@example.com",
-    "name": "Oracle_of_Value",
-    "description": "I provide high-value market insights. Payment required upfront.",
-    "execution_cost": {
-        "amount": "0.01",           # Cost per interaction
-        "token": "USDC",           # Payment currency
-        "network": "base-sepolia",  # Blockchain network
-        "pay_to_address": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
-    },
-    "deployment": {"url": "http://localhost:3773", "expose": True},
-    "skills": ["skills/premium-market-insight-skill"]
-}
-```
-
-Multiple payment options (alternative configuration):
-
-```python
-config = {
-    "author": "premium.advisor@example.com",
-    "name": "Oracle_of_Value",
-    "description": "I provide high-value market insights. Payment required upfront.",
-    "execution_cost": [
-        {
-            "amount": "0.01",          # 0.01 USDC on Base Sepolia
-            "token": "USDC",
-            "network": "base-sepolia",
-            "pay_to_address": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
-        },
-        {
-            "amount": "0.0001",        # 0.0001 ETH on Ethereum mainnet
-            "token": "ETH",
-            "network": "ethereum",
-            "pay_to_address": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
-        },
-    ],
-    "deployment": {"url": "http://localhost:3773", "expose": True},
-    "skills": ["skills/premium-market-insight-skill"]
-}
-```
-
-### Payment Flow
-
-1. **User sends message** → Bindu receives request
-2. **Payment check** → X402 validates 0.01 USDC payment
-3. **Payment processed** → Funds transferred to specified address
-4. **Agent execution** → Agno agent processes the request
-5. **Premium response** → High-quality market insights returned
-
-## Skills Integration
-
-The agent includes a Bindu skill definition with:
-
-- **Skill ID**: `premium-market-insight-skill`
-- **Capabilities**: Market analysis, investment recommendations, risk assessment
-- **Payment**: X402-gated premium service
-- **Tags**: finance, market-analysis, investment, cryptocurrency, premium
-
-## Example Interactions
-
-### Sample Query
-```
-"What's your outlook for DeFi projects this quarter?"
-```
-
-### Premium Response
-```
-🔮 **Quarterly DeFi Outlook** 🔮
-
-Based on deep-chain analysis:
-
-**🟢 Accumulate:**
-- Projects with >50% developer activity increase
-- Protocols with completed audits and transparent governance
-- Yield aggregators with diversified strategies
-
-**🔴 Avoid:**
-- Anonymous teams with no GitHub activity
-- Projects promising unrealistic APYs (>100%)
-- Protocols without insurance or safety mechanisms
-
-**💡 Strategy:**
-- DCA into blue-chip DeFi (Aave, Compound, Uniswap)
-- Allocate 20% to emerging protocols with strong fundamentals
-- Maintain 30% stablecoins for volatility management
-
-Risk Score: 6/10 (Moderate - Market volatility remains high)
-```
-
-## Development
-
-### Modifying the Agent
-
-1. **Change instructions**: Edit the `Agent` instructions in `premium_advisor.py`
-2. **Adjust pricing**: Modify `execution_cost` in the config
-3. **Update skills**: Edit `skills/premium-market-insight-skill/skill.yaml`
-4. **Change model**: Update `OpenRouter(id="...")` parameter
-
-### Adding New Capabilities
-
-```python
-# Add new tools to the agent
-from agno.tools.custom import custom_tool
-
-@custom_tool
-def analyze_token(token_address: str) -> str:
-    """Analyze a specific token"""
-    # Your analysis logic here
-    return analysis_result
-
-agent = Agent(
-    instructions="...",
-    model=OpenRouter(id="openai/gpt-oss-120b"),
-    tools=[analyze_token],
-)
-```
-
-## Testing Payments
-
-### Setting Up Test Environment
-
-1. **Get USDC on Base Sepolia**:
-   - Use Base Sepolia faucet
-   - Bridge from Ethereum Sepolia if needed
-
-2. **Configure Wallet**:
-   - Ensure your wallet has Base Sepolia network
-   - Check USDC balance: `0.01 USDC` minimum per query
-
-3. **Test Payment Flow**:
-   - Send a message to the agent
-   - Confirm payment prompt appears
-   - Complete payment transaction
-   - Receive premium insights
-
-## Dependencies
-
-All dependencies are managed through the root `pyproject.toml`:
-
-```bash
-# Core dependencies already included in bindu project
-agno>=2.4.8
-langchain>=1.2.9
-langchain-openai>=1.1.8
-python-dotenv>=1.1.0
-```
-
-## Security Considerations
-
-- **Payment Validation**: All payments validated through X402 protocol
-- **Private Keys**: Never store private keys in the code
-- **API Keys**: Use environment variables for sensitive data
-- **Network Security**: Test on Base Sepolia before mainnet deployment
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Payment Fails**:
-   - Check USDC balance on Base Sepolia
-   - Verify network configuration in wallet
-   - Ensure correct pay_to_address
-
-2. **Agent Not Responding**:
-   - Verify OPENROUTER_API_KEY is set
-   - Check agent logs for errors
-   - Ensure port 3773 is available
-
-3. **Environment Issues**:
-   - Run `uv sync` from project root
-   - Check Python version (3.12+)
-   - Verify all dependencies installed
-
-## Contributing
-
-To extend this example:
-
-1. **Add new analysis tools** in the agent
-2. **Modify payment structure** for different tiers
-3. **Update skill definition** with new capabilities
-4. **Improve documentation** and examples
-
-## License
-
-This example is part of the Bindu framework and follows the same license terms.
+For the auth-on flow (Hydra OAuth + DID-signed bodies), see [`docs/AUTH.md`](../../docs/AUTH.md). The paywall and the auth gate stack — both have to pass.

--- a/examples/summarizer/README.md
+++ b/examples/summarizer/README.md
@@ -1,243 +1,29 @@
-# Text Summarizer Agent
+# Summarizer
 
-A professional Bindu agent that creates concise, coherent summaries of any input text using OpenRouter's `openai/gpt-oss-120b` model.
+Turns any long blob of text into a 2–3 sentence summary. Agno + OpenRouter (`openai/gpt-oss-120b`), one skill (`text-summarization-skill`), no extra deps beyond the `agents` extra.
 
-## What is This?
-
-This is a **text summarization agent** that:
-- Creates clear, concise summaries of any input text
-- Preserves key information and context
-- Uses OpenRouter's advanced `openai/gpt-oss-120b` model
-- Provides rapid, high-quality text condensation
-- Demonstrates Bindu's text transformation capabilities
-
-## Features
-
-- **Intelligent Summarization**: Context-aware content condensation
-- **Key Point Preservation**: Maintains essential information
-- **Coherent Output**: Well-structured, readable summaries
-- **Fast Processing**: Optimized for quick text analysis
-- **Multi-Format Support**: Handles various text types and structures
-
-## Quick Start
-
-### Prerequisites
-- Python 3.12+
-- OpenRouter API key
-- uv package manager
-- Bindu installed in project root
-
-### 1. Set Environment Variables
-
-Create `.env` file in `examples/summarizer/`:
+## Setup
 
 ```bash
-cp .env.example .env
-# Edit .env and add your OpenRouter API key
+export OPENROUTER_API_KEY=<get one at https://openrouter.ai/keys>
+uv sync --extra agents
 ```
 
+## Run
+
 ```bash
-OPENROUTER_API_KEY=your_openrouter_api_key_here
+uv run examples/summarizer/summarizer_agent.py
+# http://localhost:3773
 ```
 
-### 2. Install Dependencies
+## Talk to it
+
+With `AUTH__ENABLED=false` (set in `examples/.env`):
 
 ```bash
-# From Bindu root directory
-uv sync
-```
-
-### 3. Start the Summarizer Agent
-
-```bash
-# From Bindu root directory
-cd examples/summarizer
-uv run python summarizer_agent.py
-```
-
-The agent will start on `http://localhost:3774`
-
-### 4. Test the Summarizer
-
-Open your browser to `http://localhost:3774/docs` and use the chat interface, or:
-
-```bash
-curl -X POST http://localhost:3774/ \
+curl -sS http://localhost:3773/ \
   -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "message/send",
-    "params": {
-      "message": {
-        "role": "user",
-        "parts": [{"kind": "text", "text": "Climate change refers to long-term shifts in global temperatures and weather patterns. While climate variations are natural, human activities have been the main driver of climate change since the mid-20th century, primarily due to fossil fuel burning, which increases heat-trapping greenhouse gas levels in Earth's atmosphere. This is raising average temperatures and causing more frequent and intense extreme weather events."}],
-        "kind": "message",
-        "messageId": "msg-001",
-        "contextId": "ctx-001",
-        "taskId": "task-001"
-      },
-      "configuration": {"acceptedOutputModes": ["application/json"]}
-    },
-    "id": "1"
-  }'
+  -d '{"jsonrpc":"2.0","method":"message/send","id":"1","params":{"message":{"role":"user","parts":[{"kind":"text","text":"Summarize: <paste your long text here>"}],"kind":"message","messageId":"m1","contextId":"c1","taskId":"t1"}}}'
 ```
 
-## Architecture
-
-### File Structure
-
-```
-examples/summarizer/
-├── summarizer_agent.py              # Main Agno agent with OpenRouter
-├── skills/
-│   └── text-summarization-skill/
-│       └── skill.yaml              # Bindu skill definition
-├── .env.example                    # Environment variables template
-└── README.md                       # This documentation
-```
-
-### Agent Configuration
-
-```python
-agent = Agent(
-    instructions="You are a professional summarization assistant...",
-    model=OpenRouter(id="openai/gpt-oss-120b")
-)
-```
-
-### Model Configuration
-
-- **Provider**: OpenRouter
-- **Model**: `openai/gpt-oss-120b`
-- **Temperature**: Default (balanced for summarization)
-- **API**: OpenRouter's API endpoint
-
-## Skills Integration
-
-The summarizer includes a Bindu skill definition with:
-
-- **Skill ID**: `text-summarization-skill`
-- **Capabilities**: Text summarization, key point extraction, context preservation
-- **Input/Output**: JSON format for structured data exchange
-- **Tags**: summarization, text-processing, content-condensation, productivity
-
-## Example Interactions
-
-### Sample Input
-```
-"Climate change refers to long-term shifts in global temperatures and weather patterns. While climate variations are natural, human activities have been the main driver of climate change since the mid-20th century, primarily due to fossil fuel burning, which increases heat-trapping greenhouse gas levels in Earth's atmosphere. This is raising average temperatures and causing more frequent and intense extreme weather events."
-```
-
-### Sample Output
-```
-"Climate change involves long-term shifts in global temperatures and weather patterns, with human activities becoming the primary driver since the mid-20th century through fossil fuel burning. This has increased greenhouse gas levels in Earth's atmosphere, leading to rising temperatures and more frequent extreme weather events."
-```
-
-## Development
-
-### Modifying the Agent
-
-1. **Change instructions**: Edit the `instructions` parameter
-2. **Adjust summary length**: Modify the prompt to specify different length requirements
-3. **Update model**: Change the OpenRouter model ID if needed
-4. **Enhance skills**: Update `skills/text-summarization-skill/skill.yaml`
-
-### Example Customization
-
-```python
-# For longer summaries
-instructions="Create detailed 4-5 sentence summaries that preserve important details..."
-
-# For bullet-point summaries
-instructions="Summarize the text using bullet points for key information..."
-
-# For specific domain summarization
-instructions="You are a scientific summarizer. Create summaries suitable for academic papers..."
-```
-
-## Use Cases
-
-### Academic & Research
-- Research paper summarization
-- Literature review condensation
-- Abstract generation
-
-### Business & Professional
-- Report summarization
-- Meeting transcript condensation
-- Email thread summaries
-
-### Content & Media
-- Article summarization
-- Document analysis
-- Content curation
-
-### Personal Productivity
-- Reading assistance
-- Information processing
-- Study aid
-
-## Dependencies
-
-All dependencies are managed through the root `pyproject.toml`:
-
-```bash
-# Core dependencies already included in bindu project
-agno>=2.4.8
-langchain>=1.2.9
-langchain-openai>=1.1.8
-python-dotenv>=1.1.0
-```
-
-## Performance
-
-### Typical Processing Time
-- **Short texts** (< 500 words): 1-2 seconds
-- **Medium texts** (500-1000 words): 2-4 seconds
-- **Long texts** (> 1000 words): 4-8 seconds
-
-### Quality Metrics
-- **Coherence**: High - maintains logical flow
-- **Accuracy**: Excellent - preserves key information
-- **Conciseness**: Optimized - 2-3 sentence summaries
-- **Readability**: Professional - clear and well-structured
-
-## Troubleshooting
-
-### Common Issues
-
-1. **API Key Errors**:
-   - Verify OPENROUTER_API_KEY is set
-   - Check key validity and credits
-   - Ensure OpenRouter service is available
-
-2. **Poor Summaries**:
-   - Review input text quality
-   - Check for complex or ambiguous content
-   - Consider adjusting instructions
-
-3. **Slow Response**:
-   - Check network connectivity
-   - Monitor API rate limits
-   - Consider text length optimization
-
-### Best Practices
-
-- **Input Quality**: Provide clear, well-structured text for best results
-- **Length Limits**: Very long texts may be better split into sections
-- **Context**: Include relevant context when summarizing specialized content
-- **Review**: Always review summaries for critical applications
-
-## Contributing
-
-To extend this example:
-
-1. **Add new summarization styles**: Bullet points, different lengths
-2. **Multi-language support**: Add language detection and translation
-3. **Domain-specific modes**: Academic, business, casual summarization
-4. **Quality metrics**: Add automatic quality assessment
-5. **Batch processing**: Support multiple text summarization
-
-## License
-
-This example is part of the Bindu framework and follows the same license terms.
+Then `tasks/get` with the same `taskId` for the artifact. With auth on, sign each body with the agent's DID key — see [`docs/AUTH.md`](../../docs/AUTH.md).

--- a/examples/typescript-langchain-agent/package-lock.json
+++ b/examples/typescript-langchain-agent/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@bindu/sdk": "file:../../sdks/typescript",
-        "@langchain/openai": "^0.4.0",
+        "@langchain/openai": "^1.0.0",
         "dotenv": "^16.4.0"
       },
       "devDependencies": {
@@ -488,122 +488,47 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.80",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
-      "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
+      "version": "1.1.46",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.46.tgz",
+      "integrity": "sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
+        "@standard-schema/spec": "^1.1.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.67",
+        "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "zod": "^3.25.32",
-        "zod-to-json-schema": "^3.22.3"
+        "zod": "^3.25.76 || ^4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@langchain/openai": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.4.9.tgz",
-      "integrity": "sha512-NAsaionRHNdqaMjVLPkFCyjUDze+OqRHghA1Cn4fPoAafz+FXcl9c7LlEl9Xo0FH6/8yiCl7Rw2t780C/SBVxQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.5.tgz",
+      "integrity": "sha512-bQ2WMIZfSh02trJLYSAtiIcD3j6EBCiAm9nw0dZWQsVaUxmWc3JJqs8uUte6AkMazmLHzcUIw+14UkXO5fRJvQ==",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.12",
-        "openai": "^4.87.3",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.3"
+        "openai": "^6.34.0",
+        "zod": "^3.25.76 || ^4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": ">=0.3.39 <0.4.0"
+        "@langchain/core": "^1.1.42"
       }
     },
-    "node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -625,126 +550,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -755,65 +560,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -858,56 +604,12 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -924,122 +626,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/js-tiktoken": {
       "version": "1.0.21",
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
@@ -1050,24 +636,20 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.1.tgz",
+      "integrity": "sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
         "@opentelemetry/exporter-trace-otlp-proto": "*",
         "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
+        "openai": "*",
+        "ws": ">=7"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -1081,44 +663,11 @@
         },
         "openai": {
           "optional": true
+        },
+        "ws": {
+          "optional": true
         }
       }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -1130,66 +679,17 @@
         "mustache": "bin/mustache"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "version": "6.38.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.38.0.tgz",
+      "integrity": "sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
       "bin": {
         "openai": "bin/cli"
       },
       "peerDependencies": {
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
         "ws": {
@@ -1227,20 +727,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -1253,55 +739,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.22.1",
@@ -1336,68 +773,13 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/examples/typescript-langchain-agent/package.json
+++ b/examples/typescript-langchain-agent/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@bindu/sdk": "file:../../sdks/typescript",
-    "@langchain/openai": "^0.4.0",
+    "@langchain/openai": "^1.0.0",
     "dotenv": "^16.4.0"
   },
   "devDependencies": {

--- a/examples/typescript-langchain-quiz-agent/package-lock.json
+++ b/examples/typescript-langchain-quiz-agent/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@bindu/sdk": "file:../../sdks/typescript",
-        "@langchain/openai": "^0.4.0",
+        "@langchain/openai": "^1.0.0",
         "dotenv": "^16.4.0",
         "yaml": "^2.8.3"
       },
@@ -490,122 +490,57 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.80",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
-      "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
+      "version": "1.1.46",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.46.tgz",
+      "integrity": "sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
+        "@standard-schema/spec": "^1.1.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.67",
+        "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "zod": "^3.25.32",
-        "zod-to-json-schema": "^3.22.3"
+        "zod": "^3.25.76 || ^4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@langchain/openai": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.4.9.tgz",
-      "integrity": "sha512-NAsaionRHNdqaMjVLPkFCyjUDze+OqRHghA1Cn4fPoAafz+FXcl9c7LlEl9Xo0FH6/8yiCl7Rw2t780C/SBVxQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.5.tgz",
+      "integrity": "sha512-bQ2WMIZfSh02trJLYSAtiIcD3j6EBCiAm9nw0dZWQsVaUxmWc3JJqs8uUte6AkMazmLHzcUIw+14UkXO5fRJvQ==",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.12",
-        "openai": "^4.87.3",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.3"
+        "openai": "^6.34.0",
+        "zod": "^3.25.76 || ^4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": ">=0.3.39 <0.4.0"
+        "@langchain/core": "^1.1.42"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/node": {
       "version": "20.19.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -627,126 +562,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -757,65 +572,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -860,56 +616,12 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -926,122 +638,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/js-tiktoken": {
       "version": "1.0.21",
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
@@ -1052,24 +648,20 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.1.tgz",
+      "integrity": "sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
         "@opentelemetry/exporter-trace-otlp-proto": "*",
         "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
+        "openai": "*",
+        "ws": ">=7"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -1083,44 +675,11 @@
         },
         "openai": {
           "optional": true
+        },
+        "ws": {
+          "optional": true
         }
       }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -1132,66 +691,17 @@
         "mustache": "bin/mustache"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "version": "6.38.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.38.0.tgz",
+      "integrity": "sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
       "bin": {
         "openai": "bin/cli"
       },
       "peerDependencies": {
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
         "ws": {
@@ -1201,21 +711,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -1244,20 +739,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -1270,55 +751,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.22.1",
@@ -1357,47 +789,8 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/yaml": {
       "version": "2.9.0",
@@ -1415,21 +808,12 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/examples/typescript-langchain-quiz-agent/package.json
+++ b/examples/typescript-langchain-quiz-agent/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@bindu/sdk": "file:../../sdks/typescript",
-    "@langchain/openai": "^0.4.0",
+    "@langchain/openai": "^1.0.0",
     "dotenv": "^16.4.0",
     "yaml": "^2.8.3"
   },

--- a/examples/weather-research/README.md
+++ b/examples/weather-research/README.md
@@ -1,185 +1,29 @@
-# Weather Research Agent
+# Weather Research
 
-A weather research agent that provides weather information and forecasts for any location worldwide using search-powered data retrieval.
+Ask it for the weather in any city. Agno + OpenRouter (`openai/gpt-oss-120b`) + DuckDuckGo search. The agent synthesises the search hits into one report — current conditions, temperature, short forecast — instead of dumping raw results.
 
-## 🌤️ Features
+## Setup
 
-### Core Capabilities
-- **Real-time Weather Data**: Current conditions via web search
-- **Weather Forecasts**: Multi-day forecasts for any location
-- **Global Coverage**: Weather information for any city worldwide
-- **Clean Response Format**: Synthesized responses without showing raw search results
-
-### 🔧 Technical Features
-- **Model**: OpenRouter's `openai/gpt-oss-120b` for advanced reasoning
-- **Search Integration**: DuckDuckGo tools for real-time weather data
-- **Smart Formatting**: Clean, synthesized responses
-- **Environment Loading**: Automatic .env file loading
-- **Bindu Integration**: Fully compatible with Bindu agent framework
-
-## 🚀 Quick Start
-
-### Prerequisites
-- Python 3.12+
-- OpenRouter API key (set in `.env` file)
-- UV package manager
-
-### Installation & Setup
-
-1. **Navigate to Bindu root directory** (required for dependencies):
-   ```bash
-   cd /path/to/bindu
-   ```
-
-2. **Install dependencies**:
-   ```bash
-   uv sync
-   ```
-
-3. **Configure environment**:
-   ```bash
-   cp examples/weather-research/.env.example examples/weather-research/.env
-   # Edit examples/weather-research/.env and add your OPENROUTER_API_KEY
-   ```
-
-4. **Run the agent**:
-   ```bash
-   uv run python examples/weather-research/weather_research_agent.py
-   ```
-
-## 📡 Usage Examples
-
-### Basic Weather Queries
-```python
-# Direct agent usage
-messages = [{"role": "user", "content": "What's the weather like in Tokyo?"}]
+```bash
+export OPENROUTER_API_KEY=<get one at https://openrouter.ai/keys>
+uv sync --extra agents
 ```
 
-### Supported Query Types
-- **Current Weather**: "weather in [location]", "current weather [location]"
-- **Forecasts**: "weather forecast [location]", "5-day forecast [location]"
-- **General**: "What's the weather like in [location]?"
+## Run
 
-### Response Format
-The agent provides clean, synthesized weather information without showing raw search results. Example:
-```
-**Current Weather in Tokyo**
-- Temperature: 30°F (-1°C)
-- Condition: Chilly (overcast/partly cloudy)
-- Note: Real-time data can shift quickly. For the most up-to-date details, check live weather services.
+```bash
+uv run examples/weather-research/weather_research_agent.py
+# http://localhost:3773
 ```
 
-## 🔐 Configuration
+## Talk to it
 
-### Agent Settings
-```python
-config = {
-    "author": "bindu.builder@getbindu.com",
-    "name": "weather_research_agent",
-    "description": "Research agent that finds current weather and forecasts for any city worldwide",
-    "deployment": {"url": "http://localhost:3773", "expose": True}
-}
+With `AUTH__ENABLED=false`:
+
+```bash
+curl -sS http://localhost:3773/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"message/send","id":"1","params":{"message":{"role":"user","parts":[{"kind":"text","text":"Weather in Tokyo right now?"}],"kind":"message","messageId":"m1","contextId":"c1","taskId":"t1"}}}'
 ```
 
-### Model Configuration
-- **Provider**: OpenRouter
-- **Model**: `openai/gpt-oss-120b`
-- **API Key**: Loaded from environment variable `OPENROUTER_API_KEY`
-
-### Tools
-- **DuckDuckGoTools**: For real-time weather data search
-
-## 🛠️ Development
-
-### Project Structure
-```
-weather-research/
-├── weather_research_agent.py    # Main agent implementation
-├── .env                     # Environment variables (API keys)
-├── .env.example              # Environment variables template
-├── .bindu/                  # Bindu configuration directory
-├── logs/                    # Log files directory
-├── skills/                  # Skills directory
-│   └── weather-research-skill/
-│       └── skill.yaml       # Skill metadata
-└── README.md                # This file
-```
-
-### Agent Implementation
-The agent uses:
-- **Agno Framework**: For agent orchestration
-- **OpenRouter Model**: For natural language processing
-- **DuckDuckGo Search**: For real-time weather data
-- **Bindu Framework**: For agent deployment and discovery
-
-## 🔍 Troubleshooting
-
-### Common Issues
-
-#### API Key Not Found
-**Error**: `OPENROUTER_API_KEY not set`
-**Solution**:
-1. Copy your OpenRouter API key
-2. Add to `.env` file: `OPENROUTER_API_KEY=your_key_here`
-3. Restart the agent
-
-#### Module Not Found
-**Error**: `ModuleNotFoundError: No module named 'bindu'`
-**Solution**:
-1. Make sure you're running from the Bindu root directory
-2. Run `uv sync` to install dependencies
-3. Use: `uv run python examples/weather-research/weather_research_agent.py`
-
-#### Environment Loading Issues
-**Error**: Environment variables not loading
-**Solution**:
-1. Ensure `.env` file exists in `examples/weather-research/` directory
-2. Check that the API key is correctly formatted
-
-## 📚 API Reference
-
-### Endpoints
-When running, the agent exposes these endpoints:
-- **POST /message**: Send weather queries
-- **GET /agent**: Get agent information
-- **GET /health**: Health check endpoint
-
-### Message Format
-```json
-{
-  "messages": [
-    {
-      "role": "user",
-      "content": "What's the weather like in Tokyo?"
-    }
-  ]
-}
-```
-
-## 🤝 Contributing
-
-### Adding New Features
-1. Update agent logic in `weather_research_agent.py`
-2. Test thoroughly with different weather queries
-3. Update documentation as needed
-
-### Code Standards
-- Follow Python PEP 8 guidelines
-- Include proper error handling
-- Add type hints for functions
-- Document changes in README
-
-## 📄 License
-
-This project is part of the Bindu framework and follows the same licensing terms.
-
-## 🆘 Support
-
-For issues and questions:
-- Check the [Bindu Documentation](https://docs.getbindu.com)
-- Review existing [Issues](https://github.com/getbindu/bindu/issues)
-- Join the [Community](https://discord.getbindu.com)
-
----
-
-**Built with ❤️ using the Bindu Agent Framework**
+Then `tasks/get` with the same `taskId`. With auth on, sign each body with the agent's DID key — see [`docs/AUTH.md`](../../docs/AUTH.md).

--- a/examples/web-scraping-agent/README.md
+++ b/examples/web-scraping-agent/README.md
@@ -1,106 +1,36 @@
-# Web Scraping AI Agent
+# Web Scraping
 
-An AI-enabled web scraping agent that crawls web pages, extracts structured data, cleans and formats outputs, and prepares datasets for analysis or integration using ScrapeGraph AI and Mem0.
+Hand it a URL and an extraction prompt, get structured JSON back. Agno orchestrates two tools: ScrapeGraph for the actual fetch + parse, and Mem0 so the agent remembers which URLs it already scraped (and your extraction preferences) across runs.
 
-## 🕷️ Features
+## Setup
 
-### Core Capabilities
-- **Intelligent Extraction**: Uses ScrapeGraph AI for smart, LLM-powered structured data extraction from any public web page.
-- **Persistent Memory**: Integrates Mem0 for deduplication (avoiding re-scraping processed URLs) and remembering extraction profiles for specific domains.
-- **Structured JSON Output**: Automatically cleans and formats extracted content into analysis-ready JSON datasets.
-- **E-commerce & Content Scraping**: Optimized for product listings, blog posts, news articles, and structured tables.
-
-### 🔧 Technical Features
-- **Model**: OpenRouter's `openai/gpt-oss-120b` for advanced synthesis and formatting.
-- **Tools**:
-  - `ScrapeGraphTools`: For intelligent web scraping.
-  - `Mem0Tools`: For persistent memory and deduplication.
-- **Environment Loading**: Automatic .env file loading for secure API key management.
-- **Bindu Integration**: Fully compatible with Bindu agent framework for discovery and deployment.
-
-## 🚀 Quick Start
-
-### Prerequisites
-- Python 3.12+
-- ScrapeGraph AI API key ([Get one](https://scrapegraphai.com/))
-- Mem0 API key ([Get one](https://app.mem0.ai/))
-- OpenRouter API key ([Get one](https://openrouter.ai/))
-- UV package manager
-
-### Installation & Setup
-
-1. **Navigate to Bindu root directory**:
-   ```bash
-   cd /path/to/bindu
-   ```
-
-2. **Install dependencies**:
-   ```bash
-   uv sync --extra agents
-   ```
-
-3. **Configure environment**:
-   ```bash
-   cp examples/web-scraping-agent/.env.example examples/web-scraping-agent/.env
-   # Edit examples/web-scraping-agent/.env and add your API keys
-   ```
-
-4. **Run the agent**:
-   ```bash
-   uv run python examples/web-scraping-agent/web_scraping_agent.py
-   ```
-
-## 📡 Usage Examples
-
-### Basic Extraction Queries
-```python
-# Direct agent usage
-messages = [
-    {"role": "user", "content": "Extract product listings from this e-commerce site: https://example.com/products"}
-]
+```bash
+export OPENROUTER_API_KEY=<get one at https://openrouter.ai/keys>
+export SCRAPEGRAPH_API_KEY=<get one at https://scrapegraphai.com>
+export MEM0_API_KEY=<get one at https://app.mem0.ai/dashboard/api-keys>
+uv sync --extra agents
+uv pip install scrapegraph-py mem0ai
 ```
 
-### Supported Query Types
-- **E-commerce**: "Extract product names and prices from [URL]"
-- **Content**: "Scrape blog titles and publish dates from [URL]"
-- **General**: "Get all article headlines from this news page"
-- **Structured**: "Extract the contents of the main table on [URL] into JSON"
+`scrapegraph-py` and `mem0ai` aren't in the `agents` extra yet — install them explicitly. Without `MEM0_API_KEY` the agent crashes at boot; without `SCRAPEGRAPH_API_KEY` it crashes the moment you ask it to scrape.
 
-## ️ Development
+## Run
 
-### Project Structure
-```
-web-scraping-agent/
-├── web_scraping_agent.py    # Main agent implementation
-├── .env                     # Environment variables (API keys)
-├── .env.example              # Environment variables template
-├── skills/                  # Skills directory
-│   └── web-scraping-skill/
-│       └── skill.yaml       # Skill metadata
-└── README.md                # This file
+```bash
+uv run examples/web-scraping-agent/web_scraping_agent.py
+# http://localhost:3773
 ```
 
-## 🔍 Troubleshooting
+## Talk to it
 
-### Common Issues
+With `AUTH__ENABLED=false`:
 
-#### API Keys Not Found
-**Error**: `SCRAPEGRAPH_API_KEY/MEM0_API_KEY/OPENROUTER_API_KEY not set`
-**Solution**: Ensure your `.env` file exists in `examples/web-scraping-agent/` and contains the required keys.
+```bash
+curl -sS http://localhost:3773/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"message/send","id":"1","params":{"message":{"role":"user","parts":[{"kind":"text","text":"Scrape https://example.com — extract the page title and first paragraph."}],"kind":"message","messageId":"m1","contextId":"c1","taskId":"t1"}}}'
+```
 
-#### Module Not Found
-**Error**: `ModuleNotFoundError: No module named 'scrapegraphpy'` or `mem0ai`
-**Solution**: Run `uv sync --extra agents` to ensure all optional dependencies are installed.
+Then `tasks/get` for the JSON. Re-running with the same URL hits Mem0 first — the agent will say "already scraped this" instead of re-fetching.
 
-#### Scraping Fails With Credit Errors
-**Error**: Messages like `insufficient credits`, `not enough credits`, or upstream `500` from ScrapeGraph.
-**Solution**: Verify your ScrapeGraph account has available credits and the key is active. Then restart the agent and retry. If needed, test with a smaller target page first.
-
-#### Agent Crashes on Startup / `ValueError` at Import
-**Error**: `ValueError: API key is required` or similar from `ScrapeGraphTools` / `Mem0Tools`.
-**Cause**: The agent initializes all three tools at startup. If any key is missing or set to a placeholder, the tool constructor raises immediately.
-**Solution**: Ensure all three keys (`SCRAPEGRAPH_API_KEY`, `MEM0_API_KEY`, `OPENROUTER_API_KEY`) are set to real values in `examples/web-scraping-agent/.env` before running.
-
----
-
-**Built with ❤️ using the Bindu Agent Framework**
+With auth on, sign each body with the agent's DID key — see [`docs/AUTH.md`](../../docs/AUTH.md).

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -93,9 +93,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -121,9 +121,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -139,9 +139,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@types/node": {
@@ -255,22 +255,22 @@
       "license": "Apache-2.0"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },


### PR DESCRIPTION
## Summary

- **Dependency fixes (16 Dependabot alerts closed).** Three lockfiles patched:
  - `sdks/typescript/package-lock.json` — `protobufjs` 7.5.5 → 7.5.8, `@protobufjs/utf8` 1.1.0 → 1.1.1. Closes alerts #286–#293 (CVE-2026-44288 through CVE-2026-44294).
  - `examples/typescript-langchain-agent/` and `examples/typescript-langchain-quiz-agent/` — `@langchain/openai` `^0.4.0` → `^1.0.0`, which pulls in `@langchain/core@1.1.46` whose looser `langsmith` range (`>=0.5.0 <1.0.0`) lets npm resolve `langsmith` 0.3.87 → 0.7.1. Closes alerts #299–#306 (CVE-2026-25528, CVE-2026-40190, CVE-2026-41182, CVE-2026-45134 — each on both examples).
- **Docs sweep (5 README rewrites)** — `examples/summarizer`, `examples/weather-research`, `examples/web-scraping-agent`, `examples/premium-advisor`, `examples/news-summarizer` rewritten in the main-README voice. Riding on this branch because the news-summarizer commit also carried the dep fixes.

## Why the langsmith fix needed a parent bump

`@langchain/core@0.3.x` pinned `langsmith@^0.3.67`, which (since langsmith is pre-1.0) means `>=0.3.67 <0.4.0` — so straight `npm update langsmith` could not move past 0.3.87. Bumping `@langchain/openai` to `^1.0.0` brings in `@langchain/core@1.x`, which uses `>=0.5.0 <1.0.0` and resolves to a patched 0.7.1. The example code only uses `new ChatOpenAI(...)` and `llm.invoke(...)`, both stable across the 0.4 → 1.x major.

## Test plan

- [x] `npm install && npm run build` in `sdks/typescript` — passes
- [ ] Smoke-run `examples/typescript-langchain-agent` with \`OPENROUTER_API_KEY\` set, verify the agent still answers a prompt end-to-end
- [ ] Smoke-run `examples/typescript-langchain-quiz-agent` likewise
- [ ] Confirm the 16 Dependabot alerts auto-close once this lands on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified example setup guides across news summarizer, premium advisor, summarizer, weather research, and web scraping agents with streamlined instructions and clearer JSON-RPC request examples.
  * Updated documentation to reference authentication details in centralized auth guide.

* **Chores**
  * Updated `@langchain/openai` dependency to version 1.0.0 in TypeScript-based examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->