### PR TITLE
feat(mtls): end-to-end mTLS for A2A traffic (off by default)

### DIFF
--- a/bindu/auth/hydra/registration.py
+++ b/bindu/auth/hydra/registration.py
@@ -245,6 +245,17 @@ async def register_agent_in_hydra(
                 "response_types": ["code", "token"],
                 "scope": " ".join(app_settings.hydra.default_agent_scopes),
                 "token_endpoint_auth_method": "client_secret_post",
+                # When mTLS is on, the agent will exchange a Hydra token for
+                # an X.509 cert at step-ca. step-ca rejects tokens whose
+                # ``aud`` claim doesn't include its configured client ID, so
+                # we declare the allowed audience at client-registration
+                # time. Off-by-default to keep the blast radius zero for
+                # deployments not using mTLS.
+                **(
+                    {"audience": [app_settings.mtls.oidc_audience]}
+                    if app_settings.mtls.enabled
+                    else {}
+                ),
                 "metadata": {
                     "agent_id": agent_id,
                     "agent_url": agent_url,

--- a/bindu/extensions/mtls/__init__.py
+++ b/bindu/extensions/mtls/__init__.py
@@ -1,0 +1,44 @@
+# |---------------------------------------------------------|
+# |                                                         |
+# |                 Give Feedback / Get Help                |
+# | https://github.com/getbindu/Bindu/issues/new/choose    |
+# |                                                         |
+# |---------------------------------------------------------|
+#
+#  Thank you users! We ❤️ you! - 🌻
+
+"""mTLS Extension for Bindu Agents.
+
+Why is mTLS an Extension?
+-------------------------
+Like the DID extension, mTLS provides an optional capability layered on top of the
+core A2A protocol. Agents that opt in fetch short-lived X.509 certificates from a
+shared Smallstep step-ca server and use them to encrypt agent-to-agent traffic at
+the transport layer.
+
+This extension owns three responsibilities:
+
+1. **Bootstrap** — at agent startup, exchange a Hydra OIDC token for an X.509
+   certificate signed by the cluster's intermediate CA.
+2. **Storage** — write cert/key/CA-bundle next to the DID keypair so a single
+   PKI directory captures the agent's full identity, with Vault backup when
+   available.
+3. **Renewal** — re-fetch the certificate before expiry. Short TTL plus passive
+   renewal is the revocation strategy; there is no CRL.
+
+The CA deployment lives in ``infragrid/bindu-prod-cluster/step-ca-deploy/`` and
+serves ``https://ca.getbindu.com``. See ``docs/MTLS_DEPLOYMENT_GUIDE.md`` for
+the full architecture.
+"""
+
+from __future__ import annotations
+
+from bindu.extensions.mtls.cert_store import CertStore
+from bindu.extensions.mtls.mtls_agent_extension import MTLSAgentExtension
+from bindu.extensions.mtls.step_ca_client import StepCAClient
+
+__all__ = [
+    "CertStore",
+    "MTLSAgentExtension",
+    "StepCAClient",
+]

--- a/bindu/extensions/mtls/cert_store.py
+++ b/bindu/extensions/mtls/cert_store.py
@@ -1,0 +1,261 @@
+# |---------------------------------------------------------|
+# |                                                         |
+# |                 Give Feedback / Get Help                |
+# | https://github.com/getbindu/Bindu/issues/new/choose    |
+# |                                                         |
+# |---------------------------------------------------------|
+#
+#  Thank you users! We ❤️ you! - 🌻
+
+"""On-disk storage for X.509 certificates, keys, and the CA bundle.
+
+Pure leaf logic — no network, no orchestration. The store owns path resolution
+inside the agent's PKI directory, atomic writes with POSIX permission bits, and
+the EC keypair / CSR / fingerprint helpers used by the rest of the mTLS
+extension.
+
+Files written by this module
+----------------------------
+``{pki_dir}/tls_key.pem``     EC P-256 private key (mode 0o600)
+``{pki_dir}/tls_cert.pem``    Agent X.509 certificate (mode 0o644)
+``{pki_dir}/ca_bundle.pem``   Intermediate + root chain (mode 0o644)
+``{pki_dir}/tls.csr``         Last CSR sent to step-ca (mode 0o644, debug only)
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Tuple
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from bindu.settings import app_settings
+from bindu.utils.logging import get_logger
+
+logger = get_logger("bindu.mtls.cert_store")
+
+
+class CertStore:
+    """File-backed store for an agent's mTLS material.
+
+    Instances are bound to a single PKI directory — typically the same directory
+    the DID extension already uses, so cert files live next to the Ed25519
+    keypair. Callers are responsible for creating the directory before
+    constructing the store.
+    """
+
+    def __init__(self, pki_dir: Path):
+        """Bind the store to a PKI directory.
+
+        Args:
+            pki_dir: Directory that already exists and is writable by the agent
+                process. The DID extension creates this directory on startup;
+                the mTLS extension reuses it.
+        """
+        self.pki_dir = Path(pki_dir)
+        cfg = app_settings.mtls
+        self.cert_path = self.pki_dir / cfg.cert_filename
+        self.key_path = self.pki_dir / cfg.key_filename
+        self.ca_bundle_path = self.pki_dir / cfg.ca_bundle_filename
+        self.csr_path = self.pki_dir / cfg.csr_filename
+
+    # ------------------------------------------------------------------
+    # Existence checks
+    # ------------------------------------------------------------------
+
+    def has_cert(self) -> bool:
+        """Return True when both the cert and its private key are on disk."""
+        return self.cert_path.is_file() and self.key_path.is_file()
+
+    def has_ca_bundle(self) -> bool:
+        """Return True when the CA bundle PEM is on disk."""
+        return self.ca_bundle_path.is_file()
+
+    # ------------------------------------------------------------------
+    # Read helpers
+    # ------------------------------------------------------------------
+
+    def read_cert(self) -> bytes:
+        """Return the cert PEM bytes. Raises FileNotFoundError if missing."""
+        return self.cert_path.read_bytes()
+
+    def read_key(self) -> bytes:
+        """Return the private-key PEM bytes. Raises FileNotFoundError if missing."""
+        return self.key_path.read_bytes()
+
+    def read_ca_bundle(self) -> bytes:
+        """Return the CA-bundle PEM bytes. Raises FileNotFoundError if missing."""
+        return self.ca_bundle_path.read_bytes()
+
+    # ------------------------------------------------------------------
+    # Write helpers — atomic, POSIX-aware
+    # ------------------------------------------------------------------
+
+    def write_cert(self, cert_pem: bytes) -> None:
+        """Write the agent cert PEM with mode 0o644."""
+        _write_bytes(self.cert_path, cert_pem, mode=0o644)
+
+    def write_key(self, key_pem: bytes) -> None:
+        """Write the private-key PEM with mode 0o600 (owner-only on POSIX)."""
+        _write_bytes(self.key_path, key_pem, mode=0o600)
+
+    def write_ca_bundle(self, bundle_pem: bytes) -> None:
+        """Write the CA bundle PEM with mode 0o644."""
+        _write_bytes(self.ca_bundle_path, bundle_pem, mode=0o644)
+
+    def write_csr(self, csr_pem: bytes) -> None:
+        """Persist the most recent CSR for debugging."""
+        _write_bytes(self.csr_path, csr_pem, mode=0o644)
+
+    # ------------------------------------------------------------------
+    # Keypair + CSR generation
+    # ------------------------------------------------------------------
+
+    def generate_keypair(self) -> Tuple[ec.EllipticCurvePrivateKey, bytes]:
+        """Generate a fresh EC P-256 keypair and persist the private key.
+
+        Returns:
+            Tuple of (private-key object, PEM bytes) so callers can build a CSR
+            without re-reading from disk.
+        """
+        private_key = ec.generate_private_key(ec.SECP256R1())
+        key_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        self.write_key(key_pem)
+        return private_key, key_pem
+
+    def load_private_key(self) -> ec.EllipticCurvePrivateKey:
+        """Load the EC private key from disk. Raises FileNotFoundError if missing."""
+        key_pem = self.read_key()
+        key = serialization.load_pem_private_key(key_pem, password=None)
+        if not isinstance(key, ec.EllipticCurvePrivateKey):
+            raise TypeError(
+                f"Expected EC private key in {self.key_path}, got {type(key).__name__}"
+            )
+        return key
+
+    def build_csr(
+        self,
+        private_key: ec.EllipticCurvePrivateKey,
+        agent_did: str,
+        agent_url: Optional[str] = None,
+    ) -> bytes:
+        """Build a CSR with the agent DID in CN and a URI SAN.
+
+        The CN carries the DID for legacy peers that authenticate by subject;
+        modern peers should rely on the URI SAN. When ``agent_url`` is provided
+        and parseable, its hostname is also added as a DNS SAN so off-the-shelf
+        TLS clients can verify by hostname.
+
+        Args:
+            private_key: EC private key returned by ``generate_keypair``.
+            agent_did: Fully-qualified DID, e.g. ``did:bindu:author:name:id``.
+            agent_url: Optional agent base URL, e.g. ``https://agent.example.com``.
+
+        Returns:
+            PEM-encoded CSR bytes. The caller is responsible for sending it to
+            step-ca; this method does not perform I/O.
+        """
+        san_entries: list[x509.GeneralName] = [
+            x509.UniformResourceIdentifier(agent_did)
+        ]
+        if agent_url:
+            host = _hostname_from_url(agent_url)
+            if host:
+                san_entries.append(x509.DNSName(host))
+
+        builder = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, agent_did)])
+            )
+            .add_extension(x509.SubjectAlternativeName(san_entries), critical=False)
+        )
+        csr = builder.sign(private_key, hashes.SHA256())
+        csr_pem = csr.public_bytes(serialization.Encoding.PEM)
+        self.write_csr(csr_pem)
+        return csr_pem
+
+    # ------------------------------------------------------------------
+    # Inspection
+    # ------------------------------------------------------------------
+
+    def get_cert_expiry(self) -> Optional[datetime]:
+        """Return the cert's notAfter as a tz-aware UTC datetime, or None.
+
+        Returns None when the cert file is missing or unparseable. Callers
+        should treat None as "renewal needed" rather than raising.
+        """
+        if not self.cert_path.is_file():
+            return None
+        try:
+            cert = x509.load_pem_x509_certificate(self.cert_path.read_bytes())
+        except ValueError as exc:
+            logger.warning("Could not parse cert at %s: %s", self.cert_path, exc)
+            return None
+        # ``not_valid_after_utc`` was added in cryptography 42.0; fall back for older.
+        not_after = getattr(cert, "not_valid_after_utc", None)
+        if not_after is None:
+            not_after = cert.not_valid_after.replace(tzinfo=timezone.utc)
+        return not_after
+
+    def is_renewal_due(self, renew_before_hours: int) -> bool:
+        """Return True when the cert is missing, unparseable, or near expiry."""
+        expiry = self.get_cert_expiry()
+        if expiry is None:
+            return True
+        remaining = expiry - datetime.now(timezone.utc)
+        return remaining.total_seconds() < renew_before_hours * 3600
+
+    def get_cert_fingerprint(self) -> Optional[str]:
+        """Return the SHA-256 fingerprint of the cert as a colon-separated hex string.
+
+        Suitable for ``AgentTrust.certificate_fingerprint``. Returns None when
+        the cert file is missing.
+        """
+        if not self.cert_path.is_file():
+            return None
+        cert = x509.load_pem_x509_certificate(self.cert_path.read_bytes())
+        digest = cert.fingerprint(hashes.SHA256())
+        return ":".join(f"{b:02x}" for b in digest)
+
+
+# ----------------------------------------------------------------------
+# Private helpers
+# ----------------------------------------------------------------------
+
+
+def _write_bytes(path: Path, data: bytes, *, mode: int) -> None:
+    """Write ``data`` to ``path`` with the requested POSIX mode.
+
+    Mirrors the DID extension's approach: on POSIX, use ``os.open`` so the
+    permission bits are set atomically at creation; on Windows, fall back to
+    a plain write because the filesystem ignores POSIX modes anyway.
+    """
+    if platform.system() == "Windows":
+        path.write_bytes(data)
+        return
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+
+
+def _hostname_from_url(url: str) -> Optional[str]:
+    """Extract the hostname from a URL, returning None on parse failure."""
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    return parsed.hostname

--- a/bindu/extensions/mtls/mtls_agent_extension.py
+++ b/bindu/extensions/mtls/mtls_agent_extension.py
@@ -282,24 +282,57 @@ class MTLSAgentExtension:
             )
 
     # ------------------------------------------------------------------
-    # Client material (Phase 4)
+    # Client material
     # ------------------------------------------------------------------
 
-    def get_httpx_client_kwargs(self) -> dict:
+    def build_client_ssl_context(self) -> ssl.SSLContext:
+        """Return an ``ssl.SSLContext`` for outbound (client-side) connections.
+
+        The context carries this agent's cert/key as the client identity and
+        trusts the CA bundle for verifying peer (server) certs. Suitable for
+        passing as ``ssl=...`` to ``aiohttp.TCPConnector`` or as ``verify=...``
+        / ``cert=...`` to httpx.
+        """
+        self._require_initialized()
+        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        context.load_cert_chain(
+            certfile=str(self._store.cert_path),
+            keyfile=str(self._store.key_path),
+        )
+        context.load_verify_locations(cafile=str(self._store.ca_bundle_path))
+        context.check_hostname = app_settings.mtls.verify_server_cert
+        context.verify_mode = (
+            ssl.CERT_REQUIRED if app_settings.mtls.verify_server_cert else ssl.CERT_NONE
+        )
+        return context
+
+    def get_httpx_client_kwargs(self) -> dict[str, Any]:
         """Return kwargs to splat into ``httpx.AsyncClient(...)``.
 
-        Includes ``cert=(cert_path, key_path)`` and ``verify=ca_bundle_path``
-        so outbound calls authenticate as this agent and validate peers
-        against the cluster CA.
+        Hands httpx the cert+key tuple and the CA-bundle path. The project's
+        primary HTTP client is aiohttp-backed (``AsyncHTTPClient``), but this
+        is provided for any callers that integrate with httpx directly.
         """
-        raise NotImplementedError(
-            "MTLSAgentExtension.get_httpx_client_kwargs lands in Phase 4"
-        )
+        self._require_initialized()
+        return {
+            "cert": (str(self._store.cert_path), str(self._store.key_path)),
+            "verify": str(self._store.ca_bundle_path),
+        }
 
-    def build_grpc_channel_credentials(self):
-        """Return ``grpc.ChannelCredentials`` for outbound gRPC."""
-        raise NotImplementedError(
-            "MTLSAgentExtension.build_grpc_channel_credentials lands in Phase 4"
+    def build_grpc_channel_credentials(self) -> grpc.ChannelCredentials:
+        """Return ``grpc.ChannelCredentials`` for outbound gRPC.
+
+        Built from the same on-disk PEM files as the server credentials so a
+        downgrade is impossible.
+        """
+        self._require_initialized()
+        cert = self._store.read_cert()
+        key = self._store.read_key()
+        ca_bundle = self._store.read_ca_bundle()
+        return grpc.ssl_channel_credentials(
+            root_certificates=ca_bundle,
+            private_key=key,
+            certificate_chain=cert,
         )
 
     # ------------------------------------------------------------------

--- a/bindu/extensions/mtls/mtls_agent_extension.py
+++ b/bindu/extensions/mtls/mtls_agent_extension.py
@@ -26,6 +26,7 @@ Phase coverage
 
 from __future__ import annotations
 
+import asyncio
 import ssl
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional
@@ -161,9 +162,50 @@ class MTLSAgentExtension:
             still good or when step-ca is unreachable and the cycle is
             skipped.
         """
-        raise NotImplementedError(
-            "MTLSAgentExtension.renew_if_needed lands in Phase 6 of the mTLS rollout"
+        if not self._store.is_renewal_due(app_settings.mtls.renew_before_hours):
+            return False
+        # step-ca down? Don't burn cycles thrashing — wait for the next tick.
+        # The cert has hours of headroom by design, so a few missed cycles
+        # are fine.
+        if not await self._ca.health_check():
+            logger.warning("step-ca unhealthy; deferring renewal")
+            return False
+        logger.info(
+            "mTLS cert near expiry (renew_before_hours=%d); renewing",
+            app_settings.mtls.renew_before_hours,
         )
+        return await self.initialize(force_renew=True)
+
+    async def run_renewal_loop(self, interval_seconds: int | None = None) -> None:
+        """Run the renewal check forever; intended for ``asyncio.create_task``.
+
+        Sleeps for ``interval_seconds`` between checks (defaults to
+        ``MTLSSettings.renew_check_interval_seconds``). Exits cleanly on
+        cancellation; logs and continues on any other exception.
+
+        Args:
+            interval_seconds: Override for the renew check cadence. The
+                renewal margin (``renew_before_hours``) gives the loop ample
+                room to miss a check or two without the cert lapsing.
+        """
+        interval = (
+            interval_seconds
+            if interval_seconds is not None
+            else app_settings.mtls.renew_check_interval_seconds
+        )
+        logger.info("mTLS renewal loop started (interval=%ds)", interval)
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                try:
+                    await self.renew_if_needed()
+                except Exception as exc:  # noqa: BLE001
+                    # Renewal loop must never die from a transient error;
+                    # logging + continuing is the right shape.
+                    logger.exception("mTLS renewal cycle failed: %s", exc)
+        except asyncio.CancelledError:
+            logger.info("mTLS renewal loop cancelled")
+            raise
 
     async def close(self) -> None:
         """Release the underlying step-ca HTTP sessions."""

--- a/bindu/extensions/mtls/mtls_agent_extension.py
+++ b/bindu/extensions/mtls/mtls_agent_extension.py
@@ -14,27 +14,33 @@ the on-disk cert store, and the step-ca client. It mirrors the role
 ``DIDAgentExtension`` plays for identity — both are constructed once at
 startup and reused for the lifetime of the agent.
 
-Phase 1 scope (this commit)
----------------------------
-- Class signature, settings/state wiring, property surface.
-- Method skeletons documenting the public API.
-
-Phase 2 will land the bootstrap flow (cert fetch + Vault backup), Phase 3 the
-server TLS wrapping (``ssl.SSLContext`` + gRPC server credentials), Phase 4
-the client TLS wrapping, and Phase 6 the in-process renewal task.
+Phase coverage
+--------------
+* Phase 2 (this commit): ``initialize()`` bootstraps the agent's cert from
+  step-ca and persists it. Server / client material builders and the
+  background renewal task remain stubs.
+* Phase 3 will return live ``ssl.SSLContext`` and ``grpc.ServerCredentials``.
+* Phase 4 will hand outbound clients their cert/key.
+* Phase 6 will land the renewal loop.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
 from bindu.extensions.mtls.cert_store import CertStore
-from bindu.extensions.mtls.step_ca_client import StepCAClient
+from bindu.extensions.mtls.step_ca_client import StepCAClient, StepCAError
 from bindu.settings import app_settings
 from bindu.utils.logging import get_logger
 
 logger = get_logger("bindu.mtls.extension")
+
+
+# A token provider is any async callable returning a Hydra OIDC access token.
+# Injecting it keeps the extension free of direct Hydra imports — the wiring
+# lives in ``bindu.penguin.mtls_setup``.
+OIDCTokenProvider = Callable[[], Awaitable[str]]
 
 
 class MTLSAgentExtension:
@@ -58,7 +64,9 @@ class MTLSAgentExtension:
         pki_dir: Path,
         agent_did: str,
         agent_url: Optional[str] = None,
-        oidc_token_provider=None,
+        oidc_token_provider: Optional[OIDCTokenProvider] = None,
+        step_ca: Optional[StepCAClient] = None,
+        cert_store: Optional[CertStore] = None,
     ):
         """Wire dependencies.
 
@@ -73,35 +81,74 @@ class MTLSAgentExtension:
             oidc_token_provider: Async callable returning a fresh Hydra OIDC
                 token. Injected so the extension does not import Hydra glue
                 directly, keeping the dependency graph one-way.
+            step_ca: Optional pre-built step-ca client. Tests pass a fake;
+                production code lets the constructor build one from settings.
+            cert_store: Optional pre-built cert store. Same rationale as
+                ``step_ca``.
         """
         self.pki_dir = Path(pki_dir)
         self.agent_did = agent_did
         self.agent_url = agent_url
         self._oidc_token_provider = oidc_token_provider
-        self._store = CertStore(self.pki_dir)
-        self._ca = StepCAClient()
+        self._store = cert_store if cert_store is not None else CertStore(self.pki_dir)
+        self._ca = step_ca if step_ca is not None else StepCAClient()
         self._initialized = False
 
     # ------------------------------------------------------------------
-    # Lifecycle (bodies land in Phase 2 and Phase 6)
+    # Lifecycle
     # ------------------------------------------------------------------
 
-    async def initialize(self) -> bool:
+    async def initialize(self, force_renew: bool = False) -> bool:
         """Bootstrap the agent's mTLS material.
 
         Steps:
             1. Ensure the CA bundle is on disk (fetch from step-ca if missing).
-            2. If a valid cert exists and is not near expiry, use it.
-            3. Otherwise generate a fresh keypair + CSR and sign via step-ca.
-            4. Optionally back up to Vault.
+            2. If a valid cert exists and is not near expiry — and ``force_renew``
+               is False — reuse it.
+            3. Otherwise generate a fresh keypair + CSR and have step-ca sign it.
+
+        Args:
+            force_renew: When True, skip the reuse-existing-cert path and
+                always go to step-ca. The renewal loop sets this to True.
 
         Returns:
-            True on success. Logs and returns False on a recoverable failure;
-            raises only on misconfiguration the operator must fix.
+            True on success. Logs and returns False on recoverable failure
+            (e.g. step-ca temporarily unreachable); raises only on
+            misconfiguration the operator must fix.
         """
-        raise NotImplementedError(
-            "MTLSAgentExtension.initialize lands in Phase 2 of the mTLS rollout"
-        )
+        if self._oidc_token_provider is None:
+            raise RuntimeError(
+                "MTLSAgentExtension.initialize() requires an oidc_token_provider; "
+                "the agent must complete Hydra registration first."
+            )
+
+        try:
+            await self._ensure_ca_bundle()
+            renewal_due = self._store.is_renewal_due(
+                app_settings.mtls.renew_before_hours
+            )
+            if not force_renew and self._store.has_cert() and not renewal_due:
+                logger.info(
+                    "mTLS cert already on disk and valid (fingerprint=%s)",
+                    self._store.get_cert_fingerprint(),
+                )
+                self._initialized = True
+                return True
+
+            await self._issue_new_cert()
+            self._initialized = True
+            logger.info(
+                "mTLS bootstrap complete for %s (fingerprint=%s)",
+                self.agent_did,
+                self._store.get_cert_fingerprint(),
+            )
+            return True
+        except StepCAError as exc:
+            logger.error("mTLS bootstrap failed against step-ca: %s", exc)
+            return False
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Unexpected mTLS bootstrap error: %s", exc)
+            return False
 
     async def renew_if_needed(self) -> bool:
         """Re-issue the cert when fewer than ``renew_before_hours`` remain.
@@ -114,6 +161,48 @@ class MTLSAgentExtension:
         raise NotImplementedError(
             "MTLSAgentExtension.renew_if_needed lands in Phase 6 of the mTLS rollout"
         )
+
+    async def close(self) -> None:
+        """Release the underlying step-ca HTTP sessions."""
+        await self._ca.close()
+
+    # ------------------------------------------------------------------
+    # Internal — bootstrap steps
+    # ------------------------------------------------------------------
+
+    async def _ensure_ca_bundle(self) -> None:
+        """Fetch the CA bundle from step-ca when it isn't already on disk."""
+        if self._store.has_ca_bundle():
+            return
+        logger.info("Fetching CA bundle from step-ca…")
+        bundle = await self._ca.fetch_root_ca()
+        self._store.write_ca_bundle(bundle)
+
+    async def _issue_new_cert(self) -> None:
+        """Generate a keypair, build a CSR, and have step-ca sign it.
+
+        Always rotates the private key. Reusing a key across renewals would
+        defeat the point of having a short-TTL cert.
+        """
+        assert self._oidc_token_provider is not None  # type guard
+
+        private_key, _ = self._store.generate_keypair()
+        csr_pem = self._store.build_csr(
+            private_key, self.agent_did, agent_url=self.agent_url
+        )
+
+        token = await self._oidc_token_provider()
+        if not token:
+            raise StepCAError(
+                "OIDC token provider returned an empty token; Hydra likely rejected the credentials"
+            )
+
+        cert_pem, chain_pem = await self._ca.sign_csr(csr_pem, token)
+        self._store.write_cert(cert_pem)
+        # Refresh the CA bundle from the sign response — step-ca returns the
+        # currently-active chain, which may have rotated since the agent last
+        # fetched ``/roots.pem``.
+        self._store.write_ca_bundle(chain_pem)
 
     # ------------------------------------------------------------------
     # Server material (Phase 3)
@@ -179,3 +268,8 @@ class MTLSAgentExtension:
     def enabled(self) -> bool:
         """Convenience accessor for the global toggle."""
         return app_settings.mtls.enabled
+
+    @property
+    def initialized(self) -> bool:
+        """True once ``initialize()`` has completed successfully."""
+        return self._initialized

--- a/bindu/extensions/mtls/mtls_agent_extension.py
+++ b/bindu/extensions/mtls/mtls_agent_extension.py
@@ -1,0 +1,181 @@
+# |---------------------------------------------------------|
+# |                                                         |
+# |                 Give Feedback / Get Help                |
+# | https://github.com/getbindu/Bindu/issues/new/choose    |
+# |                                                         |
+# |---------------------------------------------------------|
+#
+#  Thank you users! We ❤️ you! - 🌻
+
+"""mTLS extension orchestrator for Bindu agents.
+
+This class is the integration seam between the agent bootstrap (``bindufy``),
+the on-disk cert store, and the step-ca client. It mirrors the role
+``DIDAgentExtension`` plays for identity — both are constructed once at
+startup and reused for the lifetime of the agent.
+
+Phase 1 scope (this commit)
+---------------------------
+- Class signature, settings/state wiring, property surface.
+- Method skeletons documenting the public API.
+
+Phase 2 will land the bootstrap flow (cert fetch + Vault backup), Phase 3 the
+server TLS wrapping (``ssl.SSLContext`` + gRPC server credentials), Phase 4
+the client TLS wrapping, and Phase 6 the in-process renewal task.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from bindu.extensions.mtls.cert_store import CertStore
+from bindu.extensions.mtls.step_ca_client import StepCAClient
+from bindu.settings import app_settings
+from bindu.utils.logging import get_logger
+
+logger = get_logger("bindu.mtls.extension")
+
+
+class MTLSAgentExtension:
+    """Lifecycle manager for an agent's X.509 certificate.
+
+    Owns three concerns:
+
+    1. **Bootstrap.** ``initialize()`` at agent startup — load from disk, or
+       fetch a fresh cert from step-ca using the agent's Hydra OIDC token.
+    2. **Server material.** Properties that hand the live HTTP and gRPC
+       servers everything they need to start in mTLS mode.
+    3. **Client material.** Properties that hand outbound HTTP/gRPC clients
+       the cert/key/CA-bundle they need to authenticate as this agent.
+
+    Renewal is driven externally by a periodic task that calls
+    ``renew_if_needed()``.
+    """
+
+    def __init__(
+        self,
+        pki_dir: Path,
+        agent_did: str,
+        agent_url: Optional[str] = None,
+        oidc_token_provider=None,
+    ):
+        """Wire dependencies.
+
+        Args:
+            pki_dir: Directory where cert material is persisted. The DID
+                extension creates this; we co-locate to keep a single backup
+                surface.
+            agent_did: The agent's DID. Used as CN and URI SAN in the CSR.
+            agent_url: Optional agent base URL. When provided, its hostname is
+                added as a DNS SAN so off-the-shelf TLS clients can verify by
+                hostname.
+            oidc_token_provider: Async callable returning a fresh Hydra OIDC
+                token. Injected so the extension does not import Hydra glue
+                directly, keeping the dependency graph one-way.
+        """
+        self.pki_dir = Path(pki_dir)
+        self.agent_did = agent_did
+        self.agent_url = agent_url
+        self._oidc_token_provider = oidc_token_provider
+        self._store = CertStore(self.pki_dir)
+        self._ca = StepCAClient()
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle (bodies land in Phase 2 and Phase 6)
+    # ------------------------------------------------------------------
+
+    async def initialize(self) -> bool:
+        """Bootstrap the agent's mTLS material.
+
+        Steps:
+            1. Ensure the CA bundle is on disk (fetch from step-ca if missing).
+            2. If a valid cert exists and is not near expiry, use it.
+            3. Otherwise generate a fresh keypair + CSR and sign via step-ca.
+            4. Optionally back up to Vault.
+
+        Returns:
+            True on success. Logs and returns False on a recoverable failure;
+            raises only on misconfiguration the operator must fix.
+        """
+        raise NotImplementedError(
+            "MTLSAgentExtension.initialize lands in Phase 2 of the mTLS rollout"
+        )
+
+    async def renew_if_needed(self) -> bool:
+        """Re-issue the cert when fewer than ``renew_before_hours`` remain.
+
+        Returns:
+            True when a renewal happened; False when the existing cert is
+            still good or when step-ca is unreachable and the cycle is
+            skipped.
+        """
+        raise NotImplementedError(
+            "MTLSAgentExtension.renew_if_needed lands in Phase 6 of the mTLS rollout"
+        )
+
+    # ------------------------------------------------------------------
+    # Server material (Phase 3)
+    # ------------------------------------------------------------------
+
+    def build_server_ssl_context(self):
+        """Return an ``ssl.SSLContext`` for uvicorn.
+
+        Configured with the agent cert/key, the CA bundle as the trust root
+        for peer verification, and ``CERT_REQUIRED`` when
+        ``mtls.require_client_cert`` is true.
+        """
+        raise NotImplementedError(
+            "MTLSAgentExtension.build_server_ssl_context lands in Phase 3"
+        )
+
+    def build_grpc_server_credentials(self):
+        """Return ``grpc.ServerCredentials`` for the gRPC bind.
+
+        Equivalent of ``ssl_server_credentials(..., require_client_auth=True)``
+        built from the same on-disk PEM files as the HTTP context.
+        """
+        raise NotImplementedError(
+            "MTLSAgentExtension.build_grpc_server_credentials lands in Phase 3"
+        )
+
+    # ------------------------------------------------------------------
+    # Client material (Phase 4)
+    # ------------------------------------------------------------------
+
+    def get_httpx_client_kwargs(self) -> dict:
+        """Return kwargs to splat into ``httpx.AsyncClient(...)``.
+
+        Includes ``cert=(cert_path, key_path)`` and ``verify=ca_bundle_path``
+        so outbound calls authenticate as this agent and validate peers
+        against the cluster CA.
+        """
+        raise NotImplementedError(
+            "MTLSAgentExtension.get_httpx_client_kwargs lands in Phase 4"
+        )
+
+    def build_grpc_channel_credentials(self):
+        """Return ``grpc.ChannelCredentials`` for outbound gRPC."""
+        raise NotImplementedError(
+            "MTLSAgentExtension.build_grpc_channel_credentials lands in Phase 4"
+        )
+
+    # ------------------------------------------------------------------
+    # Read-only properties
+    # ------------------------------------------------------------------
+
+    @property
+    def store(self) -> CertStore:
+        """Underlying ``CertStore``. Exposed for tests and diagnostic tooling."""
+        return self._store
+
+    @property
+    def cert_fingerprint(self) -> Optional[str]:
+        """SHA-256 fingerprint of the active cert, or None when no cert is on disk."""
+        return self._store.get_cert_fingerprint()
+
+    @property
+    def enabled(self) -> bool:
+        """Convenience accessor for the global toggle."""
+        return app_settings.mtls.enabled

--- a/bindu/extensions/mtls/mtls_agent_extension.py
+++ b/bindu/extensions/mtls/mtls_agent_extension.py
@@ -243,11 +243,16 @@ class MTLSAgentExtension:
             )
 
         cert_pem, chain_pem = await self._ca.sign_csr(csr_pem, token)
-        self._store.write_cert(cert_pem)
-        # Refresh the CA bundle from the sign response — step-ca returns the
-        # currently-active chain, which may have rotated since the agent last
-        # fetched ``/roots.pem``.
-        self._store.write_ca_bundle(chain_pem)
+        # Write the leaf + intermediate concatenated so the TLS handshake
+        # presents the full chain to peers. step-ca's response is shaped:
+        #   crt = leaf
+        #   ca  = the intermediate that signed the leaf
+        # The trust anchor (root) is fetched separately via
+        # ``_ensure_ca_bundle`` and lives in ``ca_bundle.pem``; we
+        # deliberately do NOT overwrite it here. Doing so would replace
+        # the root with the intermediate, leaving peers unable to verify
+        # any chain back to the trust anchor.
+        self._store.write_cert(cert_pem + chain_pem)
 
     # ------------------------------------------------------------------
     # Server material

--- a/bindu/extensions/mtls/mtls_agent_extension.py
+++ b/bindu/extensions/mtls/mtls_agent_extension.py
@@ -26,8 +26,11 @@ Phase coverage
 
 from __future__ import annotations
 
+import ssl
 from pathlib import Path
-from typing import Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional
+
+import grpc
 
 from bindu.extensions.mtls.cert_store import CertStore
 from bindu.extensions.mtls.step_ca_client import StepCAClient, StepCAError
@@ -205,29 +208,78 @@ class MTLSAgentExtension:
         self._store.write_ca_bundle(chain_pem)
 
     # ------------------------------------------------------------------
-    # Server material (Phase 3)
+    # Server material
     # ------------------------------------------------------------------
 
-    def build_server_ssl_context(self):
-        """Return an ``ssl.SSLContext`` for uvicorn.
+    def build_server_ssl_context(self) -> ssl.SSLContext:
+        """Return an ``ssl.SSLContext`` configured for mTLS.
 
-        Configured with the agent cert/key, the CA bundle as the trust root
-        for peer verification, and ``CERT_REQUIRED`` when
-        ``mtls.require_client_cert`` is true.
+        The context loads the agent cert/key as the server identity and the
+        CA bundle as the trust root for verifying peer (client) certs. Verify
+        mode is ``CERT_REQUIRED`` when ``mtls.require_client_cert`` is true
+        (full mTLS) or ``CERT_OPTIONAL`` otherwise.
+
+        Raises:
+            FileNotFoundError: when cert / key / CA-bundle are not on disk.
+                ``initialize()`` must run first.
         """
-        raise NotImplementedError(
-            "MTLSAgentExtension.build_server_ssl_context lands in Phase 3"
+        self._require_initialized()
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.load_cert_chain(
+            certfile=str(self._store.cert_path),
+            keyfile=str(self._store.key_path),
         )
+        context.load_verify_locations(cafile=str(self._store.ca_bundle_path))
+        context.verify_mode = (
+            ssl.CERT_REQUIRED
+            if app_settings.mtls.require_client_cert
+            else ssl.CERT_OPTIONAL
+        )
+        return context
 
-    def build_grpc_server_credentials(self):
+    def get_uvicorn_ssl_kwargs(self) -> dict[str, Any]:
+        """Return the ``ssl_*`` kwargs to splat into ``uvicorn.run(...)``.
+
+        Uvicorn accepts file paths and an ssl_cert_reqs flag rather than a
+        constructed ``SSLContext``, so this method hands back the file-path
+        form. Use ``build_server_ssl_context`` when a Python ``SSLContext`` is
+        needed directly (tests, diagnostics).
+        """
+        self._require_initialized()
+        return {
+            "ssl_certfile": str(self._store.cert_path),
+            "ssl_keyfile": str(self._store.key_path),
+            "ssl_ca_certs": str(self._store.ca_bundle_path),
+            "ssl_cert_reqs": (
+                ssl.CERT_REQUIRED
+                if app_settings.mtls.require_client_cert
+                else ssl.CERT_OPTIONAL
+            ),
+        }
+
+    def build_grpc_server_credentials(self) -> grpc.ServerCredentials:
         """Return ``grpc.ServerCredentials`` for the gRPC bind.
 
-        Equivalent of ``ssl_server_credentials(..., require_client_auth=True)``
-        built from the same on-disk PEM files as the HTTP context.
+        Built from the same on-disk PEM files as the HTTP context, so an
+        attacker can't downgrade by hitting the gRPC port instead.
         """
-        raise NotImplementedError(
-            "MTLSAgentExtension.build_grpc_server_credentials lands in Phase 3"
+        self._require_initialized()
+        cert = self._store.read_cert()
+        key = self._store.read_key()
+        ca_bundle = self._store.read_ca_bundle()
+        return grpc.ssl_server_credentials(
+            [(key, cert)],
+            root_certificates=ca_bundle,
+            require_client_auth=app_settings.mtls.require_client_cert,
         )
+
+    def _require_initialized(self) -> None:
+        """Guard rail — server material is only valid post-bootstrap."""
+        if not self._store.has_cert():
+            raise FileNotFoundError(
+                f"No mTLS cert at {self._store.cert_path}; "
+                "call MTLSAgentExtension.initialize() before building server material"
+            )
 
     # ------------------------------------------------------------------
     # Client material (Phase 4)

--- a/bindu/extensions/mtls/step_ca_client.py
+++ b/bindu/extensions/mtls/step_ca_client.py
@@ -13,25 +13,31 @@ This module owns the on-the-wire contract with the CA. The cert store handles
 disk; this client handles the network. ``MTLSAgentExtension`` orchestrates the
 two.
 
-Scope for Phase 1 (this commit)
--------------------------------
-- Class signature, dependency wiring, settings binding.
-- Method signatures and docstrings so callers can program against the surface.
+The contract follows the step-ca REST API as described in
+``docs/MTLS_DEPLOYMENT_GUIDE.md`` section 8:
 
-Method bodies arrive in Phase 2 once a step-ca instance is reachable from a
-dev environment. Until then, every network call raises ``NotImplementedError``
-so a misconfigured ``mtls.enabled = True`` fails loudly rather than silently
-shipping an insecure agent.
+* ``GET {ca_root_url}`` — fetch the trust-anchor PEM (no auth).
+* ``POST {ca_url}/1.0/sign`` — body ``{"csr", "ott", "notAfter"}``; the ``ott``
+  is a Hydra-issued OIDC token validated by step-ca's OIDC provisioner.
+  Response: ``{"crt", "ca"}``.
+* ``GET {ca_url}/health`` — returns 200 when step-ca is healthy.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Tuple
+from urllib.parse import urlparse
 
 from bindu.settings import app_settings
+from bindu.utils.http import AsyncHTTPClient
 from bindu.utils.logging import get_logger
 
 logger = get_logger("bindu.mtls.step_ca")
+
+
+class StepCAError(RuntimeError):
+    """Raised when step-ca returns an unexpected response shape or status."""
 
 
 class StepCAClient:
@@ -40,6 +46,10 @@ class StepCAClient:
     The CA is shared infrastructure deployed at ``app_settings.mtls.ca_url``.
     Each agent talks to it twice per cert lifecycle: once to fetch the root
     bundle for peer verification, and once per renewal to sign a CSR.
+
+    Two underlying ``AsyncHTTPClient`` instances are used because the root
+    bundle is often served from a different host (a static well-known URL)
+    than the signing API.
     """
 
     def __init__(
@@ -49,6 +59,7 @@ class StepCAClient:
         provisioner: str | None = None,
         timeout: int | None = None,
         verify_ssl: bool | None = None,
+        max_retries: int | None = None,
     ):
         """Configure the client.
 
@@ -57,16 +68,55 @@ class StepCAClient:
         tests can override individual fields.
         """
         cfg = app_settings.mtls
-        self.ca_url = ca_url if ca_url is not None else cfg.ca_url
+        self.ca_url = (ca_url if ca_url is not None else cfg.ca_url).rstrip("/")
         self.ca_root_url = ca_root_url if ca_root_url is not None else cfg.ca_root_url
         self.provisioner = (
             provisioner if provisioner is not None else cfg.ca_provisioner
         )
         self.timeout = timeout if timeout is not None else cfg.timeout
         self.verify_ssl = verify_ssl if verify_ssl is not None else cfg.verify_ssl
+        self.max_retries = max_retries if max_retries is not None else cfg.max_retries
+
+        self._api_client = AsyncHTTPClient(
+            base_url=self.ca_url,
+            timeout=self.timeout,
+            verify_ssl=self.verify_ssl,
+            max_retries=self.max_retries,
+            default_headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+
+        # The roots URL may live on a different host (e.g. a static CDN) than
+        # the signing API, so it gets its own client. Splitting the URL into
+        # base + path keeps the request shape consistent with the rest of the
+        # codebase, which always passes an endpoint to ``AsyncHTTPClient``.
+        parsed = urlparse(self.ca_root_url)
+        self._roots_base = f"{parsed.scheme}://{parsed.netloc}"
+        self._roots_path = parsed.path or "/roots.pem"
+        self._roots_client = AsyncHTTPClient(
+            base_url=self._roots_base,
+            timeout=self.timeout,
+            verify_ssl=self.verify_ssl,
+            max_retries=self.max_retries,
+        )
+
+    async def __aenter__(self) -> "StepCAClient":
+        """Async context manager entry. Returns self for ``async with`` usage."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Async context manager exit. Closes underlying HTTP sessions."""
+        await self.close()
+
+    async def close(self) -> None:
+        """Release both underlying HTTP sessions."""
+        await self._api_client.close()
+        await self._roots_client.close()
 
     # ------------------------------------------------------------------
-    # Public API (bodies land in Phase 2)
+    # Public API
     # ------------------------------------------------------------------
 
     async def fetch_root_ca(self) -> bytes:
@@ -77,13 +127,23 @@ class StepCAClient:
             should trust when verifying peers.
 
         Raises:
-            NotImplementedError: until Phase 2 wires the HTTP call.
+            StepCAError: when the response is not a PEM bundle.
         """
-        raise NotImplementedError(
-            "StepCAClient.fetch_root_ca lands in Phase 2 of the mTLS rollout"
-        )
+        logger.debug("Fetching CA bundle from %s", self.ca_root_url)
+        response = await self._roots_client.get(self._roots_path)
+        body = response._body if hasattr(response, "_body") else await response.read()
+        if not body or b"BEGIN CERTIFICATE" not in body:
+            raise StepCAError(
+                f"CA bundle endpoint {self.ca_root_url} did not return a PEM payload"
+            )
+        return body
 
-    async def sign_csr(self, csr_pem: bytes, oidc_token: str) -> Tuple[bytes, bytes]:
+    async def sign_csr(
+        self,
+        csr_pem: bytes,
+        oidc_token: str,
+        ttl_hours: int | None = None,
+    ) -> Tuple[bytes, bytes]:
         """Submit a CSR to step-ca and return the signed certificate.
 
         Args:
@@ -91,27 +151,47 @@ class StepCAClient:
             oidc_token: A Hydra-issued OIDC token. step-ca's OIDC provisioner
                 validates this against Hydra's JWKS endpoint to authorize the
                 signing request.
+            ttl_hours: Override for the requested cert lifetime. Defaults to
+                ``MTLSSettings.cert_ttl_hours``. step-ca may clamp this to the
+                provisioner's configured max.
 
         Returns:
             ``(cert_pem, chain_pem)`` — the agent cert and the intermediate
             chain. Callers concatenate the two when serving TLS.
-
-        Raises:
-            NotImplementedError: until Phase 2 wires the HTTP call.
         """
-        raise NotImplementedError(
-            "StepCAClient.sign_csr lands in Phase 2 of the mTLS rollout"
+        ttl = ttl_hours if ttl_hours is not None else app_settings.mtls.cert_ttl_hours
+        not_after = (datetime.now(timezone.utc) + timedelta(hours=ttl)).isoformat()
+        body = {
+            "csr": csr_pem.decode("ascii"),
+            "ott": oidc_token,
+            "notAfter": not_after,
+        }
+        logger.debug(
+            "Signing CSR via %s/1.0/sign (notAfter=%s)", self.ca_url, not_after
         )
+        response = await self._api_client.post(
+            "/1.0/sign",
+            json=body,
+            headers={"Authorization": f"Bearer {oidc_token}"},
+        )
+        data = await response.json()
+        if not isinstance(data, dict) or "crt" not in data or "ca" not in data:
+            raise StepCAError(
+                f"Unexpected sign response shape from step-ca: keys={list(data.keys()) if isinstance(data, dict) else type(data)}"
+            )
+        cert_pem = data["crt"].encode("ascii")
+        chain_pem = data["ca"].encode("ascii")
+        return cert_pem, chain_pem
 
     async def health_check(self) -> bool:
         """Return True when step-ca's ``/health`` endpoint reports OK.
 
-        Used by the renewal loop to skip a renewal cycle when the CA is
-        unreachable rather than thrashing on a failing endpoint.
-
-        Raises:
-            NotImplementedError: until Phase 2 wires the HTTP call.
+        Never raises — connection errors are logged and treated as unhealthy
+        so the renewal loop can skip a cycle rather than crash the agent.
         """
-        raise NotImplementedError(
-            "StepCAClient.health_check lands in Phase 2 of the mTLS rollout"
-        )
+        try:
+            response = await self._api_client.get("/health")
+            return response.status == 200
+        except Exception as exc:  # noqa: BLE001 - intentional broad catch
+            logger.warning("step-ca health check at %s failed: %s", self.ca_url, exc)
+            return False

--- a/bindu/extensions/mtls/step_ca_client.py
+++ b/bindu/extensions/mtls/step_ca_client.py
@@ -1,0 +1,117 @@
+# |---------------------------------------------------------|
+# |                                                         |
+# |                 Give Feedback / Get Help                |
+# | https://github.com/getbindu/Bindu/issues/new/choose    |
+# |                                                         |
+# |---------------------------------------------------------|
+#
+#  Thank you users! We ❤️ you! - 🌻
+
+"""HTTP client for Smallstep step-ca.
+
+This module owns the on-the-wire contract with the CA. The cert store handles
+disk; this client handles the network. ``MTLSAgentExtension`` orchestrates the
+two.
+
+Scope for Phase 1 (this commit)
+-------------------------------
+- Class signature, dependency wiring, settings binding.
+- Method signatures and docstrings so callers can program against the surface.
+
+Method bodies arrive in Phase 2 once a step-ca instance is reachable from a
+dev environment. Until then, every network call raises ``NotImplementedError``
+so a misconfigured ``mtls.enabled = True`` fails loudly rather than silently
+shipping an insecure agent.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from bindu.settings import app_settings
+from bindu.utils.logging import get_logger
+
+logger = get_logger("bindu.mtls.step_ca")
+
+
+class StepCAClient:
+    """Thin async wrapper around the step-ca REST API.
+
+    The CA is shared infrastructure deployed at ``app_settings.mtls.ca_url``.
+    Each agent talks to it twice per cert lifecycle: once to fetch the root
+    bundle for peer verification, and once per renewal to sign a CSR.
+    """
+
+    def __init__(
+        self,
+        ca_url: str | None = None,
+        ca_root_url: str | None = None,
+        provisioner: str | None = None,
+        timeout: int | None = None,
+        verify_ssl: bool | None = None,
+    ):
+        """Configure the client.
+
+        Each argument falls back to its ``MTLSSettings`` default when omitted,
+        so production code can construct ``StepCAClient()`` with no args and
+        tests can override individual fields.
+        """
+        cfg = app_settings.mtls
+        self.ca_url = ca_url if ca_url is not None else cfg.ca_url
+        self.ca_root_url = ca_root_url if ca_root_url is not None else cfg.ca_root_url
+        self.provisioner = (
+            provisioner if provisioner is not None else cfg.ca_provisioner
+        )
+        self.timeout = timeout if timeout is not None else cfg.timeout
+        self.verify_ssl = verify_ssl if verify_ssl is not None else cfg.verify_ssl
+
+    # ------------------------------------------------------------------
+    # Public API (bodies land in Phase 2)
+    # ------------------------------------------------------------------
+
+    async def fetch_root_ca(self) -> bytes:
+        """Fetch the CA bundle PEM from ``ca_root_url``.
+
+        Returns:
+            PEM bytes containing the root + intermediate chain that agents
+            should trust when verifying peers.
+
+        Raises:
+            NotImplementedError: until Phase 2 wires the HTTP call.
+        """
+        raise NotImplementedError(
+            "StepCAClient.fetch_root_ca lands in Phase 2 of the mTLS rollout"
+        )
+
+    async def sign_csr(self, csr_pem: bytes, oidc_token: str) -> Tuple[bytes, bytes]:
+        """Submit a CSR to step-ca and return the signed certificate.
+
+        Args:
+            csr_pem: PEM-encoded CSR produced by ``CertStore.build_csr``.
+            oidc_token: A Hydra-issued OIDC token. step-ca's OIDC provisioner
+                validates this against Hydra's JWKS endpoint to authorize the
+                signing request.
+
+        Returns:
+            ``(cert_pem, chain_pem)`` — the agent cert and the intermediate
+            chain. Callers concatenate the two when serving TLS.
+
+        Raises:
+            NotImplementedError: until Phase 2 wires the HTTP call.
+        """
+        raise NotImplementedError(
+            "StepCAClient.sign_csr lands in Phase 2 of the mTLS rollout"
+        )
+
+    async def health_check(self) -> bool:
+        """Return True when step-ca's ``/health`` endpoint reports OK.
+
+        Used by the renewal loop to skip a renewal cycle when the CA is
+        unreachable rather than thrashing on a failing endpoint.
+
+        Raises:
+            NotImplementedError: until Phase 2 wires the HTTP call.
+        """
+        raise NotImplementedError(
+            "StepCAClient.health_check lands in Phase 2 of the mTLS rollout"
+        )

--- a/bindu/grpc/client.py
+++ b/bindu/grpc/client.py
@@ -61,6 +61,7 @@ class GrpcAgentClient:
         callback_address: str,
         timeout: float = 30.0,
         use_streaming: bool = False,
+        channel_credentials: grpc.ChannelCredentials | None = None,
     ) -> None:
         """Initialize the gRPC agent client.
 
@@ -71,25 +72,36 @@ class GrpcAgentClient:
             use_streaming: If True, use HandleMessagesStream (server-side streaming)
                 instead of HandleMessages (unary). The streaming RPC returns a
                 generator that ResultProcessor.collect_results() will drain.
+            channel_credentials: Optional mTLS credentials produced by
+                ``MTLSAgentExtension.build_grpc_channel_credentials``. When
+                provided, the channel is built with ``grpc.secure_channel``
+                so the agent authenticates over mTLS. When None, falls back
+                to ``grpc.insecure_channel`` for same-host SDK setups.
         """
         self._address = callback_address
         self._timeout = timeout
         self._use_streaming = use_streaming
+        self._channel_credentials = channel_credentials
         self._channel: grpc.Channel | None = None
         self._stub: agent_handler_pb2_grpc.AgentHandlerStub | None = None
 
     def _ensure_connected(self) -> None:
         """Lazily create the gRPC channel and stub on first use."""
         if self._channel is None:
-            self._channel = grpc.insecure_channel(
-                self._address,
-                options=[
-                    ("grpc.max_receive_message_length", 4 * 1024 * 1024),
-                    ("grpc.max_send_message_length", 4 * 1024 * 1024),
-                ],
-            )
+            options = [
+                ("grpc.max_receive_message_length", 4 * 1024 * 1024),
+                ("grpc.max_send_message_length", 4 * 1024 * 1024),
+            ]
+            if self._channel_credentials is not None:
+                self._channel = grpc.secure_channel(
+                    self._address, self._channel_credentials, options=options
+                )
+                scheme = "grpcs"
+            else:
+                self._channel = grpc.insecure_channel(self._address, options=options)
+                scheme = "grpc"
             self._stub = agent_handler_pb2_grpc.AgentHandlerStub(self._channel)
-            logger.debug(f"Connected to agent handler at {self._address}")
+            logger.debug(f"Connected to agent handler at {scheme}://{self._address}")
 
     def _build_request(
         self, messages: list[dict[str, str]]

--- a/bindu/grpc/server.py
+++ b/bindu/grpc/server.py
@@ -38,6 +38,7 @@ def start_grpc_server(
     host: str | None = None,
     port: int | None = None,
     max_workers: int | None = None,
+    server_credentials: grpc.ServerCredentials | None = None,
 ) -> grpc.Server:
     """Start the Bindu gRPC server for SDK agent registration.
 
@@ -49,6 +50,11 @@ def start_grpc_server(
         host: Bind host. Defaults to app_settings.grpc.host.
         port: Bind port. Defaults to app_settings.grpc.port (3774).
         max_workers: Thread pool size. Defaults to app_settings.grpc.max_workers.
+        server_credentials: Optional mTLS credentials produced by
+            ``MTLSAgentExtension.build_grpc_server_credentials``. When provided,
+            the gRPC port is bound over TLS with mutual-auth verification.
+            When None, the server falls back to ``add_insecure_port`` — used
+            for SDK-on-the-same-host setups where the bus is over localhost.
 
     Returns:
         The started grpc.Server instance. Call wait_for_termination() to block,
@@ -80,13 +86,19 @@ def start_grpc_server(
         server,
     )
 
-    # Bind to address
+    # Bind to address. mTLS-enabled deployments pass server_credentials so the
+    # gRPC port can't be downgraded relative to the HTTP A2A port.
     bind_address = f"{host}:{port}"
-    server.add_insecure_port(bind_address)
+    if server_credentials is not None:
+        server.add_secure_port(bind_address, server_credentials)
+        scheme = "grpcs"
+    else:
+        server.add_insecure_port(bind_address)
+        scheme = "grpc"
 
     # Start serving
     server.start()
-    logger.info(f"gRPC server started on {bind_address}")
+    logger.info(f"gRPC server started on {scheme}://{bind_address}")
     logger.info(
         "Waiting for SDK agent registrations... "
         "(TypeScript, Kotlin, Rust agents can now connect)"

--- a/bindu/penguin/bindufy.py
+++ b/bindu/penguin/bindufy.py
@@ -606,6 +606,7 @@ def _bindufy_core(
         scheduler_config=scheduler_config,
         sentry_config=sentry_config,
         cors_origins=deployment_config.cors_origins if deployment_config else None,
+        mtls_extension=mtls_extension,
     )
 
     # Parse deployment URL

--- a/bindu/penguin/bindufy.py
+++ b/bindu/penguin/bindufy.py
@@ -25,6 +25,7 @@ from bindu.common.models import (
 from bindu.extensions.x402 import X402AgentExtension
 from bindu.penguin.did_setup import initialize_did_extension
 from bindu.penguin.manifest import create_manifest, validate_agent_function
+from bindu.penguin.mtls_setup import initialize_mtls_extension
 from bindu.settings import app_settings
 from bindu.utils import add_extension_to_capabilities
 from bindu.utils.config import (
@@ -560,6 +561,31 @@ def _bindufy_core(
         did_extension,
         caller_dir or Path.cwd(),
     )
+
+    # Bootstrap mTLS. Off by default (mtls.enabled=False) so existing
+    # deployments are unaffected. When on, requires Hydra credentials because
+    # step-ca's OIDC provisioner validates the cert request against Hydra.
+    mtls_extension = initialize_mtls_extension(
+        agent_id=agent_id_str,
+        agent_did=did_extension.did,
+        agent_url=agent_url,
+        pki_dir=resolved_key_dir / app_settings.did.pki_dir,
+        hydra_credentials=credentials,
+    )
+    if mtls_extension is not None:
+        # Populate AgentTrust on the manifest so the cert fingerprint flows
+        # into the agent card and downstream trust decisions.
+        fingerprint = mtls_extension.cert_fingerprint
+        if fingerprint is not None:
+            _manifest.agent_trust["certificate_fingerprint"] = fingerprint
+    elif app_settings.mtls.enabled and app_settings.mtls.require_client_cert:
+        # Operator asked for strict mTLS but bootstrap failed — refuse to start
+        # rather than fall through to plain HTTP and create a false sense of
+        # security.
+        raise RuntimeError(
+            "mTLS is enabled with require_client_cert=True but cert bootstrap "
+            "failed. Check step-ca reachability and Hydra OIDC config."
+        )
 
     logger.info(f"Starting deployment for agent: {agent_id}")
 

--- a/bindu/penguin/bindufy.py
+++ b/bindu/penguin/bindufy.py
@@ -627,6 +627,20 @@ def _bindufy_core(
             tunnel_url=tunnel_url,
         )
 
+        # When mTLS is configured and bootstrap succeeded, hand uvicorn the
+        # cert/key/CA-bundle paths so the HTTP server runs over TLS with
+        # mutual-auth peer verification.
+        ssl_kwargs = (
+            mtls_extension.get_uvicorn_ssl_kwargs()
+            if mtls_extension is not None
+            else None
+        )
+        if ssl_kwargs and agent_url.startswith("http://"):
+            logger.warning(
+                "mTLS is on but agent_url starts with http://; downstream callers "
+                "will fail TLS. Set deployment URL to https://… to match."
+            )
+
         if run_server_in_background:
             # Start uvicorn in a background thread (used by gRPC service)
             import threading
@@ -634,7 +648,12 @@ def _bindufy_core(
             server_thread = threading.Thread(
                 target=start_uvicorn_server,
                 args=(bindu_app,),
-                kwargs={"host": host, "port": port, "display_info": True},
+                kwargs={
+                    "host": host,
+                    "port": port,
+                    "display_info": True,
+                    "ssl_kwargs": ssl_kwargs,
+                },
                 daemon=True,
                 name=f"uvicorn-{validated_config['name']}",
             )
@@ -642,7 +661,13 @@ def _bindufy_core(
             logger.info(f"HTTP server started in background thread on {host}:{port}")
         else:
             # Run server blocking (normal Python bindufy path)
-            start_uvicorn_server(bindu_app, host=host, port=port, display_info=True)
+            start_uvicorn_server(
+                bindu_app,
+                host=host,
+                port=port,
+                display_info=True,
+                ssl_kwargs=ssl_kwargs,
+            )
     else:
         logger.info(
             "Server not started (run_server=False). Manifest returned for programmatic use."

--- a/bindu/penguin/mtls_setup.py
+++ b/bindu/penguin/mtls_setup.py
@@ -48,6 +48,9 @@ def _build_token_provider(credentials: AgentCredentials):
             client_id=credentials.client_id,
             client_secret=credentials.client_secret,
             scope="openid",
+            # step-ca's OIDC provisioner enforces this — without an ``aud``
+            # claim matching its configured client ID the sign request 403s.
+            audience=app_settings.mtls.oidc_audience,
         )
         if not result:
             logger.error("Hydra returned no token for client %s", credentials.client_id)

--- a/bindu/penguin/mtls_setup.py
+++ b/bindu/penguin/mtls_setup.py
@@ -1,0 +1,161 @@
+"""mTLS setup utilities for the penguin module.
+
+Mirrors ``did_setup.py``: a thin synchronous facade over the async
+``MTLSAgentExtension`` so ``bindufy`` (which runs synchronously) can wire mTLS
+without touching the event loop directly.
+
+The bootstrap order is:
+
+1. DID extension is initialized (``did_setup``).
+2. Agent registers as an OAuth2 client in Hydra (``_register_in_hydra``).
+3. **This module runs** — using the Hydra credentials to fetch an OIDC token,
+   which is exchanged at step-ca for an X.509 cert.
+4. Manifest is created, server is started, etc.
+
+The function returns ``None`` when ``mtls.enabled`` is false, when Hydra
+credentials are unavailable (mTLS without Hydra OIDC isn't supported in this
+rollout), or when bootstrap fails — callers must handle ``None`` by either
+running in plain-HTTP mode or aborting, per ``mtls.require_client_cert``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+from bindu.common.models import AgentCredentials
+from bindu.extensions.mtls import MTLSAgentExtension
+from bindu.settings import app_settings
+from bindu.utils.http.tokens import get_client_credentials_token
+from bindu.utils.logging import get_logger
+
+logger = get_logger("bindu.penguin.mtls_setup")
+
+
+def _build_token_provider(credentials: AgentCredentials):
+    """Build the async OIDC token provider closed over Hydra credentials.
+
+    step-ca's OIDC provisioner expects an OIDC ID token signed by Hydra.
+    Hydra returns ``id_token`` when ``openid`` is included in the scope on a
+    client_credentials grant (provisioner config dependent); we fall back to
+    ``access_token`` so misconfigured deployments fail loudly at step-ca
+    rather than silently here.
+    """
+
+    async def _provider() -> str:
+        result = await get_client_credentials_token(
+            client_id=credentials.client_id,
+            client_secret=credentials.client_secret,
+            scope="openid",
+        )
+        if not result:
+            logger.error("Hydra returned no token for client %s", credentials.client_id)
+            return ""
+        return result.get("id_token") or result.get("access_token", "")
+
+    return _provider
+
+
+async def _bootstrap_async(
+    pki_dir: Path,
+    agent_did: str,
+    agent_url: Optional[str],
+    credentials: AgentCredentials,
+    agent_id_str: str,
+) -> Optional[MTLSAgentExtension]:
+    """Async core: construct the extension, initialize, optionally back up.
+
+    Kept private so the sync caller in ``bindufy`` only sees the wrapper.
+    """
+    extension = MTLSAgentExtension(
+        pki_dir=pki_dir,
+        agent_did=agent_did,
+        agent_url=agent_url,
+        oidc_token_provider=_build_token_provider(credentials),
+    )
+
+    try:
+        ok = await extension.initialize()
+    finally:
+        await extension.close()
+
+    if not ok:
+        return None
+
+    if app_settings.vault.enabled:
+        await _backup_mtls_to_vault(agent_id_str, extension)
+
+    return extension
+
+
+async def _backup_mtls_to_vault(
+    agent_id_str: str, extension: MTLSAgentExtension
+) -> None:
+    """Back up the freshly-issued cert material to Vault.
+
+    Failures are logged but do not abort the agent — Vault is a durability
+    aid (restart-recovery), not a hard dependency of the bootstrap.
+    """
+    from bindu.utils.http.vault_client import VaultClient
+
+    store = extension.store
+    vault = VaultClient()
+    try:
+        await vault.store_mtls_material(
+            agent_id=agent_id_str,
+            cert_pem=store.read_cert().decode("ascii"),
+            key_pem=store.read_key().decode("ascii"),
+            ca_bundle_pem=store.read_ca_bundle().decode("ascii"),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to back up mTLS material to Vault: %s", exc)
+    finally:
+        await vault.close()
+
+
+def initialize_mtls_extension(
+    agent_id: str,
+    agent_did: str,
+    agent_url: Optional[str],
+    pki_dir: Path,
+    hydra_credentials: Optional[AgentCredentials],
+) -> Optional[MTLSAgentExtension]:
+    """Bootstrap the mTLS extension for an agent.
+
+    Returns ``None`` (and logs) when:
+      * ``app_settings.mtls.enabled`` is False — the feature is opt-in.
+      * ``hydra_credentials`` is None — step-ca requires a Hydra OIDC token
+        for the OIDC provisioner; without Hydra registration we cannot
+        bootstrap a cert.
+      * ``MTLSAgentExtension.initialize()`` returns False — typically step-ca
+        unreachable or the OIDC token was rejected. Caller decides whether
+        this is fatal (``require_client_cert=True``) or recoverable.
+
+    Returns the initialized extension on success.
+    """
+    if not app_settings.mtls.enabled:
+        logger.debug("mTLS disabled (mtls.enabled=False); skipping bootstrap")
+        return None
+
+    if hydra_credentials is None:
+        logger.error(
+            "mTLS bootstrap requires Hydra credentials, but none were supplied. "
+            "Enable Hydra auth (auth.enabled=True, auth.provider=hydra) or disable mTLS."
+        )
+        return None
+
+    logger.info("Bootstrapping mTLS cert for %s via step-ca…", agent_did)
+    try:
+        return asyncio.run(
+            _bootstrap_async(
+                pki_dir=pki_dir,
+                agent_did=agent_did,
+                agent_url=agent_url,
+                credentials=hydra_credentials,
+                agent_id_str=agent_id,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("mTLS bootstrap raised: %s", exc)
+        return None

--- a/bindu/server/applications.py
+++ b/bindu/server/applications.py
@@ -698,16 +698,31 @@ class BinduApplication(Starlette):
             )
             middleware_list.append(x402_middleware)
 
+        # Install mTLS first so the peer DID is on scope before Hydra checks
+        # the token's client_id against it. In mtls-only mode this is the sole
+        # auth layer; in hybrid mode both run; off/disabled is a no-op.
+        mtls_runs = app_settings.mtls.enabled and app_settings.mtls.mode != "off"
+        if mtls_runs:
+            from .middleware.auth import MTLSMiddleware
+
+            logger.info("mTLS middleware enabled (mode=%s)", app_settings.mtls.mode)
+            mtls_middleware = Middleware(MTLSMiddleware, mtls_config=app_settings.mtls)  # type: ignore[arg-type]
+            middleware_list.append(mtls_middleware)
+
         # Add authentication middleware if requested or globally enabled
         # (previous behavior required both flags; we now treat settings as authoritative
         # so that enabling auth via config always installs the middleware).
-        if auth_enabled or app_settings.auth.enabled:
+        # In mtls-only mode we skip Hydra: the cert is the credential.
+        hydra_skipped = mtls_runs and app_settings.mtls.mode == "mtls"
+        if (auth_enabled or app_settings.auth.enabled) and not hydra_skipped:
             if app_settings.auth.enabled:
                 # ensure config value drives logging
                 logger.info("Authentication middleware enabled")
             auth_middleware = self._create_auth_middleware()
             # Add auth middleware after CORS and X402
             middleware_list.append(auth_middleware)
+        elif hydra_skipped:
+            logger.info("mTLS-only mode — skipping Hydra auth middleware")
 
         # Add metrics middleware (should be last to capture all requests)
         from .middleware import MetricsMiddleware

--- a/bindu/server/applications.py
+++ b/bindu/server/applications.py
@@ -75,6 +75,7 @@ class BinduApplication(Starlette):
         telemetry_config: TelemetryConfig | None = None,
         sentry_config: SentryConfig | None = None,
         cors_origins: list[str] | None = None,
+        mtls_extension: Any | None = None,
     ):
         """Initialize Bindu application.
 
@@ -103,6 +104,10 @@ class BinduApplication(Starlette):
         self._scheduler_config = scheduler_config
         self._telemetry_config = telemetry_config or TelemetryConfig()
         self._sentry_config = sentry_config or SentryConfig()
+        # Optional mTLS extension; the lifespan starts its renewal loop when
+        # set so the cert is re-issued before expiry without the operator
+        # having to run a sidecar process.
+        self._mtls_extension = mtls_extension
 
         # Create default lifespan if none provided
         if lifespan is None:
@@ -390,19 +395,41 @@ class BinduApplication(Starlette):
             if app._payment_session_manager:
                 await app._payment_session_manager.start_cleanup_task()
 
-            # Start TaskManager
-            if manifest:
-                logger.info("🔧 Starting TaskManager...")
-                task_manager = TaskManager(
-                    scheduler=scheduler, storage=storage, manifest=manifest
+            # Start the mTLS renewal loop if configured. Spawned here (vs in
+            # bindufy) so it runs inside uvicorn's event loop and gets clean
+            # cancellation on app shutdown.
+            import asyncio as _asyncio
+
+            renewal_task: _asyncio.Task | None = None
+            if self._mtls_extension is not None:
+                renewal_task = _asyncio.create_task(
+                    self._mtls_extension.run_renewal_loop(),
+                    name="mtls-renewal-loop",
                 )
-                async with task_manager:
-                    app.task_manager = task_manager
-                    logger.info("✅ TaskManager started")
+
+            try:
+                # Start TaskManager
+                if manifest:
+                    logger.info("🔧 Starting TaskManager...")
+                    task_manager = TaskManager(
+                        scheduler=scheduler, storage=storage, manifest=manifest
+                    )
+                    async with task_manager:
+                        app.task_manager = task_manager
+                        logger.info("✅ TaskManager started")
+                        yield
+                    logger.info("🛑 TaskManager stopped")
+                else:
                     yield
-                logger.info("🛑 TaskManager stopped")
-            else:
-                yield
+            finally:
+                if renewal_task is not None:
+                    renewal_task.cancel()
+                    try:
+                        await renewal_task
+                    except _asyncio.CancelledError:
+                        pass
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("mTLS renewal task exited with: %s", exc)
 
             # Stop payment session manager cleanup task
             if app._payment_session_manager:

--- a/bindu/server/middleware/auth/__init__.py
+++ b/bindu/server/middleware/auth/__init__.py
@@ -20,8 +20,10 @@ from __future__ import annotations as _annotations
 
 from .base import AuthMiddleware
 from .hydra import HydraMiddleware
+from .mtls import MTLSMiddleware
 
 __all__ = [
     "AuthMiddleware",
     "HydraMiddleware",
+    "MTLSMiddleware",
 ]

--- a/bindu/server/middleware/auth/mtls.py
+++ b/bindu/server/middleware/auth/mtls.py
@@ -1,0 +1,200 @@
+# |---------------------------------------------------------|
+# |                                                         |
+# |                 Give Feedback / Get Help                |
+# | https://github.com/getbindu/Bindu/issues/new/choose    |
+# |                                                         |
+# |---------------------------------------------------------|
+#
+#  Thank you users! We ❤️ you! - 🌻
+
+"""mTLS authentication middleware.
+
+Extracts the peer (client) X.509 certificate from the ASGI TLS extension,
+parses out the agent DID (URI SAN preferred, CN fallback), and injects it
+into the request scope so downstream handlers can authorize off the
+cryptographic identity rather than a token.
+
+Composes with HydraMiddleware under ``mtls.mode``:
+
+* ``"hybrid"`` — this middleware extracts the peer DID; Hydra still
+  introspects the bearer token. Requests must satisfy *both* layers, and
+  the cert CN must match the Hydra ``client_id``. This is the rollout
+  default while every agent is migrated to a cert.
+* ``"mtls"``  — this middleware is the sole authentication layer; Hydra
+  introspection is skipped. The target end state.
+* ``"off"``   — middleware short-circuits, behavior is identical to a
+  deployment without mTLS wired in.
+
+Peer cert plumbing follows the ASGI TLS extension spec
+(https://asgi.readthedocs.io/en/latest/extensions.html#tls): uvicorn
+exposes ``scope["extensions"]["tls"]["client_cert_chain"]`` as a list of
+PEM-encoded certs when ``ssl_cert_reqs=ssl.CERT_REQUIRED`` is set.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from typing import Any, Callable, Optional
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+
+from bindu.settings import app_settings
+from bindu.utils.logging import get_logger
+
+logger = get_logger("bindu.server.middleware.mtls")
+
+
+SCOPE_KEY_PEER_DID = "bindu_peer_did"
+SCOPE_KEY_PEER_CERT = "bindu_peer_cert"
+
+
+class MTLSMiddleware:
+    """ASGI middleware that turns a verified peer cert into a DID.
+
+    Placement: install **before** ``HydraMiddleware`` in hybrid mode so the
+    peer DID is available when Hydra cross-checks the token's ``client_id``;
+    install in place of ``HydraMiddleware`` in mtls-only mode.
+    """
+
+    def __init__(self, app: Callable, mtls_config: Any) -> None:
+        """Wire the middleware.
+
+        Args:
+            app: The next ASGI application in the chain.
+            mtls_config: Typically ``app_settings.mtls``. Read for ``mode``,
+                ``require_client_cert``, and the public-endpoint allowlist
+                (reuses Hydra's list — both middlewares should agree on what
+                bypasses auth).
+        """
+        self.app = app
+        self.config = mtls_config
+
+        # Reuse Hydra's public-endpoint list so /health, /.well-known/...,
+        # etc. don't require a peer cert. Operators who tune the allowlist
+        # only have to maintain one knob.
+        self._public_patterns: list[re.Pattern[str]] = []
+        for pattern in getattr(app_settings.hydra, "public_endpoints", []):
+            self._public_patterns.append(re.compile(fnmatch.translate(pattern)))
+
+    async def __call__(self, scope, receive, send):
+        """ASGI entry point."""
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        if self.config.mode == "off" or not self.config.enabled:
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "/")
+        if self._is_public_endpoint(path):
+            await self.app(scope, receive, send)
+            return
+
+        cert_chain = self._extract_cert_chain(scope)
+        if not cert_chain:
+            if self.config.require_client_cert:
+                await self._reject(send, 403, "Client certificate required")
+                return
+            # Soft mode — no peer cert but mTLS doesn't strictly require one.
+            await self.app(scope, receive, send)
+            return
+
+        leaf_pem = cert_chain[0]
+        peer_did = self._extract_did(leaf_pem)
+        if peer_did is None:
+            await self._reject(
+                send, 403, "Client certificate lacks an identifiable DID"
+            )
+            return
+
+        scope[SCOPE_KEY_PEER_DID] = peer_did
+        scope[SCOPE_KEY_PEER_CERT] = leaf_pem
+        logger.debug("mTLS peer authenticated: %s", peer_did)
+        await self.app(scope, receive, send)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _is_public_endpoint(self, path: str) -> bool:
+        return any(p.match(path) for p in self._public_patterns)
+
+    @staticmethod
+    def _extract_cert_chain(scope) -> list[str]:
+        """Pull the peer cert chain from the ASGI TLS extension.
+
+        Returns an empty list when TLS isn't wired (e.g. local dev over
+        plain HTTP), the handshake didn't surface a cert, or the server
+        doesn't implement the ASGI TLS extension. Callers decide whether
+        absence is fatal.
+        """
+        extensions = scope.get("extensions") or {}
+        tls = extensions.get("tls") or {}
+        chain = tls.get("client_cert_chain") or []
+        # ASGI spec types this as list[str] (PEM). Defensive: filter to strs.
+        return [c for c in chain if isinstance(c, str)]
+
+    @staticmethod
+    def _extract_did(cert_pem: str) -> Optional[str]:
+        """Pull the DID out of a PEM cert.
+
+        Prefers a URI SAN whose value starts with ``did:`` (the cleaner
+        identity carrier); falls back to the CN when no SAN matches.
+        Returns None when neither yields a DID.
+        """
+        try:
+            cert = x509.load_pem_x509_certificate(cert_pem.encode("ascii"))
+        except (ValueError, UnicodeEncodeError) as exc:
+            logger.warning("Could not parse peer cert PEM: %s", exc)
+            return None
+
+        # Preferred path — URI SAN.
+        try:
+            san = cert.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            ).value
+            for uri in san.get_values_for_type(x509.UniformResourceIdentifier):
+                if uri.startswith("did:"):
+                    return uri
+        except x509.ExtensionNotFound:
+            pass
+
+        # Fallback — CN. Legacy peers may not carry a SAN. The cryptography
+        # API types ``NameAttribute.value`` as ``str | bytes``; we only
+        # accept str-shaped DIDs.
+        try:
+            cn_attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+            if cn_attrs:
+                cn_value = cn_attrs[0].value
+                if isinstance(cn_value, str) and cn_value.startswith("did:"):
+                    return cn_value
+        except IndexError:
+            pass
+
+        return None
+
+    @staticmethod
+    async def _reject(send, status: int, message: str) -> None:
+        """Emit a minimal ASGI 4xx response.
+
+        Kept dependency-free (no Starlette JSONResponse) so the middleware
+        can run before any application-level error handlers.
+        """
+        body = (
+            b'{"error":{"code":'
+            + str(status).encode("ascii")
+            + b',"message":"'
+            + message.encode("utf-8")
+            + b'"}}'
+        )
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})

--- a/bindu/settings.py
+++ b/bindu/settings.py
@@ -790,6 +790,13 @@ class MTLSSettings(BaseSettings):
     # true; ``{agent_id}`` is substituted at runtime.
     vault_path_template: str = "secret/bindu/agents/{agent_id}/mtls"
 
+    # OIDC audience that step-ca's OIDC provisioner expects in the token's
+    # ``aud`` claim. step-ca rejects sign requests whose token doesn't carry
+    # this audience, so Hydra registration and the token request both need
+    # to include it. Matches the ``clientID`` field in step-ca's
+    # ``ca-config.json`` on the infra side.
+    oidc_audience: str = "step-ca"
+
 
 class StorageSettings(BaseSettings):
     """Storage backend configuration settings.

--- a/bindu/settings.py
+++ b/bindu/settings.py
@@ -720,6 +720,77 @@ class HydraSettings(BaseSettings):
     ]
 
 
+class MTLSSettings(BaseSettings):
+    """Mutual TLS (mTLS) configuration for end-to-end encrypted agent communication.
+
+    Bindu agents fetch short-lived X.509 certificates from a Smallstep step-ca
+    server, using a Hydra OIDC token as the provisioner credential. Certificates
+    live on disk alongside the DID keypair (``DIDSettings.pki_dir``), are backed
+    up to Vault when ``VaultSettings.enabled`` is true, and are renewed in-process
+    before expiry.
+
+    See ``docs/MTLS_DEPLOYMENT_GUIDE.md`` for the CA architecture.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_prefix="MTLS__",
+        extra="allow",
+    )
+
+    # Enable/disable mTLS. Off by default so existing deployments are unaffected
+    # until the step-ca service is up and an agent is explicitly opted in.
+    enabled: bool = False
+
+    # step-ca service endpoints. The root URL serves the public PEM bundle and
+    # does not require authentication; the API URL is mTLS-protected on the
+    # CA side once the agent is enrolled.
+    ca_url: str = "https://ca.getbindu.com"
+    ca_root_url: str = "https://ca.getbindu.com/roots.pem"
+    ca_provisioner: str = "hydra"  # OIDC provisioner name configured in step-ca
+
+    # Connection settings
+    timeout: int = 10
+    verify_ssl: bool = True
+    max_retries: int = 3
+
+    # Certificate lifecycle. Short TTL + passive renewal is the revocation
+    # strategy (see deployment guide); there is no CRL.
+    cert_ttl_hours: int = 24
+    renew_before_hours: int = 8  # re-fetch when fewer than this many hours remain
+    renew_check_interval_seconds: int = 3600  # how often the renewal task wakes up
+
+    # Key type for agent certs. step-ca templates expect EC P-256.
+    key_type: str = "EC"
+    key_curve: str = "P-256"
+
+    # On-disk filenames. These live next to the DID key files inside
+    # ``DIDSettings.pki_dir`` so a single backup captures both identities.
+    cert_filename: str = "tls_cert.pem"
+    key_filename: str = "tls_key.pem"
+    ca_bundle_filename: str = "ca_bundle.pem"
+    csr_filename: str = "tls.csr"  # written for debugging; not load-bearing
+
+    # Server-side TLS behavior. When ``require_client_cert`` is true, the HTTP
+    # and gRPC servers reject any connection that doesn't present a verified
+    # peer cert (full mTLS).
+    require_client_cert: bool = True
+
+    # Client-side TLS behavior. Verify peer server certs against the bundled CA.
+    verify_server_cert: bool = True
+
+    # Rollout mode controls how inbound auth is validated:
+    #   "hybrid" - mTLS + Hydra both required; cert CN must match Hydra client_id
+    #              (default during the migration window)
+    #   "mtls"   - mTLS only; skip Hydra introspection entirely on inbound
+    #   "off"    - same effect as enabled=False; mTLS is wired but not enforced
+    mode: str = "hybrid"
+
+    # Vault paths for cert backup. Only used when ``VaultSettings.enabled`` is
+    # true; ``{agent_id}`` is substituted at runtime.
+    vault_path_template: str = "secret/bindu/agents/{agent_id}/mtls"
+
+
 class StorageSettings(BaseSettings):
     """Storage backend configuration settings.
 
@@ -1133,6 +1204,7 @@ class Settings(BaseSettings):
     agent: AgentSettings = AgentSettings()
     auth: AuthSettings = AuthSettings()
     hydra: HydraSettings = HydraSettings()
+    mtls: MTLSSettings = MTLSSettings()
     vault: VaultSettings = VaultSettings()
     oauth: OAuthSettings = OAuthSettings()
     storage: StorageSettings = StorageSettings()

--- a/bindu/utils/http/auth_client.py
+++ b/bindu/utils/http/auth_client.py
@@ -33,6 +33,7 @@ class HybridAuthClient:
         agent_id: str,
         credentials_dir: Path,
         did_extension,
+        mtls_extension=None,
     ):
         """Initialize hybrid auth client.
 
@@ -40,12 +41,32 @@ class HybridAuthClient:
             agent_id: Agent identifier
             credentials_dir: Directory containing oauth_credentials.json
             did_extension: DIDExtension instance with private key
+            mtls_extension: Optional MTLSAgentExtension. When provided, all
+                outbound requests use mTLS — the client's cert authenticates
+                this agent at the transport layer, and the CA bundle verifies
+                peer servers. Layered on top of the existing OAuth2 + DID
+                signature stack (defense in depth during the migration
+                window).
         """
         self.agent_id = agent_id
         self.credentials_dir = credentials_dir
         self.did_extension = did_extension
+        self.mtls_extension = mtls_extension
         self.credentials = None
         self.access_token = None
+
+    def _build_http_client(self, base_url: str) -> AsyncHTTPClient:
+        """Build an ``AsyncHTTPClient`` for the given base URL.
+
+        Threads the mTLS SSL context through when configured; otherwise the
+        client uses default TLS settings (system trust store).
+        """
+        ssl_context = (
+            self.mtls_extension.build_client_ssl_context()
+            if self.mtls_extension is not None
+            else None
+        )
+        return AsyncHTTPClient(base_url=base_url, ssl_context=ssl_context)
 
     async def initialize(self):
         """Load credentials and get initial access token."""
@@ -142,7 +163,7 @@ class HybridAuthClient:
             auth_headers.update(headers)
 
         # Make request
-        async with AsyncHTTPClient(base_url=base_url) as client:
+        async with self._build_http_client(base_url) as client:
             response = await client.post(path, headers=auth_headers, json=data)
 
             if response.status == 401:
@@ -195,7 +216,7 @@ class HybridAuthClient:
             auth_headers.update(headers)
 
         # Make request
-        async with AsyncHTTPClient(base_url=base_url) as client:
+        async with self._build_http_client(base_url) as client:
             response = await client.get(path, headers=auth_headers)
 
             if response.status == 401:

--- a/bindu/utils/http/client.py
+++ b/bindu/utils/http/client.py
@@ -7,6 +7,7 @@ to avoid duplicating HTTP request logic, retry mechanisms, and session managemen
 from __future__ import annotations
 
 import asyncio
+import ssl
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -42,19 +43,26 @@ class AsyncHTTPClient:
         verify_ssl: bool = True,
         max_retries: int = 3,
         default_headers: dict[str, str] | None = None,
+        ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         """Initialize HTTP client.
 
         Args:
             base_url: Base URL for all requests (e.g., https://api.example.com)
             timeout: Request timeout in seconds
-            verify_ssl: Whether to verify SSL certificates
+            verify_ssl: Whether to verify SSL certificates. Ignored when
+                ``ssl_context`` is provided.
             max_retries: Maximum number of retry attempts (used by retry decorators)
             default_headers: Default headers to include in all requests
+            ssl_context: Optional ``ssl.SSLContext`` for mutual-TLS client
+                authentication. When provided, takes precedence over
+                ``verify_ssl`` and is handed directly to the underlying
+                ``aiohttp.TCPConnector``.
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.verify_ssl = verify_ssl
+        self.ssl_context = ssl_context
         self.max_retries = max_retries
         self.default_headers = default_headers or {}
         self._session: aiohttp.ClientSession | None = None
@@ -73,7 +81,11 @@ class AsyncHTTPClient:
     async def _ensure_session(self) -> None:
         """Ensure aiohttp session exists."""
         if self._session is None or self._session.closed:
-            connector = aiohttp.TCPConnector(ssl=self.verify_ssl)
+            # ssl_context (mTLS) overrides verify_ssl when both are set.
+            ssl_param: ssl.SSLContext | bool = (
+                self.ssl_context if self.ssl_context is not None else self.verify_ssl
+            )
+            connector = aiohttp.TCPConnector(ssl=ssl_param)
             timeout = aiohttp.ClientTimeout(total=self.timeout)
             self._session = aiohttp.ClientSession(
                 connector=connector,

--- a/bindu/utils/http/tokens.py
+++ b/bindu/utils/http/tokens.py
@@ -16,7 +16,10 @@ logger = get_logger("bindu.utils.token_utils")
 
 
 async def get_client_credentials_token(
-    client_id: str, client_secret: str, scope: Optional[str] = None
+    client_id: str,
+    client_secret: str,
+    scope: Optional[str] = None,
+    audience: Optional[str] = None,
 ) -> Optional[dict]:
     """Get access token using client credentials grant.
 
@@ -24,6 +27,10 @@ async def get_client_credentials_token(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         scope: Optional space-separated scopes
+        audience: Optional audience to request. When provided, Hydra
+            includes the value in the issued token's ``aud`` claim — needed
+            by step-ca's OIDC provisioner, which rejects tokens without
+            ``aud: step-ca``.
 
     Returns:
         Token response dict with access_token, token_type, expires_in
@@ -43,6 +50,8 @@ async def get_client_credentials_token(
 
         if scope:
             data["scope"] = scope
+        if audience:
+            data["audience"] = audience
 
         async with http_client(
             base_url=app_settings.hydra.public_url,

--- a/bindu/utils/http/vault_client.py
+++ b/bindu/utils/http/vault_client.py
@@ -261,6 +261,77 @@ class VaultClient:
             logger.error(f"Failed to delete DID keys from Vault for agent: {agent_id}")
             return False
 
+    async def store_mtls_material(
+        self,
+        agent_id: str,
+        cert_pem: str,
+        key_pem: str,
+        ca_bundle_pem: str,
+    ) -> bool:
+        """Store mTLS cert + key + CA bundle in Vault.
+
+        Mirrors ``store_did_keys`` so a single Vault namespace per agent
+        holds the agent's full identity (DID keys + X.509 material).
+
+        Args:
+            agent_id: Unique agent identifier
+            cert_pem: Agent X.509 certificate PEM
+            key_pem: Agent EC private key PEM
+            ca_bundle_pem: CA chain PEM
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.enabled:
+            logger.debug("Vault disabled, skipping mTLS material storage")
+            return False
+
+        path = app_settings.mtls.vault_path_template.format(agent_id=agent_id)
+        path = f"/v1/secret/data/{path.lstrip('/')}"
+        data = {
+            "data": {
+                "cert": cert_pem,
+                "key": key_pem,
+                "ca_bundle": ca_bundle_pem,
+            }
+        }
+
+        result = await self._make_request("POST", path, data)
+        if result:
+            logger.info(f"✅ mTLS material stored in Vault for agent: {agent_id}")
+            return True
+        logger.error(f"Failed to store mTLS material in Vault for agent: {agent_id}")
+        return False
+
+    async def get_mtls_material(self, agent_id: str) -> Optional[dict[str, str]]:
+        """Retrieve mTLS cert + key + CA bundle from Vault.
+
+        Args:
+            agent_id: Unique agent identifier
+
+        Returns:
+            Dictionary with 'cert', 'key', 'ca_bundle' keys or None if not found
+        """
+        if not self.enabled:
+            logger.debug("Vault disabled, skipping mTLS material retrieval")
+            return None
+
+        path = app_settings.mtls.vault_path_template.format(agent_id=agent_id)
+        path = f"/v1/secret/data/{path.lstrip('/')}"
+        result = await self._make_request("GET", path)
+
+        if result and "data" in result and "data" in result["data"]:
+            payload = result["data"]["data"]
+            logger.info(f"✅ mTLS material retrieved from Vault for agent: {agent_id}")
+            return {
+                "cert": payload.get("cert"),
+                "key": payload.get("key"),
+                "ca_bundle": payload.get("ca_bundle"),
+            }
+
+        logger.debug(f"No mTLS material found in Vault for agent: {agent_id}")
+        return None
+
     async def delete_hydra_credentials(self, did: str) -> bool:
         """Delete Hydra credentials from Vault.
 

--- a/bindu/utils/server_runner.py
+++ b/bindu/utils/server_runner.py
@@ -42,7 +42,13 @@ def setup_signal_handlers() -> None:
     logger.debug("Signal handlers registered for graceful shutdown")
 
 
-def run_server(app: Any, host: str, port: int, display_info: bool = True) -> None:
+def run_server(
+    app: Any,
+    host: str,
+    port: int,
+    display_info: bool = True,
+    ssl_kwargs: dict[str, Any] | None = None,
+) -> None:
     """Run uvicorn server with graceful shutdown handling.
 
     Supports being called from both the main thread (normal bindufy flow)
@@ -54,16 +60,24 @@ def run_server(app: Any, host: str, port: int, display_info: bool = True) -> Non
         host: Host address to bind to
         port: Port number to bind to
         display_info: Whether to display startup info messages
+        ssl_kwargs: Optional dict produced by ``MTLSAgentExtension.get_uvicorn_ssl_kwargs``.
+            When provided, uvicorn serves over TLS with mutual-auth verification
+            of peer client certificates against the bundled CA.
     """
     # Setup signal handlers (skips automatically if not in main thread)
     setup_signal_handlers()
 
+    scheme = "https" if ssl_kwargs else "http"
     if display_info:
-        logger.info(f"Starting uvicorn server at {host}:{port}...")
+        logger.info(f"Starting uvicorn server at {scheme}://{host}:{port}...")
+        if ssl_kwargs:
+            logger.info(
+                "mTLS enabled — clients must present a cert chained to the CA bundle"
+            )
         logger.info("Press Ctrl+C to stop the server gracefully")
 
     try:
-        uvicorn.run(app, host=host, port=port)
+        uvicorn.run(app, host=host, port=port, **(ssl_kwargs or {}))
     except KeyboardInterrupt:
         # This shouldn't be reached due to signal handler, but just in case
         logger.info("\n🛑 Server interrupted, shutting down...")

--- a/tests/unit/extensions/mtls/__init__.py
+++ b/tests/unit/extensions/mtls/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the bindu.extensions.mtls package."""

--- a/tests/unit/extensions/mtls/test_cert_store.py
+++ b/tests/unit/extensions/mtls/test_cert_store.py
@@ -1,0 +1,185 @@
+"""Tests for the CertStore leaf logic.
+
+Covers the disk + crypto operations that ship in Phase 1. The step-ca client
+and the orchestrator are stubs at this stage, so they have no tests yet.
+"""
+
+from __future__ import annotations
+
+import platform
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from bindu.extensions.mtls import CertStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CertStore:
+    """Bind a CertStore to a per-test tmp directory."""
+    return CertStore(tmp_path)
+
+
+class TestPathsAndExistence:
+    def test_paths_live_under_pki_dir(self, tmp_path: Path, store: CertStore) -> None:
+        assert store.cert_path.parent == tmp_path
+        assert store.key_path.parent == tmp_path
+        assert store.ca_bundle_path.parent == tmp_path
+        assert store.csr_path.parent == tmp_path
+
+    def test_has_cert_false_when_empty(self, store: CertStore) -> None:
+        assert store.has_cert() is False
+        assert store.has_ca_bundle() is False
+
+    def test_has_cert_requires_both_files(self, store: CertStore) -> None:
+        store.cert_path.write_bytes(b"cert")
+        assert store.has_cert() is False  # key still missing
+        store.key_path.write_bytes(b"key")
+        assert store.has_cert() is True
+
+
+class TestKeyGeneration:
+    def test_generate_keypair_writes_pem(self, store: CertStore) -> None:
+        private_key, key_pem = store.generate_keypair()
+        assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+        assert b"BEGIN PRIVATE KEY" in key_pem  # pragma: allowlist secret
+        assert store.key_path.is_file()
+
+    def test_generate_keypair_uses_p256(self, store: CertStore) -> None:
+        private_key, _ = store.generate_keypair()
+        assert isinstance(private_key.curve, ec.SECP256R1)
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX permission bits are not enforced on Windows",
+    )
+    def test_private_key_written_with_owner_only_mode(self, store: CertStore) -> None:
+        store.generate_keypair()
+        mode = stat.S_IMODE(store.key_path.stat().st_mode)
+        assert mode == 0o600
+
+    def test_load_private_key_round_trips(self, store: CertStore) -> None:
+        original, _ = store.generate_keypair()
+        loaded = store.load_private_key()
+        assert (
+            loaded.private_numbers().private_value
+            == original.private_numbers().private_value
+        )
+
+    def test_load_private_key_missing_raises(self, store: CertStore) -> None:
+        with pytest.raises(FileNotFoundError):
+            store.load_private_key()
+
+
+class TestCSRBuilding:
+    DID = "did:bindu:raahul:test:abc123"
+
+    def test_csr_contains_did_in_subject(self, store: CertStore) -> None:
+        private_key, _ = store.generate_keypair()
+        csr_pem = store.build_csr(private_key, self.DID)
+        csr = x509.load_pem_x509_csr(csr_pem)
+        cn_attr = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn_attr[0].value == self.DID
+
+    def test_csr_includes_did_as_uri_san(self, store: CertStore) -> None:
+        private_key, _ = store.generate_keypair()
+        csr_pem = store.build_csr(private_key, self.DID)
+        csr = x509.load_pem_x509_csr(csr_pem)
+        san = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        uris = san.get_values_for_type(x509.UniformResourceIdentifier)
+        assert self.DID in uris
+
+    def test_csr_includes_dns_san_when_url_provided(self, store: CertStore) -> None:
+        private_key, _ = store.generate_keypair()
+        csr_pem = store.build_csr(
+            private_key, self.DID, agent_url="https://agent.example.com/path"
+        )
+        csr = x509.load_pem_x509_csr(csr_pem)
+        san = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        dns = san.get_values_for_type(x509.DNSName)
+        assert "agent.example.com" in dns
+
+    def test_csr_omits_dns_san_when_no_url(self, store: CertStore) -> None:
+        private_key, _ = store.generate_keypair()
+        csr_pem = store.build_csr(private_key, self.DID)
+        csr = x509.load_pem_x509_csr(csr_pem)
+        san = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        assert san.get_values_for_type(x509.DNSName) == []
+
+    def test_csr_persisted_to_disk(self, store: CertStore) -> None:
+        private_key, _ = store.generate_keypair()
+        store.build_csr(private_key, self.DID)
+        assert store.csr_path.is_file()
+        assert b"BEGIN CERTIFICATE REQUEST" in store.csr_path.read_bytes()
+
+
+class TestExpiryAndRenewal:
+    def test_get_cert_expiry_none_when_missing(self, store: CertStore) -> None:
+        assert store.get_cert_expiry() is None
+
+    def test_is_renewal_due_true_when_missing(self, store: CertStore) -> None:
+        assert store.is_renewal_due(renew_before_hours=8) is True
+
+    def test_get_cert_fingerprint_none_when_missing(self, store: CertStore) -> None:
+        assert store.get_cert_fingerprint() is None
+
+    def test_get_cert_expiry_none_on_corrupt_file(self, store: CertStore) -> None:
+        store.cert_path.write_bytes(b"not a real PEM")
+        assert store.get_cert_expiry() is None
+        assert store.is_renewal_due(8) is True
+
+    def test_expiry_and_renewal_on_real_cert(self, store: CertStore) -> None:
+        """End-to-end: write a self-signed cert and read back expiry + fingerprint."""
+        private_key, _ = store.generate_keypair()
+        not_before = datetime.now(timezone.utc) - timedelta(minutes=1)
+        not_after = datetime.now(timezone.utc) + timedelta(hours=24)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test")]))
+            .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test")]))
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_before)
+            .not_valid_after(not_after)
+            .sign(private_key, hashes.SHA256())
+        )
+        store.write_cert(cert.public_bytes(serialization.Encoding.PEM))
+
+        expiry = store.get_cert_expiry()
+        assert expiry is not None
+        # Allow a 5s slop window for the date roundtrip through the X.509 encoder.
+        assert abs((expiry - not_after).total_seconds()) < 5
+
+        # 24h cert with an 8h renewal margin is still good.
+        assert store.is_renewal_due(renew_before_hours=8) is False
+        # But a 48h margin would force a renewal.
+        assert store.is_renewal_due(renew_before_hours=48) is True
+
+        fp = store.get_cert_fingerprint()
+        assert fp is not None
+        # Colon-separated hex bytes -> 32 octets, 95 chars.
+        assert len(fp) == 95
+        assert fp.count(":") == 31
+
+
+class TestWritePermissions:
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX permission bits are not enforced on Windows",
+    )
+    def test_cert_and_bundle_are_world_readable(self, store: CertStore) -> None:
+        store.write_cert(b"cert pem")
+        store.write_ca_bundle(b"bundle pem")
+        assert stat.S_IMODE(store.cert_path.stat().st_mode) == 0o644
+        assert stat.S_IMODE(store.ca_bundle_path.stat().st_mode) == 0o644
+
+    def test_writes_overwrite_existing_content(self, store: CertStore) -> None:
+        store.write_cert(b"v1")
+        store.write_cert(b"v2")
+        assert store.cert_path.read_bytes() == b"v2"

--- a/tests/unit/extensions/mtls/test_mtls_agent_extension.py
+++ b/tests/unit/extensions/mtls/test_mtls_agent_extension.py
@@ -55,6 +55,7 @@ def fake_step_ca() -> MagicMock:
     ca.sign_csr = AsyncMock(
         return_value=(_build_signed_cert(hours_valid=24), CA_BUNDLE)
     )
+    ca.health_check = AsyncMock(return_value=True)
     ca.close = AsyncMock()
     return ca
 
@@ -366,3 +367,159 @@ class TestClientMaterial:
             ext.get_httpx_client_kwargs()
         with pytest.raises(FileNotFoundError):
             ext.build_grpc_channel_credentials()
+
+
+class TestRenewIfNeeded:
+    """Phase 6: cert renewal decision logic."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_cert_fresh(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        # Seed a cert with 24h validity — well above the 8h renewal margin.
+        store = CertStore(tmp_path)
+        store.write_ca_bundle(CA_BUNDLE)
+        store.generate_keypair()
+        store.write_cert(_build_signed_cert(hours_valid=24))
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+            cert_store=store,
+        )
+        renewed = await ext.renew_if_needed()
+        assert renewed is False
+        fake_step_ca.sign_csr.assert_not_awaited()
+        fake_step_ca.health_check.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_renews_when_cert_near_expiry_and_ca_healthy(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        # Cert valid for only 1h — inside the 8h renewal margin.
+        store = CertStore(tmp_path)
+        store.write_ca_bundle(CA_BUNDLE)
+        store.generate_keypair()
+        store.write_cert(_build_signed_cert(hours_valid=1))
+        fake_step_ca.health_check = AsyncMock(return_value=True)
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+            cert_store=store,
+        )
+        renewed = await ext.renew_if_needed()
+        assert renewed is True
+        fake_step_ca.health_check.assert_awaited_once()
+        fake_step_ca.sign_csr.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_renewal_when_ca_unhealthy(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        store = CertStore(tmp_path)
+        store.write_ca_bundle(CA_BUNDLE)
+        store.generate_keypair()
+        store.write_cert(_build_signed_cert(hours_valid=1))
+        fake_step_ca.health_check = AsyncMock(return_value=False)
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+            cert_store=store,
+        )
+        renewed = await ext.renew_if_needed()
+        assert renewed is False
+        fake_step_ca.health_check.assert_awaited_once()
+        fake_step_ca.sign_csr.assert_not_awaited()
+
+
+class TestRenewalLoop:
+    """Phase 6: the long-running renewal task."""
+
+    @pytest.mark.asyncio
+    async def test_loop_invokes_renew_if_needed_each_tick(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        import asyncio
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+        )
+
+        call_count = 0
+
+        async def fake_renew():
+            nonlocal call_count
+            call_count += 1
+            return False
+
+        ext.renew_if_needed = fake_renew  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+
+        task = asyncio.create_task(ext.run_renewal_loop(interval_seconds=0))
+        # Yield enough times to let the loop tick multiple times.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_loop_survives_renew_exception(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        import asyncio
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+        )
+
+        calls = 0
+
+        async def flaky_renew():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("network glitch")
+            return False
+
+        ext.renew_if_needed = flaky_renew  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+
+        task = asyncio.create_task(ext.run_renewal_loop(interval_seconds=0))
+        for _ in range(10):
+            await asyncio.sleep(0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        # The loop kept ticking past the first failure.
+        assert calls >= 2
+
+    @pytest.mark.asyncio
+    async def test_loop_propagates_cancellation(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        import asyncio
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+        )
+        task = asyncio.create_task(ext.run_renewal_loop(interval_seconds=60))
+        # Let the task start.
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/tests/unit/extensions/mtls/test_mtls_agent_extension.py
+++ b/tests/unit/extensions/mtls/test_mtls_agent_extension.py
@@ -42,9 +42,14 @@ def _build_signed_cert(*, hours_valid: int) -> bytes:
     return cert.public_bytes(serialization.Encoding.PEM)
 
 
-CA_BUNDLE = b"-----BEGIN CERTIFICATE-----\nCA-CONTENT\n-----END CERTIFICATE-----\n"
+# A real PEM (self-signed) used as the fake CA bundle. The Phase-2 fix makes
+# the bootstrap write leaf+intermediate concatenated into the cert file, so
+# the fixture's bundle has to parse cleanly as PEM — a placeholder like
+# b"CA-CONTENT" inside BEGIN/END markers no longer survives the cert-store
+# fingerprint pass that runs at the end of initialize().
 DID = "did:bindu:raahul:test:abc123"
 AGENT_URL = "https://agent.example.com"
+CA_BUNDLE = _build_signed_cert(hours_valid=24 * 365)
 
 
 @pytest.fixture
@@ -155,6 +160,38 @@ class TestInitializeHappyPath:
         ok = await ext.initialize()
         assert ok is True
         fake_step_ca.sign_csr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_preserves_ca_bundle_as_trust_anchor(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        """Regression: ``_issue_new_cert`` must not overwrite ``ca_bundle.pem``.
+
+        The CA bundle is the trust anchor (root) used by peers to verify
+        chains. step-ca's sign response includes the *intermediate* in the
+        ``ca`` field — concatenating that into the cert file is correct
+        (it forms the chain a TLS handshake presents), but writing it
+        over the bundle would silently break peer verification.
+        """
+        leaf = _build_signed_cert(hours_valid=24)
+        intermediate = _build_signed_cert(hours_valid=24 * 365)
+        root_pem_at_bootstrap = b"root-bundle-marker-" + CA_BUNDLE
+        fake_step_ca.fetch_root_ca = AsyncMock(return_value=root_pem_at_bootstrap)
+        fake_step_ca.sign_csr = AsyncMock(return_value=(leaf, intermediate))
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+        )
+        await ext.initialize()
+
+        # The cert file is leaf + intermediate concatenated.
+        on_disk_cert = ext.store.read_cert()
+        assert on_disk_cert == leaf + intermediate
+
+        # The CA bundle is whatever fetch_root_ca returned — untouched.
+        assert ext.store.read_ca_bundle() == root_pem_at_bootstrap
 
     @pytest.mark.asyncio
     async def test_force_renew_triggers_resign(

--- a/tests/unit/extensions/mtls/test_mtls_agent_extension.py
+++ b/tests/unit/extensions/mtls/test_mtls_agent_extension.py
@@ -224,3 +224,93 @@ class TestInitializeFailureModes:
         )
         ok = await ext.initialize()
         assert ok is False
+
+
+class TestServerMaterial:
+    """Phase 3: server-side TLS material builders."""
+
+    def _seed_extension_with_real_pki(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> MTLSAgentExtension:
+        """Run a real bootstrap so the on-disk PEM files exist for SSLContext."""
+        import asyncio
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+        )
+        # Replace the fake's returned cert with one whose key actually matches
+        # what generate_keypair() writes — ssl.SSLContext.load_cert_chain
+        # checks that the cert's public key is the pair of the private key.
+        store = ext.store
+        pk, _ = store.generate_keypair()
+        from datetime import timedelta
+        from cryptography.x509 import (
+            CertificateBuilder,
+            Name,
+            NameAttribute,
+            random_serial_number,
+        )
+
+        now = datetime.now(timezone.utc)
+        cert = (
+            CertificateBuilder()
+            .subject_name(Name([NameAttribute(NameOID.COMMON_NAME, "test")]))
+            .issuer_name(Name([NameAttribute(NameOID.COMMON_NAME, "test")]))
+            .public_key(pk.public_key())
+            .serial_number(random_serial_number())
+            .not_valid_before(now - timedelta(minutes=1))
+            .not_valid_after(now + timedelta(hours=24))
+            .sign(pk, hashes.SHA256())
+        )
+        store.write_cert(cert.public_bytes(serialization.Encoding.PEM))
+        # CA bundle just needs to be a valid PEM cert for SSLContext.load_verify_locations.
+        store.write_ca_bundle(cert.public_bytes(serialization.Encoding.PEM))
+        # Mark as initialized so the require_initialized guard passes.
+        ext._initialized = True
+        asyncio.run(ext.close())
+        return ext
+
+    def test_build_server_ssl_context_returns_configured_context(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        import ssl
+
+        ext = self._seed_extension_with_real_pki(tmp_path, fake_step_ca, token_provider)
+        ctx = ext.build_server_ssl_context()
+        assert isinstance(ctx, ssl.SSLContext)
+        # Default settings: require_client_cert=True
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+    def test_get_uvicorn_ssl_kwargs_returns_file_paths(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        import ssl
+
+        ext = self._seed_extension_with_real_pki(tmp_path, fake_step_ca, token_provider)
+        kwargs = ext.get_uvicorn_ssl_kwargs()
+        assert kwargs["ssl_certfile"] == str(ext.store.cert_path)
+        assert kwargs["ssl_keyfile"] == str(ext.store.key_path)
+        assert kwargs["ssl_ca_certs"] == str(ext.store.ca_bundle_path)
+        assert kwargs["ssl_cert_reqs"] == ssl.CERT_REQUIRED
+
+    def test_build_grpc_server_credentials_returns_grpc_creds(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        import grpc
+
+        ext = self._seed_extension_with_real_pki(tmp_path, fake_step_ca, token_provider)
+        creds = ext.build_grpc_server_credentials()
+        assert isinstance(creds, grpc.ServerCredentials)
+
+    def test_server_material_raises_when_uninitialized(self, tmp_path: Path) -> None:
+        ext = _make_extension(tmp_path)
+        with pytest.raises(
+            FileNotFoundError, match="call MTLSAgentExtension.initialize"
+        ):
+            ext.build_server_ssl_context()
+        with pytest.raises(FileNotFoundError):
+            ext.get_uvicorn_ssl_kwargs()
+        with pytest.raises(FileNotFoundError):
+            ext.build_grpc_server_credentials()

--- a/tests/unit/extensions/mtls/test_mtls_agent_extension.py
+++ b/tests/unit/extensions/mtls/test_mtls_agent_extension.py
@@ -1,0 +1,226 @@
+"""Tests for the MTLSAgentExtension orchestrator.
+
+Mocks StepCAClient and the OIDC token provider so the bootstrap logic can be
+exercised in isolation, without a live step-ca or Hydra instance.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from bindu.extensions.mtls import CertStore, MTLSAgentExtension
+from bindu.extensions.mtls.step_ca_client import StepCAError
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: build a real signed cert PEM step-ca would plausibly return.
+# ---------------------------------------------------------------------------
+
+
+def _build_signed_cert(*, hours_valid: int) -> bytes:
+    """Build a self-signed cert PEM with the requested validity window."""
+    pk = ec.generate_private_key(ec.SECP256R1())
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test")]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test")]))
+        .public_key(pk.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(hours=hours_valid))
+        .sign(pk, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+CA_BUNDLE = b"-----BEGIN CERTIFICATE-----\nCA-CONTENT\n-----END CERTIFICATE-----\n"
+DID = "did:bindu:raahul:test:abc123"
+AGENT_URL = "https://agent.example.com"
+
+
+@pytest.fixture
+def fake_step_ca() -> MagicMock:
+    """A StepCAClient stand-in whose methods are AsyncMocks."""
+    ca = MagicMock()
+    ca.fetch_root_ca = AsyncMock(return_value=CA_BUNDLE)
+    ca.sign_csr = AsyncMock(
+        return_value=(_build_signed_cert(hours_valid=24), CA_BUNDLE)
+    )
+    ca.close = AsyncMock()
+    return ca
+
+
+@pytest.fixture
+def token_provider() -> AsyncMock:
+    return AsyncMock(return_value="fake-oidc-token")
+
+
+def _make_extension(
+    tmp_path: Path,
+    *,
+    step_ca=None,
+    oidc_token_provider=None,
+    cert_store=None,
+) -> MTLSAgentExtension:
+    return MTLSAgentExtension(
+        pki_dir=tmp_path,
+        agent_did=DID,
+        agent_url=AGENT_URL,
+        step_ca=step_ca,
+        oidc_token_provider=oidc_token_provider,
+        cert_store=cert_store,
+    )
+
+
+class TestInitializeHappyPath:
+    @pytest.mark.asyncio
+    async def test_full_bootstrap_writes_cert_key_and_bundle(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+        )
+        ok = await ext.initialize()
+        assert ok is True
+        assert ext.initialized is True
+        store = ext.store
+        assert store.has_cert()
+        assert store.has_ca_bundle()
+        # CSR was built with the DID
+        assert b"BEGIN CERTIFICATE REQUEST" in store.csr_path.read_bytes()
+
+    @pytest.mark.asyncio
+    async def test_passes_oidc_token_to_sign_request(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+        )
+        await ext.initialize()
+        token_provider.assert_awaited_once()
+        fake_step_ca.sign_csr.assert_awaited_once()
+        _, called_token = fake_step_ca.sign_csr.call_args.args
+        assert called_token == "fake-oidc-token"
+
+    @pytest.mark.asyncio
+    async def test_skips_root_fetch_when_bundle_present(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        store = CertStore(tmp_path)
+        store.write_ca_bundle(CA_BUNDLE)
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+            cert_store=store,
+        )
+        await ext.initialize()
+        fake_step_ca.fetch_root_ca.assert_not_awaited()
+        fake_step_ca.sign_csr.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reuses_valid_cert_on_disk(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        # Pre-seed a valid cert + key + bundle.
+        store = CertStore(tmp_path)
+        store.write_ca_bundle(CA_BUNDLE)
+        pk, _ = store.generate_keypair()
+        # Build a cert whose private key matches what's on disk so it parses
+        # cleanly; the cert content itself doesn't matter — the store only
+        # checks notAfter.
+        cert_pem = _build_signed_cert(hours_valid=24)
+        store.write_cert(cert_pem)
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+            cert_store=store,
+        )
+        ok = await ext.initialize()
+        assert ok is True
+        fake_step_ca.sign_csr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_force_renew_triggers_resign(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        store = CertStore(tmp_path)
+        store.write_ca_bundle(CA_BUNDLE)
+        store.generate_keypair()
+        store.write_cert(_build_signed_cert(hours_valid=24))
+
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+            cert_store=store,
+        )
+        await ext.initialize(force_renew=True)
+        fake_step_ca.sign_csr.assert_awaited_once()
+
+
+class TestInitializeFailureModes:
+    @pytest.mark.asyncio
+    async def test_missing_token_provider_raises_runtime_error(
+        self, tmp_path: Path, fake_step_ca: MagicMock
+    ) -> None:
+        ext = _make_extension(tmp_path, step_ca=fake_step_ca)
+        with pytest.raises(RuntimeError, match="oidc_token_provider"):
+            await ext.initialize()
+
+    @pytest.mark.asyncio
+    async def test_step_ca_error_returns_false(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        fake_step_ca.sign_csr.side_effect = StepCAError("CA exploded")
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+        )
+        ok = await ext.initialize()
+        assert ok is False
+        assert ext.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_empty_oidc_token_raises_step_ca_error(
+        self, tmp_path: Path, fake_step_ca: MagicMock
+    ) -> None:
+        provider = AsyncMock(return_value="")
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=provider,
+        )
+        ok = await ext.initialize()
+        # initialize() catches StepCAError and returns False.
+        assert ok is False
+        fake_step_ca.sign_csr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_returns_false_not_raises(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        fake_step_ca.fetch_root_ca.side_effect = ConnectionError("network down")
+        ext = _make_extension(
+            tmp_path,
+            step_ca=fake_step_ca,
+            oidc_token_provider=token_provider,
+        )
+        ok = await ext.initialize()
+        assert ok is False

--- a/tests/unit/extensions/mtls/test_mtls_agent_extension.py
+++ b/tests/unit/extensions/mtls/test_mtls_agent_extension.py
@@ -314,3 +314,55 @@ class TestServerMaterial:
             ext.get_uvicorn_ssl_kwargs()
         with pytest.raises(FileNotFoundError):
             ext.build_grpc_server_credentials()
+
+
+class TestClientMaterial:
+    """Phase 4: client-side (outbound) TLS material builders."""
+
+    def _seed_extension_with_real_pki(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> MTLSAgentExtension:
+        """Reuse the server-material seed; same on-disk layout."""
+        return TestServerMaterial()._seed_extension_with_real_pki(
+            tmp_path, fake_step_ca, token_provider
+        )
+
+    def test_build_client_ssl_context_loads_cert_chain(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        import ssl
+
+        ext = self._seed_extension_with_real_pki(tmp_path, fake_step_ca, token_provider)
+        ctx = ext.build_client_ssl_context()
+        assert isinstance(ctx, ssl.SSLContext)
+        # Default settings: verify_server_cert=True -> CERT_REQUIRED.
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+    def test_httpx_kwargs_returns_cert_tuple_and_verify_path(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        ext = self._seed_extension_with_real_pki(tmp_path, fake_step_ca, token_provider)
+        kwargs = ext.get_httpx_client_kwargs()
+        assert kwargs["cert"] == (
+            str(ext.store.cert_path),
+            str(ext.store.key_path),
+        )
+        assert kwargs["verify"] == str(ext.store.ca_bundle_path)
+
+    def test_build_grpc_channel_credentials_returns_creds(
+        self, tmp_path: Path, fake_step_ca: MagicMock, token_provider: AsyncMock
+    ) -> None:
+        import grpc
+
+        ext = self._seed_extension_with_real_pki(tmp_path, fake_step_ca, token_provider)
+        creds = ext.build_grpc_channel_credentials()
+        assert isinstance(creds, grpc.ChannelCredentials)
+
+    def test_client_material_raises_when_uninitialized(self, tmp_path: Path) -> None:
+        ext = _make_extension(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            ext.build_client_ssl_context()
+        with pytest.raises(FileNotFoundError):
+            ext.get_httpx_client_kwargs()
+        with pytest.raises(FileNotFoundError):
+            ext.build_grpc_channel_credentials()

--- a/tests/unit/extensions/mtls/test_settings.py
+++ b/tests/unit/extensions/mtls/test_settings.py
@@ -1,0 +1,74 @@
+"""Tests for the MTLS pydantic settings block."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestMTLSSettingsDefaults:
+    def test_disabled_by_default(self) -> None:
+        from bindu.settings import app_settings
+
+        # Phase 1 lands the wiring but does not flip the default; existing
+        # deployments must be unaffected until they opt in.
+        assert app_settings.mtls.enabled is False
+
+    def test_ca_endpoints_point_at_production_host(self) -> None:
+        from bindu.settings import app_settings
+
+        assert app_settings.mtls.ca_url == "https://ca.getbindu.com"
+        assert app_settings.mtls.ca_root_url == "https://ca.getbindu.com/roots.pem"
+
+    def test_lifecycle_defaults_match_deployment_guide(self) -> None:
+        from bindu.settings import app_settings
+
+        assert app_settings.mtls.cert_ttl_hours == 24
+        assert app_settings.mtls.renew_before_hours == 8
+        assert app_settings.mtls.renew_check_interval_seconds == 3600
+
+    def test_rollout_mode_defaults_to_hybrid(self) -> None:
+        from bindu.settings import app_settings
+
+        # mTLS + Hydra both required during the migration window. Flip to
+        # "mtls" once every deployed agent is on a cert.
+        assert app_settings.mtls.mode == "hybrid"
+
+    def test_key_filenames_are_distinct_from_did(self) -> None:
+        from bindu.settings import app_settings
+
+        # mTLS files live next to the DID keypair; the filenames must not
+        # collide with private.pem / public.pem.
+        assert app_settings.mtls.cert_filename != app_settings.did.private_key_filename
+        assert app_settings.mtls.key_filename != app_settings.did.private_key_filename
+        assert app_settings.mtls.key_filename != app_settings.did.public_key_filename
+
+
+class TestMTLSSettingsEnvOverride:
+    @pytest.mark.parametrize(
+        "env_var,attr,value,coerced",
+        [
+            ("MTLS__ENABLED", "enabled", "true", True),
+            (
+                "MTLS__CA_URL",
+                "ca_url",
+                "https://ca.example.com",
+                "https://ca.example.com",
+            ),
+            ("MTLS__CERT_TTL_HOURS", "cert_ttl_hours", "168", 168),
+            ("MTLS__MODE", "mode", "mtls", "mtls"),
+        ],
+    )
+    def test_env_var_overrides_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        env_var: str,
+        attr: str,
+        value: str,
+        coerced,
+    ) -> None:
+        monkeypatch.setenv(env_var, value)
+        # Re-instantiate so the env var is read fresh.
+        from bindu.settings import MTLSSettings
+
+        settings = MTLSSettings()
+        assert getattr(settings, attr) == coerced

--- a/tests/unit/extensions/mtls/test_settings.py
+++ b/tests/unit/extensions/mtls/test_settings.py
@@ -33,6 +33,15 @@ class TestMTLSSettingsDefaults:
         # "mtls" once every deployed agent is on a cert.
         assert app_settings.mtls.mode == "hybrid"
 
+    def test_oidc_audience_matches_step_ca_client_id(self) -> None:
+        from bindu.settings import app_settings
+
+        # The string must match the ``clientID`` field in step-ca's
+        # ca-config.json. Changing one without the other 403s every sign
+        # request — that's an operator concern, but pin the default here
+        # so the symmetry is obvious from a single source of truth.
+        assert app_settings.mtls.oidc_audience == "step-ca"
+
     def test_key_filenames_are_distinct_from_did(self) -> None:
         from bindu.settings import app_settings
 

--- a/tests/unit/extensions/mtls/test_step_ca_client.py
+++ b/tests/unit/extensions/mtls/test_step_ca_client.py
@@ -1,0 +1,157 @@
+"""Tests for the StepCAClient HTTP surface.
+
+These tests mock the underlying AsyncHTTPClient so we exercise the
+on-the-wire contract with step-ca (request shapes, response parsing,
+error handling) without needing a live CA.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bindu.extensions.mtls.step_ca_client import StepCAClient, StepCAError
+
+
+def _mock_response(
+    *,
+    status: int = 200,
+    body: bytes = b"",
+    json_payload: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Build an aiohttp.ClientResponse stand-in that StepCAClient understands."""
+    response = MagicMock()
+    response.status = status
+    response._body = body
+    response.read = AsyncMock(return_value=body)
+    response.json = AsyncMock(return_value=json_payload or {})
+    return response
+
+
+@pytest.fixture
+def client() -> StepCAClient:
+    return StepCAClient(
+        ca_url="https://ca.example.com",
+        ca_root_url="https://ca.example.com/roots.pem",
+    )
+
+
+class TestFetchRootCA:
+    @pytest.mark.asyncio
+    async def test_returns_pem_body(self, client: StepCAClient) -> None:
+        pem = (
+            b"-----BEGIN CERTIFICATE-----\nMIIBkTCCATug...\n-----END CERTIFICATE-----\n"
+        )
+        client._roots_client.get = AsyncMock(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            return_value=_mock_response(body=pem)
+        )
+        result = await client.fetch_root_ca()
+        assert result == pem
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_pem_response(self, client: StepCAClient) -> None:
+        client._roots_client.get = AsyncMock(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            return_value=_mock_response(body=b"not a cert")
+        )
+        with pytest.raises(StepCAError, match="did not return a PEM payload"):
+            await client.fetch_root_ca()
+
+    @pytest.mark.asyncio
+    async def test_calls_root_path(self, client: StepCAClient) -> None:
+        pem = b"-----BEGIN CERTIFICATE-----\nxxx\n-----END CERTIFICATE-----\n"
+        client._roots_client.get = AsyncMock(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            return_value=_mock_response(body=pem)
+        )
+        await client.fetch_root_ca()
+        client._roots_client.get.assert_awaited_once()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        called_path = client._roots_client.get.call_args.args[0]  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        assert called_path == "/roots.pem"
+
+
+class TestSignCSR:
+    CSR_PEM = b"-----BEGIN CERTIFICATE REQUEST-----\nMIIBxxx\n-----END CERTIFICATE REQUEST-----\n"
+    CERT_PEM = "-----BEGIN CERTIFICATE-----\nAAA\n-----END CERTIFICATE-----\n"
+    CHAIN_PEM = "-----BEGIN CERTIFICATE-----\nBBB\n-----END CERTIFICATE-----\n"
+
+    @pytest.mark.asyncio
+    async def test_posts_csr_and_token_and_parses_response(
+        self, client: StepCAClient
+    ) -> None:
+        client._api_client.post = AsyncMock(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            return_value=_mock_response(
+                json_payload={"crt": self.CERT_PEM, "ca": self.CHAIN_PEM}
+            )
+        )
+        cert, chain = await client.sign_csr(
+            self.CSR_PEM, "fake-oidc-token", ttl_hours=4
+        )
+        assert cert == self.CERT_PEM.encode("ascii")
+        assert chain == self.CHAIN_PEM.encode("ascii")
+
+        call = client._api_client.post.call_args  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        assert call.args[0] == "/1.0/sign"
+        body = call.kwargs["json"]
+        assert body["csr"] == self.CSR_PEM.decode("ascii")
+        assert body["ott"] == "fake-oidc-token"
+        assert "notAfter" in body and body["notAfter"]
+        assert call.kwargs["headers"]["Authorization"] == "Bearer fake-oidc-token"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_missing_crt_field(self, client: StepCAClient) -> None:
+        client._api_client.post = AsyncMock(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            return_value=_mock_response(json_payload={"ca": self.CHAIN_PEM})
+        )
+        with pytest.raises(StepCAError, match="Unexpected sign response shape"):
+            await client.sign_csr(self.CSR_PEM, "tok")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_non_dict_response(self, client: StepCAClient) -> None:
+        client._api_client.post = AsyncMock(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            return_value=_mock_response(json_payload=None)
+        )
+        # json() returns {} from the helper when payload is None -> dict without keys.
+        with pytest.raises(StepCAError):
+            await client.sign_csr(self.CSR_PEM, "tok")
+
+
+class TestHealthCheck:
+    @pytest.mark.asyncio
+    async def test_returns_true_on_200(self, client: StepCAClient) -> None:
+        client._api_client.get = AsyncMock(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            return_value=_mock_response(status=200)
+        )
+        assert await client.health_check() is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_error_status(self, client: StepCAClient) -> None:
+        client._api_client.get = AsyncMock(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            return_value=_mock_response(status=503)
+        )
+        assert await client.health_check() is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_exception(self, client: StepCAClient) -> None:
+        client._api_client.get = AsyncMock(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            side_effect=ConnectionError("boom")
+        )
+        # health_check is documented to never raise.
+        assert await client.health_check() is False
+
+
+class TestURLParsing:
+    def test_strips_trailing_slash_from_ca_url(self) -> None:
+        c = StepCAClient(
+            ca_url="https://ca.example.com/",
+            ca_root_url="https://ca.example.com/roots.pem",
+        )
+        assert c.ca_url == "https://ca.example.com"
+
+    def test_splits_root_url_into_base_and_path(self) -> None:
+        c = StepCAClient(
+            ca_url="https://ca.example.com",
+            ca_root_url="https://static.cdn.example.com/bindu/roots.pem",
+        )
+        assert c._roots_base == "https://static.cdn.example.com"
+        assert c._roots_path == "/bindu/roots.pem"

--- a/tests/unit/grpc/test_grpc_client_mtls.py
+++ b/tests/unit/grpc/test_grpc_client_mtls.py
@@ -1,0 +1,52 @@
+"""Tests for the channel-credentials wiring in GrpcAgentClient.
+
+Phase 4: outbound gRPC must use ``grpc.secure_channel`` when channel
+credentials are supplied. The default (None) preserves the existing
+``grpc.insecure_channel`` behavior for SDK-on-the-same-host setups.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import grpc
+
+from bindu.grpc.client import GrpcAgentClient
+
+
+class TestChannelCredentialsWiring:
+    def test_default_is_insecure_channel(self) -> None:
+        client = GrpcAgentClient(callback_address="localhost:50052")
+        with (
+            patch("bindu.grpc.client.grpc.insecure_channel") as fake_insecure,
+            patch("bindu.grpc.client.grpc.secure_channel") as fake_secure,
+        ):
+            fake_insecure.return_value = MagicMock(spec=grpc.Channel)
+            client._ensure_connected()
+            fake_insecure.assert_called_once()
+            fake_secure.assert_not_called()
+
+    def test_secure_channel_when_credentials_provided(self) -> None:
+        creds = MagicMock(spec=grpc.ChannelCredentials)
+        client = GrpcAgentClient(
+            callback_address="agent.example.com:50052",
+            channel_credentials=creds,
+        )
+        with (
+            patch("bindu.grpc.client.grpc.insecure_channel") as fake_insecure,
+            patch("bindu.grpc.client.grpc.secure_channel") as fake_secure,
+        ):
+            fake_secure.return_value = MagicMock(spec=grpc.Channel)
+            client._ensure_connected()
+            fake_secure.assert_called_once()
+            assert fake_secure.call_args.args[0] == "agent.example.com:50052"
+            assert fake_secure.call_args.args[1] is creds
+            fake_insecure.assert_not_called()
+
+    def test_channel_built_only_once(self) -> None:
+        client = GrpcAgentClient(callback_address="localhost:50052")
+        with patch("bindu.grpc.client.grpc.insecure_channel") as fake_insecure:
+            fake_insecure.return_value = MagicMock(spec=grpc.Channel)
+            client._ensure_connected()
+            client._ensure_connected()
+            assert fake_insecure.call_count == 1

--- a/tests/unit/penguin/test_mtls_setup.py
+++ b/tests/unit/penguin/test_mtls_setup.py
@@ -1,0 +1,134 @@
+"""Tests for the bindu.penguin.mtls_setup wrapper.
+
+The wrapper is mostly a guard layer in front of the async extension; tests
+focus on the toggle behavior (off-by-default, refusal without Hydra
+credentials) and on the success path that returns an initialized extension.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bindu.common.models import AgentCredentials
+from bindu.penguin.mtls_setup import initialize_mtls_extension
+
+
+@pytest.fixture
+def fake_credentials() -> AgentCredentials:
+    return AgentCredentials(
+        agent_id="agent-123",
+        client_id="did:bindu:raahul:test:agent-123",
+        client_secret="s3cret",  # pragma: allowlist secret
+        created_at="2026-05-17T00:00:00Z",
+        scopes=["openid"],
+    )
+
+
+class TestToggleGuards:
+    def test_returns_none_when_mtls_disabled(
+        self, tmp_path: Path, fake_credentials: AgentCredentials
+    ) -> None:
+        with patch("bindu.penguin.mtls_setup.app_settings") as settings:
+            settings.mtls.enabled = False
+            result = initialize_mtls_extension(
+                agent_id="agent-123",
+                agent_did="did:bindu:raahul:test:agent-123",
+                agent_url="https://agent.example.com",
+                pki_dir=tmp_path,
+                hydra_credentials=fake_credentials,
+            )
+        assert result is None
+
+    def test_returns_none_when_hydra_credentials_missing(self, tmp_path: Path) -> None:
+        with patch("bindu.penguin.mtls_setup.app_settings") as settings:
+            settings.mtls.enabled = True
+            result = initialize_mtls_extension(
+                agent_id="agent-123",
+                agent_did="did:bindu:raahul:test:agent-123",
+                agent_url="https://agent.example.com",
+                pki_dir=tmp_path,
+                hydra_credentials=None,
+            )
+        assert result is None
+
+
+class TestBootstrapPath:
+    def test_returns_extension_on_success(
+        self, tmp_path: Path, fake_credentials: AgentCredentials
+    ) -> None:
+        fake_extension = AsyncMock()
+        fake_extension.initialize = AsyncMock(return_value=True)
+        fake_extension.close = AsyncMock()
+        fake_extension.store = AsyncMock()
+
+        with (
+            patch("bindu.penguin.mtls_setup.app_settings") as settings,
+            patch(
+                "bindu.penguin.mtls_setup.MTLSAgentExtension",
+                return_value=fake_extension,
+            ),
+        ):
+            settings.mtls.enabled = True
+            settings.vault.enabled = False
+
+            result = initialize_mtls_extension(
+                agent_id="agent-123",
+                agent_did="did:bindu:raahul:test:agent-123",
+                agent_url="https://agent.example.com",
+                pki_dir=tmp_path,
+                hydra_credentials=fake_credentials,
+            )
+        assert result is fake_extension
+        fake_extension.initialize.assert_awaited_once()
+        fake_extension.close.assert_awaited_once()
+
+    def test_returns_none_when_initialize_fails(
+        self, tmp_path: Path, fake_credentials: AgentCredentials
+    ) -> None:
+        fake_extension = AsyncMock()
+        fake_extension.initialize = AsyncMock(return_value=False)
+        fake_extension.close = AsyncMock()
+
+        with (
+            patch("bindu.penguin.mtls_setup.app_settings") as settings,
+            patch(
+                "bindu.penguin.mtls_setup.MTLSAgentExtension",
+                return_value=fake_extension,
+            ),
+        ):
+            settings.mtls.enabled = True
+            settings.vault.enabled = False
+
+            result = initialize_mtls_extension(
+                agent_id="agent-123",
+                agent_did="did:bindu:raahul:test:agent-123",
+                agent_url="https://agent.example.com",
+                pki_dir=tmp_path,
+                hydra_credentials=fake_credentials,
+            )
+        assert result is None
+        # Still closed cleanly even on failure.
+        fake_extension.close.assert_awaited_once()
+
+    def test_unexpected_exception_returns_none(
+        self, tmp_path: Path, fake_credentials: AgentCredentials
+    ) -> None:
+        with (
+            patch("bindu.penguin.mtls_setup.app_settings") as settings,
+            patch(
+                "bindu.penguin.mtls_setup.MTLSAgentExtension",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            settings.mtls.enabled = True
+            result = initialize_mtls_extension(
+                agent_id="agent-123",
+                agent_did="did:bindu:raahul:test:agent-123",
+                agent_url="https://agent.example.com",
+                pki_dir=tmp_path,
+                hydra_credentials=fake_credentials,
+            )
+        assert result is None

--- a/tests/unit/server/middleware/__init__.py
+++ b/tests/unit/server/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the bindu.server.middleware package."""

--- a/tests/unit/server/middleware/test_mtls_middleware.py
+++ b/tests/unit/server/middleware/test_mtls_middleware.py
@@ -1,0 +1,225 @@
+"""Tests for the mTLS authentication middleware.
+
+The middleware is pure ASGI, so tests construct minimal scope dicts and
+fake send/receive callables — no Starlette TestClient, no live server.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Awaitable, Callable, Optional
+from unittest.mock import patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from bindu.server.middleware.auth.mtls import (
+    SCOPE_KEY_PEER_CERT,
+    SCOPE_KEY_PEER_DID,
+    MTLSMiddleware,
+)
+
+
+# ---------------------------------------------------------------------------
+# Cert fixtures
+# ---------------------------------------------------------------------------
+
+
+def _cert_pem(
+    *, did_in_san: Optional[str] = None, did_in_cn: Optional[str] = None
+) -> str:
+    """Build a self-signed cert PEM with DID placement controlled by args."""
+    pk = ec.generate_private_key(ec.SECP256R1())
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(
+            x509.Name(
+                [x509.NameAttribute(NameOID.COMMON_NAME, did_in_cn or "anonymous")]
+            )
+        )
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test")]))
+        .public_key(pk.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(minutes=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(hours=1))
+    )
+    if did_in_san:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(did_in_san)]),
+            critical=False,
+        )
+    cert = builder.sign(pk, hashes.SHA256())
+    return cert.public_bytes(serialization.Encoding.PEM).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# ASGI scaffolding
+# ---------------------------------------------------------------------------
+
+
+class _RecordingApp:
+    """A minimal downstream ASGI app that just records what it sees."""
+
+    def __init__(self) -> None:
+        self.called = False
+        self.last_scope: Optional[dict] = None
+
+    async def __call__(self, scope, receive, send) -> None:
+        self.called = True
+        self.last_scope = scope
+
+
+def _make_scope(*, path: str = "/", cert_chain: Optional[list[str]] = None) -> dict:
+    scope: dict = {"type": "http", "path": path}
+    if cert_chain is not None:
+        scope["extensions"] = {"tls": {"client_cert_chain": cert_chain}}
+    return scope
+
+
+async def _collect_send() -> tuple[list[dict], Callable[[dict], Awaitable[None]]]:
+    """Return (events_list, send_callable) pair."""
+    events: list[dict] = []
+
+    async def send(event):
+        events.append(event)
+
+    return events, send
+
+
+def _mtls_config(**overrides) -> SimpleNamespace:
+    """Build a settings-like object with the fields the middleware reads."""
+    cfg = {
+        "enabled": True,
+        "mode": "hybrid",
+        "require_client_cert": True,
+    }
+    cfg.update(overrides)
+    return SimpleNamespace(**cfg)
+
+
+def _install_middleware(
+    config: SimpleNamespace, public_endpoints: list[str] | None = None
+) -> tuple[MTLSMiddleware, _RecordingApp]:
+    """Build the middleware while patching the Hydra public-endpoint list."""
+    downstream = _RecordingApp()
+    hydra_ns = SimpleNamespace(public_endpoints=public_endpoints or [])
+    with patch("bindu.server.middleware.auth.mtls.app_settings") as settings:
+        settings.hydra = hydra_ns
+        middleware = MTLSMiddleware(app=downstream, mtls_config=config)
+    return middleware, downstream
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPassThrough:
+    @pytest.mark.asyncio
+    async def test_websocket_scope_passes_through_untouched(self) -> None:
+        middleware, downstream = _install_middleware(_mtls_config())
+        events, send = await _collect_send()
+        scope: dict = {"type": "lifespan"}
+        await middleware(scope, lambda: None, send)
+        assert downstream.called
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_mode_off_passes_through(self) -> None:
+        middleware, downstream = _install_middleware(_mtls_config(mode="off"))
+        events, send = await _collect_send()
+        await middleware(_make_scope(), lambda: None, send)
+        assert downstream.called
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_passes_through(self) -> None:
+        middleware, downstream = _install_middleware(_mtls_config(enabled=False))
+        events, send = await _collect_send()
+        await middleware(_make_scope(), lambda: None, send)
+        assert downstream.called
+
+    @pytest.mark.asyncio
+    async def test_public_endpoint_bypasses_cert_requirement(self) -> None:
+        middleware, downstream = _install_middleware(
+            _mtls_config(),
+            public_endpoints=["/health", "/.well-known/*"],
+        )
+        events, send = await _collect_send()
+        await middleware(_make_scope(path="/health"), lambda: None, send)
+        assert downstream.called
+        assert events == []
+
+
+class TestDIDExtraction:
+    DID = "did:bindu:raahul:test:abc123"
+
+    @pytest.mark.asyncio
+    async def test_uri_san_did_is_injected(self) -> None:
+        middleware, downstream = _install_middleware(_mtls_config())
+        events, send = await _collect_send()
+        scope = _make_scope(cert_chain=[_cert_pem(did_in_san=self.DID)])
+        await middleware(scope, lambda: None, send)
+        assert downstream.called
+        assert downstream.last_scope is not None
+        assert downstream.last_scope[SCOPE_KEY_PEER_DID] == self.DID
+        assert downstream.last_scope[SCOPE_KEY_PEER_CERT].startswith(
+            "-----BEGIN CERTIFICATE-----"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cn_did_is_fallback(self) -> None:
+        middleware, downstream = _install_middleware(_mtls_config())
+        events, send = await _collect_send()
+        scope = _make_scope(cert_chain=[_cert_pem(did_in_cn=self.DID)])
+        await middleware(scope, lambda: None, send)
+        assert downstream.called
+        assert downstream.last_scope is not None
+        assert downstream.last_scope[SCOPE_KEY_PEER_DID] == self.DID
+
+
+class TestRejection:
+    @pytest.mark.asyncio
+    async def test_missing_cert_with_require_client_cert_rejects(self) -> None:
+        middleware, downstream = _install_middleware(_mtls_config())
+        events, send = await _collect_send()
+        await middleware(_make_scope(), lambda: None, send)
+        assert not downstream.called
+        assert events[0]["type"] == "http.response.start"
+        assert events[0]["status"] == 403
+
+    @pytest.mark.asyncio
+    async def test_missing_cert_with_soft_mode_passes_through(self) -> None:
+        middleware, downstream = _install_middleware(
+            _mtls_config(require_client_cert=False)
+        )
+        events, send = await _collect_send()
+        await middleware(_make_scope(), lambda: None, send)
+        assert downstream.called
+        # No peer DID injected since there was no cert.
+        assert downstream.last_scope is not None
+        assert SCOPE_KEY_PEER_DID not in downstream.last_scope
+
+    @pytest.mark.asyncio
+    async def test_cert_without_did_rejects(self) -> None:
+        middleware, downstream = _install_middleware(_mtls_config())
+        events, send = await _collect_send()
+        # Cert has neither URI SAN nor a DID-shaped CN.
+        scope = _make_scope(cert_chain=[_cert_pem()])
+        await middleware(scope, lambda: None, send)
+        assert not downstream.called
+        assert events[0]["status"] == 403
+        assert b"lacks an identifiable DID" in events[1]["body"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_pem_rejected_as_missing_did(self) -> None:
+        middleware, downstream = _install_middleware(_mtls_config())
+        events, send = await _collect_send()
+        scope = _make_scope(cert_chain=["not a pem"])
+        await middleware(scope, lambda: None, send)
+        assert not downstream.called
+        assert events[0]["status"] == 403

--- a/tests/unit/utils/test_http_client_mtls.py
+++ b/tests/unit/utils/test_http_client_mtls.py
@@ -1,0 +1,75 @@
+"""Tests for the mTLS plumbing in AsyncHTTPClient and HybridAuthClient.
+
+These tests focus on the wiring change — that an ssl_context handed in at
+construction time reaches the underlying aiohttp connector, and that
+HybridAuthClient threads an mtls_extension through to its inner HTTP client.
+"""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from bindu.utils.http import AsyncHTTPClient, HybridAuthClient
+
+
+class TestAsyncHTTPClientSSLContext:
+    def test_defaults_to_no_ssl_context(self) -> None:
+        client = AsyncHTTPClient(base_url="https://example.com")
+        assert client.ssl_context is None
+        # verify_ssl preserved as fallback.
+        assert client.verify_ssl is True
+
+    def test_accepts_ssl_context(self) -> None:
+        ctx = ssl.create_default_context()
+        client = AsyncHTTPClient(base_url="https://example.com", ssl_context=ctx)
+        assert client.ssl_context is ctx
+
+
+class TestHybridAuthClientMTLSWiring:
+    def test_constructor_accepts_mtls_extension(self, tmp_path: Path) -> None:
+        did_ext = MagicMock()
+        mtls_ext = MagicMock()
+        client = HybridAuthClient(
+            agent_id="agent-1",
+            credentials_dir=tmp_path,
+            did_extension=did_ext,
+            mtls_extension=mtls_ext,
+        )
+        assert client.mtls_extension is mtls_ext
+
+    def test_default_mtls_extension_is_none(self, tmp_path: Path) -> None:
+        client = HybridAuthClient(
+            agent_id="agent-1",
+            credentials_dir=tmp_path,
+            did_extension=MagicMock(),
+        )
+        assert client.mtls_extension is None
+
+    def test_build_http_client_passes_ssl_context_when_mtls_set(
+        self, tmp_path: Path
+    ) -> None:
+        ctx = ssl.create_default_context()
+        mtls_ext = MagicMock()
+        mtls_ext.build_client_ssl_context.return_value = ctx
+        client = HybridAuthClient(
+            agent_id="agent-1",
+            credentials_dir=tmp_path,
+            did_extension=MagicMock(),
+            mtls_extension=mtls_ext,
+        )
+        http = client._build_http_client(base_url="https://peer.example.com")
+        assert http.ssl_context is ctx
+        mtls_ext.build_client_ssl_context.assert_called_once()
+
+    def test_build_http_client_omits_ssl_context_when_no_mtls(
+        self, tmp_path: Path
+    ) -> None:
+        client = HybridAuthClient(
+            agent_id="agent-1",
+            credentials_dir=tmp_path,
+            did_extension=MagicMock(),
+        )
+        http = client._build_http_client(base_url="https://peer.example.com")
+        assert http.ssl_context is None

--- a/tests/unit/utils/test_tokens_audience.py
+++ b/tests/unit/utils/test_tokens_audience.py
@@ -1,0 +1,83 @@
+"""Tests for the audience-claim plumbing in get_client_credentials_token.
+
+The token request needs to include ``audience=step-ca`` for step-ca's OIDC
+provisioner to accept the resulting token. Verify the parameter is
+forwarded into the form body.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@asynccontextmanager
+async def _fake_client(client_mock: MagicMock) -> AsyncIterator[MagicMock]:
+    """Async context manager that yields the mock — matches http_client()."""
+    yield client_mock
+
+
+class TestAudienceParameter:
+    @pytest.mark.asyncio
+    async def test_audience_forwarded_to_token_request(self) -> None:
+        from bindu.utils.http import tokens
+
+        captured_data: dict = {}
+
+        async def fake_post(endpoint, *, headers=None, data=None, **kwargs):
+            captured_data.update(data or {})
+            resp = MagicMock()
+            resp.status = 200
+            resp.json = AsyncMock(
+                return_value={"access_token": "tok", "id_token": "idtok"}
+            )
+            return resp
+
+        client_mock = MagicMock()
+        client_mock.post = fake_post
+
+        with patch.object(
+            tokens, "http_client", return_value=_fake_client(client_mock)
+        ):
+            result = await tokens.get_client_credentials_token(
+                client_id="did:bindu:test:agent-1",
+                client_secret="s3cret",  # pragma: allowlist secret
+                scope="openid",
+                audience="step-ca",
+            )
+
+        assert result is not None
+        assert captured_data["audience"] == "step-ca"
+        assert captured_data["scope"] == "openid"
+        assert captured_data["grant_type"] == "client_credentials"
+
+    @pytest.mark.asyncio
+    async def test_audience_omitted_when_none(self) -> None:
+        from bindu.utils.http import tokens
+
+        captured_data: dict = {}
+
+        async def fake_post(endpoint, *, headers=None, data=None, **kwargs):
+            captured_data.update(data or {})
+            resp = MagicMock()
+            resp.status = 200
+            resp.json = AsyncMock(return_value={"access_token": "tok"})
+            return resp
+
+        client_mock = MagicMock()
+        client_mock.post = fake_post
+
+        with patch.object(
+            tokens, "http_client", return_value=_fake_client(client_mock)
+        ):
+            await tokens.get_client_credentials_token(
+                client_id="did:bindu:test:agent-1",
+                client_secret="s3cret",  # pragma: allowlist secret
+            )
+
+        # Confirm we didn't sneak an audience field in when none was requested
+        # — deployments without mTLS shouldn't see any behavior change.
+        assert "audience" not in captured_data


### PR DESCRIPTION
## Summary

Adds full mTLS support for agent-to-agent (A2A) traffic, layered on top of the existing DID + Hydra OAuth2 stack. Off by default (`mtls.enabled=False`) so existing deployments are unaffected until the operator opts in.

The agent fetches a short-lived (24h) X.509 cert from a private step-ca, using a Hydra-issued OIDC token as the provisioner credential — same DID/identity flows end to end:

```
Hydra DID  ──►  OIDC token  ──►  step-ca  ──►  X.509 cert (DID in URI SAN)
                                                    │
                                                    ▼
                                         uvicorn / aiohttp / gRPC
                                            with mTLS context
```

See `docs/MTLS_DEPLOYMENT_GUIDE.md` for the CA-side architecture, and the companion infragrid PR for the `step-ca` deploy artifacts (`step-ca-deploy/`).

## Phases (one commit each)

| # | What landed |
|---|---|
| 1 | `MTLSSettings` + `bindu/extensions/mtls/` scaffold; `cert_store` fully implemented (EC P-256 keypair, 0o600 key, CSR with DID-in-CN + URI SAN + DNS SAN, expiry / fingerprint) |
| 2 | `StepCAClient` against `POST /1.0/sign` + `GET /health` + roots fetch; `MTLSAgentExtension.initialize()` orchestrating the bootstrap; `bindu/penguin/mtls_setup.py` wired into bindufy after Hydra registration; Vault backup; `AgentTrust.certificate_fingerprint` stamped on the manifest |
| 3 | `build_server_ssl_context`, `get_uvicorn_ssl_kwargs`, `build_grpc_server_credentials`; `run_server` accepts `ssl_kwargs`; `start_grpc_server` accepts `server_credentials`; bindufy threads them through; warning when `mtls.enabled` but `agent_url` is `http://` |
| 4 | `build_client_ssl_context`, `get_httpx_client_kwargs`, `build_grpc_channel_credentials`; `AsyncHTTPClient` accepts `ssl_context`; `HybridAuthClient` takes optional `mtls_extension`; `GrpcAgentClient` switches to `grpc.secure_channel` when credentials supplied |
| 5 | `MTLSMiddleware` (pure ASGI) reads `scope.extensions.tls.client_cert_chain`, extracts DID from URI SAN (CN fallback), injects `scope["bindu_peer_did"]`; composes with `HydraMiddleware` via `mtls.mode` (`hybrid` runs both, `mtls` skips Hydra) |
| 6 | `renew_if_needed()` + `run_renewal_loop()`; `BinduApplication` accepts `mtls_extension` and spawns the loop as an `asyncio.Task` in lifespan; cancellation is clean |
| fix | `_issue_new_cert` was overwriting `ca_bundle.pem` with the intermediate — caught by end-to-end against a real step-ca. Now writes leaf+intermediate to `tls_cert.pem` and leaves the root as the trust anchor. Regression test pins both invariants. |

## Rollout

* Default `MTLS__ENABLED=false` — zero behavior change for existing agents.
* `mtls.mode=hybrid` — once enabled, mTLS + Hydra both required; cert CN must match Hydra `client_id`.
* `mtls.mode=mtls` — end state; skips Hydra introspection on inbound.
* `require_client_cert=true` — strict by default; bootstrap failure refuses to start in plain HTTP rather than silently downgrade.

## Test plan

- [x] 58 new unit tests (cert_store, step_ca_client, agent_extension, mtls_setup, http auth_client, grpc_client, middleware). Full suite: **1078 passing, 3 skipped** (baseline was 1019).
- [x] **End-to-end** against a real local step-ca (JWK provisioner — Hydra-OIDC path needs production step-ca to validate):
  - Bootstrap: cert issued, persisted, DID in URI SAN, SHA-256 fingerprint computed, both server + client SSL contexts load.
  - Middleware: production `MTLSMiddleware._extract_did` extracts the DID from the cert step-ca just issued.
  - Live TLS handshake: server uses issued cert, client connects with mTLS, peer DID surfaces on the server side.
- [ ] Hydra → OIDC → step-ca path: needs production step-ca up before this can be exercised end-to-end (companion infragrid PR).
- [ ] Canary one agent with `MTLS__ENABLED=true` in staging once step-ca is deployed; verify A2A still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mutual TLS (mTLS) support: bootstrap, persistent storage, renewal, and fingerprinting of certs
  * Step CA provisioning + optional Vault backup for cert/key/CA material
  * mTLS-enabled auth middleware extracting peer DID and injecting into requests
  * TLS/mTLS wiring for HTTP clients, gRPC client/server, and server startup (uvicorn)
* **Tests**
  * Unit tests covering mTLS lifecycle, middleware, clients, settings, and Step CA interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->