### PR TITLE
fix(mtls): cap CSR CN at 64 bytes; trust transport-layer cert enforcement

### DIFF
--- a/bindu/extensions/mtls/cert_store.py
+++ b/bindu/extensions/mtls/cert_store.py
@@ -177,7 +177,11 @@ class CertStore:
         builder = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(
-                x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, agent_did)])
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, _shorten_cn(agent_did)),
+                    ]
+                )
             )
             .add_extension(x509.SubjectAlternativeName(san_entries), critical=False)
         )
@@ -259,3 +263,29 @@ def _hostname_from_url(url: str) -> Optional[str]:
     except ValueError:
         return None
     return parsed.hostname
+
+
+# X.509 CommonName is capped at 64 bytes by RFC 5280. Real Bindu DIDs of
+# the shape ``did:bindu:{author}:{name}:{agent_id}`` routinely exceed
+# that — an email author + a meaningful agent name + a 36-char UUID
+# easily clears 80 chars. The full DID still goes in the URI SAN (which
+# has no length cap), and step-ca's OIDC provisioner overrides whatever
+# we put in CN with the token's ``sub`` claim anyway, so the CN we send
+# is largely cosmetic. We use the last colon-delimited segment (the
+# agent UUID for the canonical DID format) as the CN — short, stable,
+# unique, and human-readable.
+_CN_MAX_LEN = 64
+
+
+def _shorten_cn(agent_did: str) -> str:
+    """Produce a CN value ≤ 64 bytes from any DID.
+
+    Tries the last ``:``-delimited segment first (the agent UUID under the
+    canonical ``did:bindu:author:name:id`` shape). Falls back to a hard
+    truncation for DIDs whose tail segment is itself >64 bytes — both
+    pathways yield a stable derivative of the input.
+    """
+    last_segment = agent_did.rsplit(":", 1)[-1]
+    if 0 < len(last_segment) <= _CN_MAX_LEN:
+        return last_segment
+    return agent_did[:_CN_MAX_LEN]

--- a/bindu/server/middleware/auth/mtls.py
+++ b/bindu/server/middleware/auth/mtls.py
@@ -95,10 +95,26 @@ class MTLSMiddleware:
 
         cert_chain = self._extract_cert_chain(scope)
         if not cert_chain:
-            if self.config.require_client_cert:
-                await self._reject(send, 403, "Client certificate required")
-                return
-            # Soft mode — no peer cert but mTLS doesn't strictly require one.
+            # uvicorn (and most ASGI servers as of 2026-05) doesn't
+            # populate scope.extensions.tls.client_cert_chain — the
+            # peer cert never reaches ASGI. But uvicorn DOES enforce
+            # the cert at the TLS handshake layer when
+            # ssl_cert_reqs=CERT_REQUIRED, which we set from
+            # ``require_client_cert``. So when the chain is absent we
+            # trust the transport-layer enforcement: the connection
+            # would not have completed the handshake without a valid
+            # peer cert chained to our trust root. We just can't
+            # extract the DID to put on scope, so downstream code that
+            # wants to authorize by peer DID has to fall back to
+            # token-based identity (HydraMiddleware in hybrid mode).
+            #
+            # Hypercorn and a future uvicorn that implements the ASGI
+            # TLS extension will hit the path below; this fallback is
+            # for current production.
+            logger.debug(
+                "TLS extension empty in ASGI scope; trusting transport-layer "
+                "enforcement (uvicorn ssl_cert_reqs). Peer DID not extracted."
+            )
             await self.app(scope, receive, send)
             return
 

--- a/tests/e2e/mtls/__init__.py
+++ b/tests/e2e/mtls/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end mTLS tests against production endpoints."""

--- a/tests/e2e/mtls/canary.py
+++ b/tests/e2e/mtls/canary.py
@@ -1,0 +1,258 @@
+"""Production canary for the mTLS bootstrap path.
+
+Exercises the live stack end-to-end against the production deployment:
+
+  1. Register a throwaway OAuth2 client in Hydra with ``audience=step-ca``
+  2. Mint a token via ``client_credentials`` grant, requesting that audience
+  3. Verify the token actually carries ``aud=step-ca`` in its claims
+  4. Drive ``MTLSAgentExtension.initialize()`` against the real
+     ``https://ca.getbindu.com`` using that token
+  5. Walk away with a real X.509 cert signed by the live Bindu Intermediate CA
+  6. Clean up the OAuth2 client
+
+Every network call hits the real production endpoint — no mocks, no
+local docker, no shortcuts. This is the smoke test for "step-ca is alive
+and Bindu agents can fetch certs from it."
+
+Running it
+----------
+    uv run python tests/e2e/mtls/canary.py
+
+The script auto-cleans up its Hydra client at the end, even on failure.
+If the cleanup itself fails (network blip, etc.), the leftover client_id
+is logged so you can ``curl -X DELETE`` it manually against
+``https://hydra-admin.getbindu.com/admin/clients/<id>``.
+
+Not run in CI
+-------------
+This isn't a pytest test on purpose:
+
+* Each run creates and deletes a real OAuth2 client in production Hydra.
+* It depends on DNS for ca.getbindu.com and hydra.getbindu.com working.
+* CI sandboxes typically can't reach production from inside their network.
+
+Run it manually when you want to verify the production stack — e.g. after
+an infra change to Hydra, a step-ca redeploy, or a Caddyfile shuffle.
+
+Prerequisites
+-------------
+* ``MTLS__ENABLED`` does NOT need to be set — the canary drives the
+  extension directly with explicit URLs.
+* Hydra must have ``STRATEGIES_ACCESS_TOKEN=jwt`` set (see
+  ``infragrid/bindu-prod-cluster/shelley-deploy/compose/hydra.yml`` for
+  the operational note). Without this Hydra returns opaque access tokens
+  that step-ca cannot verify.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import secrets
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+
+from bindu.extensions.mtls import MTLSAgentExtension
+from bindu.extensions.mtls.step_ca_client import StepCAClient
+from bindu.utils.http.tokens import get_client_credentials_token
+
+
+HYDRA_ADMIN = "https://hydra-admin.getbindu.com"
+CA_URL = "https://ca.getbindu.com"
+
+CANARY_ID = f"bindu-mtls-canary-{int(time.time())}"
+CANARY_SECRET = secrets.token_urlsafe(32)  # pragma: allowlist secret
+AGENT_DID = f"did:bindu:test:canary:{int(time.time())}"
+
+
+def run(cmd: list[str], *, input: bytes | None = None) -> str:
+    """Subprocess helper that fails loudly."""
+    result = subprocess.run(cmd, input=input, capture_output=True, check=False)
+    if result.returncode != 0:
+        print(f"  ! cmd failed: {' '.join(cmd)}")
+        print(f"    stdout: {result.stdout.decode(errors='replace')[:500]}")
+        print(f"    stderr: {result.stderr.decode(errors='replace')[:500]}")
+        sys.exit(1)
+    return result.stdout.decode()
+
+
+def decode_jwt_payload(token: str) -> dict:
+    """Decode (not verify) a JWT and return the payload."""
+    payload = token.split(".")[1]
+    # JWT base64 is URL-safe and unpadded; add padding to get back to a
+    # multiple of 4 so b64decode doesn't choke.
+    payload += "=" * (-len(payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(payload))
+
+
+def register_canary() -> None:
+    """Create the throwaway OAuth2 client in production Hydra."""
+    print(f"\n=== Phase 1: register {CANARY_ID} in Hydra ===")
+    body = {
+        "client_id": CANARY_ID,
+        "client_secret": CANARY_SECRET,
+        "client_name": "bindu mTLS production canary",
+        "grant_types": ["client_credentials"],
+        "response_types": ["token"],
+        "scope": "openid",
+        "audience": ["step-ca"],
+        "token_endpoint_auth_method": "client_secret_post",
+    }
+    out = run(
+        [
+            "curl",
+            "-sfS",
+            "-X",
+            "POST",
+            f"{HYDRA_ADMIN}/admin/clients",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            json.dumps(body),
+        ]
+    )
+    parsed = json.loads(out)
+    assert parsed["client_id"] == CANARY_ID
+    assert parsed.get("audience") == ["step-ca"], parsed.get("audience")
+    print(
+        f"  ✓ client registered: client_id={CANARY_ID}, audience={parsed['audience']}"
+    )
+
+
+def cleanup_canary() -> None:
+    """Delete the throwaway client. Best-effort; doesn't fail the test."""
+    print(f"\n=== Cleanup: delete {CANARY_ID} from Hydra ===")
+    result = subprocess.run(
+        ["curl", "-sS", "-X", "DELETE", f"{HYDRA_ADMIN}/admin/clients/{CANARY_ID}"],
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        print("  ✓ deleted (no traces left in Hydra)")
+    else:
+        print(f"  ! cleanup failed; remove manually: {CANARY_ID}")
+
+
+async def phase_2_token_with_audience() -> str:
+    """Mint a token and verify it actually carries aud=step-ca."""
+    print("\n=== Phase 2: get Hydra token with audience=step-ca ===")
+    result = await get_client_credentials_token(
+        client_id=CANARY_ID,
+        client_secret=CANARY_SECRET,
+        scope="openid",
+        audience="step-ca",
+    )
+    assert result is not None, "Hydra returned no token"
+    token = result.get("id_token") or result["access_token"]
+    print(f"  ✓ Hydra returned a token ({len(token)} chars)")
+
+    payload = decode_jwt_payload(token)
+    aud = payload.get("aud")
+    if isinstance(aud, str):
+        aud = [aud]
+    assert aud and "step-ca" in aud, f"aud={aud!r} (expected to contain 'step-ca')"
+    print(f"  ✓ token aud claim = {aud}")
+    print(f"  ✓ token iss claim = {payload.get('iss')!r}")
+    return token
+
+
+async def phase_3_bootstrap_against_prod(token: str) -> None:
+    """Drive MTLSAgentExtension.initialize() against the real ca.getbindu.com."""
+    print("\n=== Phase 3: bootstrap cert via production step-ca ===")
+    with tempfile.TemporaryDirectory() as d:
+        pki_dir = Path(d)
+        step_ca = StepCAClient(
+            ca_url=CA_URL,
+            ca_root_url=f"{CA_URL}/roots.pem",
+            verify_ssl=True,
+        )
+
+        async def token_provider() -> str:
+            return token
+
+        ext = MTLSAgentExtension(
+            pki_dir=pki_dir,
+            agent_did=AGENT_DID,
+            agent_url=None,
+            oidc_token_provider=token_provider,
+            step_ca=step_ca,
+        )
+
+        ok = await ext.initialize()
+        await ext.close()
+        assert ok, "MTLSAgentExtension.initialize() returned False"
+
+        cert = x509.load_pem_x509_certificate(ext.store.read_cert())
+        print(f"  ✓ cert issued by: {cert.issuer.rfc4514_string()}")
+        print(f"  ✓ cert subject:   {cert.subject.rfc4514_string()}")
+        not_before = getattr(cert, "not_valid_before_utc", cert.not_valid_before)
+        not_after = getattr(cert, "not_valid_after_utc", cert.not_valid_after)
+        print(f"  ✓ not valid before / after: {not_before} → {not_after}")
+
+        # step-ca's OIDC provisioner ignores the CSR's SANs and synthesizes
+        # identity from token claims:
+        #   CN      = sub claim (= OAuth client_id under client_credentials)
+        #   URI SAN = {iss}#{sub}
+        # In production, Bindu agents register their DID as the client_id,
+        # so CN ends up being the agent's DID — that's the canonical path
+        # MTLSMiddleware._extract_did reads via its CN fallback. The
+        # canary uses a synthetic client_id, so we just sanity-check the
+        # subject matches whoever holds the credential.
+        try:
+            san = cert.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            ).value
+            uris = list(san.get_values_for_type(x509.UniformResourceIdentifier))
+            dns = list(san.get_values_for_type(x509.DNSName))
+            emails = list(san.get_values_for_type(x509.RFC822Name))
+            print(f"  ✓ SAN: uris={uris} dns={dns} emails={emails}")
+        except x509.ExtensionNotFound:
+            print("  ✓ SAN: (none — OIDC provisioner emitted no SAN extension)")
+
+        cn_attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn_attrs, "cert has no CN"
+        assert cn_attrs[0].value == CANARY_ID, (
+            f"cert CN {cn_attrs[0].value!r} != canary client_id {CANARY_ID!r}"
+        )
+        print("  ✓ cert CN matches the authenticated client_id")
+
+        # Cert file holds leaf + intermediate concatenated; the CA bundle
+        # is the trust anchor (root only). Both are verified by parsing.
+        chain_pem = ext.store.read_cert()
+        chain_certs = []
+        for block in chain_pem.split(b"-----BEGIN CERTIFICATE-----"):
+            if b"END CERTIFICATE" in block:
+                pem = b"-----BEGIN CERTIFICATE-----" + block
+                chain_certs.append(x509.load_pem_x509_certificate(pem))
+        print(f"  ✓ cert file holds {len(chain_certs)} cert(s) (leaf + intermediate)")
+        if len(chain_certs) >= 2:
+            print(f"    leaf issuer:       {chain_certs[0].issuer.rfc4514_string()}")
+            print(f"    intermediate from: {chain_certs[1].issuer.rfc4514_string()}")
+
+        bundle = x509.load_pem_x509_certificate(ext.store.read_ca_bundle())
+        print(f"  ✓ CA bundle (root) subject: {bundle.subject.rfc4514_string()}")
+        fp = ext.cert_fingerprint
+        assert fp is not None
+        print(f"  ✓ SHA-256 fingerprint: {fp[:23]}…")
+
+
+async def main() -> int:
+    """Drive all three phases. Cleanup runs even on failure."""
+    register_canary()
+    try:
+        token = await phase_2_token_with_audience()
+        await phase_3_bootstrap_against_prod(token)
+        print("\n=== production mTLS canary: all phases passed ===")
+        return 0
+    finally:
+        cleanup_canary()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/unit/extensions/mtls/test_cert_store.py
+++ b/tests/unit/extensions/mtls/test_cert_store.py
@@ -80,12 +80,51 @@ class TestKeyGeneration:
 class TestCSRBuilding:
     DID = "did:bindu:raahul:test:abc123"
 
-    def test_csr_contains_did_in_subject(self, store: CertStore) -> None:
+    def test_csr_cn_carries_short_identifier(self, store: CertStore) -> None:
+        """CN is the DID's last colon-delimited segment.
+
+        Full DID lands in the URI SAN (no length cap). CN gets the
+        ``agent_id`` segment so long DIDs don't blow the X.509 64-byte
+        cap. Either way, step-ca's OIDC provisioner overrides the CN
+        with the token's ``sub`` claim in the issued cert.
+        """
         private_key, _ = store.generate_keypair()
         csr_pem = store.build_csr(private_key, self.DID)
         csr = x509.load_pem_x509_csr(csr_pem)
         cn_attr = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
-        assert cn_attr[0].value == self.DID
+        assert cn_attr[0].value == "abc123"  # last segment of self.DID
+
+    def test_csr_cn_truncates_when_segment_too_long(
+        self, store: CertStore, tmp_path
+    ) -> None:
+        """Pathological DIDs whose tail segment itself >64b fall back to truncation."""
+        private_key, _ = store.generate_keypair()
+        ridiculous = "did:weird:" + ("x" * 200)
+        csr_pem = store.build_csr(private_key, ridiculous)
+        csr = x509.load_pem_x509_csr(csr_pem)
+        cn = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+        assert len(cn) == 64
+
+    def test_csr_handles_real_world_long_did(self, store: CertStore) -> None:
+        """Production-shape DIDs (>64 chars) build a valid CSR.
+
+        Regression: an 80-char DID like
+        did:bindu:author@example.com:agent-name:<uuid> used to blow up
+        with ``Attribute's length must be >= 1 and <= 64`` because the
+        full DID landed in the CN.
+        """
+        private_key, _ = store.generate_keypair()
+        long_did = (
+            "did:bindu:author@example.com:realistic_agent_name:"
+            "ef87a1d5-ea3b-4c34-d590-ad07fb18f864"
+        )
+        assert len(long_did) > 64
+        # Must not raise.
+        csr_pem = store.build_csr(private_key, long_did)
+        csr = x509.load_pem_x509_csr(csr_pem)
+        # Full DID still present in URI SAN — only CN is shortened.
+        san = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        assert long_did in san.get_values_for_type(x509.UniformResourceIdentifier)
 
     def test_csr_includes_did_as_uri_san(self, store: CertStore) -> None:
         private_key, _ = store.generate_keypair()

--- a/tests/unit/server/middleware/test_mtls_middleware.py
+++ b/tests/unit/server/middleware/test_mtls_middleware.py
@@ -184,13 +184,24 @@ class TestDIDExtraction:
 
 class TestRejection:
     @pytest.mark.asyncio
-    async def test_missing_cert_with_require_client_cert_rejects(self) -> None:
+    async def test_empty_scope_passes_through_trusting_transport(self) -> None:
+        """When uvicorn doesn't expose the cert in scope, the middleware
+        trusts the TLS-layer enforcement (ssl_cert_reqs=CERT_REQUIRED).
+
+        Rationale: uvicorn 0.46 doesn't implement the ASGI TLS extension
+        for client_cert_chain. If the connection reached ASGI, uvicorn
+        already validated the cert at the handshake. Rejecting here
+        would just double-enforce, and break the request path entirely.
+        Downstream code that wants DID-based authorization needs another
+        identity source (the Hydra Bearer token in hybrid mode).
+        """
         middleware, downstream = _install_middleware(_mtls_config())
         events, send = await _collect_send()
         await middleware(_make_scope(), lambda: None, send)
-        assert not downstream.called
-        assert events[0]["type"] == "http.response.start"
-        assert events[0]["status"] == 403
+        assert downstream.called
+        # No peer DID injected — we couldn't extract one.
+        assert downstream.last_scope is not None
+        assert SCOPE_KEY_PEER_DID not in downstream.last_scope
 
     @pytest.mark.asyncio
     async def test_missing_cert_with_soft_mode_passes_through(self) -> None:


### PR DESCRIPTION
## Why

Two issues uncovered during a full end-to-end run against the production deployment (real Hydra at \`hydra.getbindu.com\`, real step-ca at \`ca.getbindu.com\`, real \`bindufy\` agent on localhost, real driver doing JSON-RPC over mTLS). Neither was caught by unit tests because the fixtures use short DIDs and the middleware was tested against a synthetic scope with the cert chain populated.

## 1. \`cert_store.build_csr\` — 64-byte CN ceiling

Production Bindu DIDs look like:

\`\`\`
did:bindu:author@example.com:realistic_agent_name:ef87a1d5-ea3b-4c34-d590-ad07fb18f864
\`\`\`

That's 80+ chars. X.509 caps CN at 64 bytes (RFC 5280), and the cryptography library raises \`ValueError: Attribute's length must be >= 1 and <= 64\` when building such a CSR — every real agent would hit this on first cert request.

The CN we send is largely cosmetic anyway: step-ca's OIDC provisioner overrides it with the token's \`sub\` claim. So:

- Full DID still goes in the URI SAN (no length cap)
- CN now uses the DID's last colon-delimited segment (the agent UUID for the canonical shape)
- Hard 64-byte truncate as fallback for pathological tails

Regression tests cover both the canonical shape and the truncation path.

## 2. \`MTLSMiddleware\` — uvicorn doesn't expose peer certs

uvicorn 0.46 (and prior) does not implement the ASGI TLS extension's \`client_cert_chain\` field. The peer cert never reaches ASGI even when uvicorn is running with \`ssl_cert_reqs=CERT_REQUIRED\`.

The previous middleware logic rejected with 403 on empty scope, which meant strict \`require_client_cert\` double-enforced at both layers and **rejected every request** — uvicorn already validated the cert at the handshake, but the middleware then 403'd because it couldn't re-validate from scope.

New behavior: when scope doesn't expose the chain, trust the transport-layer enforcement (uvicorn would have rejected the handshake without a valid peer cert chained to our trust root) and pass through. Downstream code that wants peer-DID authorization falls back to the Bearer-token identity in hybrid mode.

The Hypercorn / forward-header path that surfaces the cert to ASGI is a separate production follow-up.

## End-to-end verified

\`\`\`
[driver]  spawn agent       → bindufy on https://localhost:18443
[agent]   ✓ DID registered, cert from prod step-ca, uvicorn over TLS
[driver]  GET /health                                → 200
[driver]  GET /.well-known/agent.json                → 200
[driver]  POST / (jsonrpc message/send, cert+token)  → 200, handler ran
[driver]  === e2e: all phases passed ===
\`\`\`

## Test plan

- [x] New regression tests for both fixes (cert_store CN length, middleware empty-scope pass-through).
- [x] Full unit suite still green.
- [x] Live end-to-end against production (Hydra + step-ca + bindufy + driver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * mTLS certificate generation now uses shortened Common Name fields while preserving full identifiers in certificate extensions

* **Improvements**
  * mTLS middleware now delegates client certificate enforcement to the transport layer for streamlined request handling

* **Tests**
  * Added production end-to-end mTLS test suite
  * Enhanced test coverage for certificate generation and middleware behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->