### PR TITLE
feat(inbox,gateway): mTLS on by default — Phases A+B+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
     <a href="https://discord.gg/3w5zuYUuwt"><img alt="Discord" src="https://img.shields.io/badge/Discord-7289DA?logo=discord&logoColor=white"></a>
     <a href="https://github.com/getbindu/Bindu/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/getbindu/Bindu"></a>
     <a href="https://hits.sh/github.com/Saptha-me/Bindu.svg"><img alt="Hits" src="https://hits.sh/github.com/Saptha-me/Bindu.svg"></a>
+    <a href="https://www.star-history.com/getbindu/bindu">
+        <picture>
+            <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/badge?repo=GetBindu/Bindu&theme=dark" />
+            <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/badge?repo=GetBindu/Bindu" />
+            <img alt="Star History Rank" src="https://api.star-history.com/badge?repo=GetBindu/Bindu" />
+        </picture>
+    </a>
 </p>
 
 <h4 align="center">

--- a/bindu/auth/hydra/client.py
+++ b/bindu/auth/hydra/client.py
@@ -178,6 +178,33 @@ class HydraClient:
             logger.error(f"Failed to get OAuth client: {error}")
             raise
 
+    async def update_oauth_client(
+        self, client_id: str, client_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Replace an OAuth2 client's config.
+
+        Hydra's PUT /admin/clients/{id} is a full replace, not a patch — the
+        caller must supply the complete desired state. Used by the agent's
+        registration flow to reconcile drift (e.g. adding the step-ca audience
+        when mTLS is turned on against a client that was first registered
+        without it).
+        """
+        try:
+            encoded_client_id = quote(client_id, safe="")
+            response = await self._http_client.put(
+                f"/admin/clients/{encoded_client_id}", json=client_data
+            )
+
+            if response.status not in (200, 201):
+                error_text = await response.text()
+                raise ValueError(f"Failed to update OAuth client: {error_text}")
+
+            return await response.json()
+
+        except Exception as error:
+            logger.error(f"Failed to update OAuth client: {error}")
+            raise
+
     async def list_oauth_clients(
         self, limit: int = 100, offset: int = 0
     ) -> List[Dict[str, Any]]:

--- a/bindu/auth/hydra/registration.py
+++ b/bindu/auth/hydra/registration.py
@@ -180,6 +180,41 @@ async def register_agent_in_hydra(
                 if existing_creds:
                     logger.info(f"OAuth credentials verified for DID: {did}")
 
+                    # Reconcile audience drift. When mTLS is enabled we need
+                    # `oidc_audience` in the client's allowed audiences, or
+                    # step-ca token requests later fail with
+                    # "Requested audience '<x>' has not been whitelisted".
+                    # Agents first registered with mTLS off (or before mTLS
+                    # support shipped) have an empty/stale audience array;
+                    # patch them in place rather than forcing a manual
+                    # admin-side fix.
+                    if app_settings.mtls.enabled:
+                        desired_aud = app_settings.mtls.oidc_audience
+                        current_aud = existing_client.get("audience") or []
+                        if desired_aud not in current_aud:
+                            # Hydra's PUT /admin/clients/{id} is a FULL replace.
+                            # GET never returns the client_secret hash, so a PUT
+                            # built from the GET response would either drop the
+                            # secret or trigger a rotation — either way the next
+                            # client_credentials call fails with 401
+                            # "passwords do not match". Re-send the secret from
+                            # the local creds we just loaded so Hydra preserves
+                            # the existing password row.
+                            updated = {
+                                **existing_client,
+                                "audience": [*current_aud, desired_aud],
+                                "client_secret": existing_creds.client_secret,
+                            }
+                            try:
+                                await hydra.update_oauth_client(client_id, updated)
+                                logger.info(
+                                    f"Patched Hydra client {client_id} to include audience={desired_aud}"
+                                )
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to patch audience on existing Hydra client {client_id}: {e}"
+                                )
+
                     # Backup to Vault if enabled and not already there
                     if vault_client and not vault_creds:
                         try:

--- a/bindu/penguin/bindufy.py
+++ b/bindu/penguin/bindufy.py
@@ -595,10 +595,15 @@ def _bindufy_core(
     # Create telemetry configuration
     telemetry_config = _create_telemetry_config(validated_config)
 
-    # Create Bindu application with configs
+    # Create Bindu application with configs. `url=agent_url` is load-bearing:
+    # the agent-card endpoint reads `app.url` (not `manifest.url`) when
+    # building /.well-known/agent.json, so without this the card advertises
+    # the BinduApplication default of "http://localhost" — peers fetching
+    # the card can't reach back. See bindu/server/endpoints/agent_card.py:126.
     bindu_app = BinduApplication(
         penguin_id=agent_id,
         manifest=_manifest,
+        url=agent_url,
         version=validated_config["version"],
         auth_enabled=app_settings.auth.enabled,
         telemetry_config=telemetry_config,

--- a/examples/gateway_test_fleet/faq_agent.py
+++ b/examples/gateway_test_fleet/faq_agent.py
@@ -14,12 +14,7 @@ Environment:
 
 import os
 
-from agno.agent import Agent
-from agno.models.openrouter import OpenRouter
-from agno.tools.duckduckgo import DuckDuckGoTools
 from dotenv import load_dotenv
-
-from bindu.penguin.bindufy import bindufy
 
 # Per-agent override: this agent demos Hydra-protected calls even when
 # the shared examples/.env keeps AUTH__ENABLED=false for the rest of the
@@ -28,7 +23,16 @@ from bindu.penguin.bindufy import bindufy
 os.environ["AUTH__ENABLED"] = "true"
 os.environ.setdefault("AUTH__PROVIDER", "hydra")
 
+# Load .env BEFORE importing bindu — `bindu.settings:app_settings = Settings()`
+# is constructed at module-import time, so any MTLS__/AUTH__/HYDRA__ vars set
+# by a later load_dotenv land in os.environ but never reach the singleton.
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+from agno.agent import Agent  # noqa: E402
+from agno.models.openrouter import OpenRouter  # noqa: E402
+from agno.tools.duckduckgo import DuckDuckGoTools  # noqa: E402
+
+from bindu.penguin.bindufy import bindufy  # noqa: E402
 
 PORT = int(os.getenv("BINDU_PORT", "5778"))
 
@@ -63,9 +67,9 @@ config = {
     "name": "bindu_docs_agent",
     "description": "Answers Bindu documentation questions with cited sources.",
     "deployment": {
-        "url": f"http://localhost:{PORT}",
+        "url": f"https://127.0.0.1:{PORT}",
         "expose": True,
-        "cors_origins": ["http://localhost:5173"],
+        "cors_origins": ["http://localhost:5173", "http://localhost:3775"],
     },
     "capabilities": {"push_notifications": True},
     "global_webhook_url": "http://127.0.0.1:3787/webhooks/bindu/bindu_docs_agent",

--- a/examples/gateway_test_fleet/joke_agent.py
+++ b/examples/gateway_test_fleet/joke_agent.py
@@ -19,13 +19,17 @@ Environment:
 
 import os
 
-from agno.agent import Agent
-from agno.models.openrouter import OpenRouter
 from dotenv import load_dotenv
 
-from bindu.penguin.bindufy import bindufy
-
+# Load .env BEFORE importing bindu — `bindu.settings:app_settings = Settings()`
+# is constructed at module-import time, so any MTLS__/AUTH__/HYDRA__ vars set
+# by a later load_dotenv land in os.environ but never reach the singleton.
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+from agno.agent import Agent  # noqa: E402
+from agno.models.openrouter import OpenRouter  # noqa: E402
+
+from bindu.penguin.bindufy import bindufy  # noqa: E402
 
 PORT = int(os.getenv("BINDU_PORT", "5773"))
 
@@ -52,9 +56,12 @@ config = {
     "name": "joke_agent",
     "description": "Tells jokes on request. Declines anything else.",
     "deployment": {
-        "url": f"http://localhost:{PORT}",
+        # https + 127.0.0.1: matches what bindu actually serves when
+        # MTLS__ENABLED=true (peers fetching /.well-known/agent.json
+        # would otherwise see http://localhost and fail to reach back).
+        "url": f"https://127.0.0.1:{PORT}",
         "expose": True,
-        "cors_origins": ["http://localhost:5173"],
+        "cors_origins": ["http://localhost:5173", "http://localhost:3775"],
     },
     "capabilities": {"push_notifications": True},
     "global_webhook_url": "http://127.0.0.1:3787/webhooks/bindu/joke_agent",

--- a/examples/gateway_test_fleet/math_agent.py
+++ b/examples/gateway_test_fleet/math_agent.py
@@ -21,13 +21,17 @@ Environment:
 
 import os
 
-from agno.agent import Agent
-from agno.models.openrouter import OpenRouter
 from dotenv import load_dotenv
 
-from bindu.penguin.bindufy import bindufy
-
+# Load .env BEFORE importing bindu — `bindu.settings:app_settings = Settings()`
+# is constructed at module-import time, so any MTLS__/AUTH__/HYDRA__ vars set
+# by a later load_dotenv land in os.environ but never reach the singleton.
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+from agno.agent import Agent  # noqa: E402
+from agno.models.openrouter import OpenRouter  # noqa: E402
+
+from bindu.penguin.bindufy import bindufy  # noqa: E402
 
 PORT = int(os.getenv("BINDU_PORT", "5775"))
 
@@ -55,9 +59,12 @@ config = {
     "name": "math_agent",
     "description": "Solves math problems step-by-step. Declines anything else.",
     "deployment": {
-        "url": f"http://localhost:{PORT}",
+        # https + 127.0.0.1: matches what bindu actually serves when
+        # MTLS__ENABLED=true (peers fetching /.well-known/agent.json
+        # would otherwise see http://localhost and fail to reach back).
+        "url": f"https://127.0.0.1:{PORT}",
         "expose": True,
-        "cors_origins": ["http://localhost:5173"],
+        "cors_origins": ["http://localhost:5173", "http://localhost:3775"],
     },
     "capabilities": {"push_notifications": True},
     "global_webhook_url": "http://127.0.0.1:3787/webhooks/bindu/math_agent",

--- a/examples/gateway_test_fleet/poet_agent.py
+++ b/examples/gateway_test_fleet/poet_agent.py
@@ -14,11 +14,7 @@ Environment:
 
 import os
 
-from agno.agent import Agent
-from agno.models.openrouter import OpenRouter
 from dotenv import load_dotenv
-
-from bindu.penguin.bindufy import bindufy
 
 # Per-agent override: this agent demos Hydra-protected calls even when
 # the shared examples/.env keeps AUTH__ENABLED=false for the rest of the
@@ -27,7 +23,15 @@ from bindu.penguin.bindufy import bindufy
 os.environ["AUTH__ENABLED"] = "true"
 os.environ.setdefault("AUTH__PROVIDER", "hydra")
 
+# Load .env BEFORE importing bindu — `bindu.settings:app_settings = Settings()`
+# is constructed at module-import time, so any MTLS__/AUTH__/HYDRA__ vars set
+# by a later load_dotenv land in os.environ but never reach the singleton.
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+from agno.agent import Agent  # noqa: E402
+from agno.models.openrouter import OpenRouter  # noqa: E402
+
+from bindu.penguin.bindufy import bindufy  # noqa: E402
 
 PORT = int(os.getenv("BINDU_PORT", "5776"))
 
@@ -55,9 +59,9 @@ config = {
     "name": "poet_agent",
     "description": "Writes short poems (max 4 lines). Declines anything else.",
     "deployment": {
-        "url": f"http://localhost:{PORT}",
+        "url": f"https://127.0.0.1:{PORT}",
         "expose": True,
-        "cors_origins": ["http://localhost:5173"],
+        "cors_origins": ["http://localhost:5173", "http://localhost:3775"],
     },
     "capabilities": {"push_notifications": True},
     "global_webhook_url": "http://127.0.0.1:3787/webhooks/bindu/poet_agent",

--- a/examples/gateway_test_fleet/research_agent.py
+++ b/examples/gateway_test_fleet/research_agent.py
@@ -18,14 +18,18 @@ Environment:
 
 import os
 
-from agno.agent import Agent
-from agno.models.openrouter import OpenRouter
-from agno.tools.duckduckgo import DuckDuckGoTools
 from dotenv import load_dotenv
 
-from bindu.penguin.bindufy import bindufy
-
+# Load .env BEFORE importing bindu — `bindu.settings:app_settings = Settings()`
+# is constructed at module-import time, so any MTLS__/AUTH__/HYDRA__ vars set
+# by a later load_dotenv land in os.environ but never reach the singleton.
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+from agno.agent import Agent  # noqa: E402
+from agno.models.openrouter import OpenRouter  # noqa: E402
+from agno.tools.duckduckgo import DuckDuckGoTools  # noqa: E402
+
+from bindu.penguin.bindufy import bindufy  # noqa: E402
 
 PORT = int(os.getenv("BINDU_PORT", "5777"))
 
@@ -53,9 +57,9 @@ config = {
     "name": "research_agent",
     "description": "Researches topics via web search and summarizes findings.",
     "deployment": {
-        "url": f"http://localhost:{PORT}",
+        "url": f"https://127.0.0.1:{PORT}",
         "expose": True,
-        "cors_origins": ["http://localhost:5173"],
+        "cors_origins": ["http://localhost:5173", "http://localhost:3775"],
     },
     "capabilities": {"push_notifications": True},
     "global_webhook_url": "http://127.0.0.1:3787/webhooks/bindu/research_agent",

--- a/examples/gateway_test_fleet/run_matrix.sh
+++ b/examples/gateway_test_fleet/run_matrix.sh
@@ -253,7 +253,65 @@ case_Q13() {
 EOF
 }
 
-ALL_CASES=(Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8 Q9 Q10 Q11 Q12 Q_MULTIHOP)
+# --------------------------------------------------------------------
+# Inbox-reproduction regression cases.
+#
+# These three cases mirror bugs first observed in the operator inbox
+# (compound prompt produced only one agent's reply; turn-2 follow-up
+# stuck to turn-1's agent; resubmitting a draft after a timeout
+# double-billed). The first two pass against /plan today and exist as
+# regression guards. The third (_C) currently fails — /plan has no
+# idempotency — and is excluded from ALL_CASES so the matrix stays
+# green. Run it explicitly with `run_dup_check` (see below the matrix).
+# --------------------------------------------------------------------
+
+case_Q_INBOX_REPRO_A() {
+  # The exact prompt that surfaced the bug in the inbox log: a single
+  # message requiring TWO agents (math, then joke about the result).
+  # Today /plan handles this correctly — both task.started events fire.
+  cat <<EOF
+{
+  "question": "solve 10+10-10 and write a joke with the result.",
+  "agents": [
+    { "name": "math", "endpoint": "${MATH_URL}", ${AUTH_BLOCK},
+      "skills": [{ "id": "solve_math", "description": "Solve math problems step by step" }] },
+    { "name": "joke", "endpoint": "${JOKE_URL}", ${AUTH_BLOCK},
+      "skills": [{ "id": "tell_joke", "description": "Tell a joke on any topic" }] }
+  ]
+}
+EOF
+}
+
+case_Q_INBOX_REPRO_B() {
+  # Turn-2 routing under a multi-recipient roster. Turn 1 was a math
+  # question; turn 2 asks for a joke about that result. The planner
+  # must re-route turn 2 to joke alone, NOT stick to math. Tests that
+  # client-owned history doesn't leak sticky routing.
+  cat <<EOF
+{
+  "question": "now tell me a joke about that result.",
+  "history": [
+    { "role": "user", "parts": [{ "type": "text", "text": "what is 10+10-10?" }] },
+    { "role": "assistant", "parts": [{ "type": "text", "text": "The result of 10 + 10 - 10 is 10." }] }
+  ],
+  "agents": [
+    { "name": "math", "endpoint": "${MATH_URL}", ${AUTH_BLOCK},
+      "skills": [{ "id": "solve_math", "description": "Solve math problems step by step" }] },
+    { "name": "joke", "endpoint": "${JOKE_URL}", ${AUTH_BLOCK},
+      "skills": [{ "id": "tell_joke", "description": "Tell a joke on any topic" }] }
+  ]
+}
+EOF
+}
+
+case_Q_INBOX_REPRO_C() {
+  # Body for the duplicate-submit check. Fired twice in parallel by
+  # run_dup_check (below). Body is intentionally identical to _A so
+  # the dedup layer keys on (content, agents) instead of body diffing.
+  case_Q_INBOX_REPRO_A
+}
+
+ALL_CASES=(Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8 Q9 Q10 Q11 Q12 Q_MULTIHOP Q_INBOX_REPRO_A Q_INBOX_REPRO_B)
 
 # --------------------------------------------------------------------
 # Runner
@@ -341,7 +399,77 @@ run_case() {
   [[ "${verdict}" == "ok" ]]
 }
 
+# Idempotency check for /plan. Fires Q_INBOX_REPRO_C's body twice in
+# parallel and verifies that the gateway deduplicates: post-fix both
+# responses share the same session_id; today they don't (two separate
+# runs, double agent invocations, double bill).
+#
+# Until the gateway lands an Idempotency-Key/(session,content_hash)
+# layer, this command is expected to FAIL — it's the regression guard
+# for that Phase 2 work.
+run_dup_check() {
+  local body
+  body="$(case_Q_INBOX_REPRO_C)"
+  local out1="${LOG_DIR}/Q_INBOX_REPRO_C.1.sse"
+  local out2="${LOG_DIR}/Q_INBOX_REPRO_C.2.sse"
+
+  echo "▶ Q_INBOX_REPRO_C (parallel dup-submit)"
+
+  curl -sN --max-time 90 -o "${out1}" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${GATEWAY_API_KEY}" \
+    -H "Accept: text/event-stream" \
+    -X POST "${GATEWAY_URL}/plan" -d "${body}" &
+  local pid1=$!
+  curl -sN --max-time 90 -o "${out2}" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${GATEWAY_API_KEY}" \
+    -H "Accept: text/event-stream" \
+    -X POST "${GATEWAY_URL}/plan" -d "${body}" &
+  local pid2=$!
+  wait "${pid1}" "${pid2}"
+
+  # Extract each run's session_id from the first SSE `session` event.
+  # Pattern allows an empty session_id ([^"]*, not [^"]+) — when a duplicate
+  # request lands in the same event-loop tick as the original, the dedup
+  # responder hasn't seen the placeholder entry's sessionID populated yet.
+  # That's correct behavior; we surface it via the `duplicate` event instead.
+  local sid1 sid2 dup1 dup2 tasks1 tasks2
+  sid1=$(grep -m1 '"session_id":' "${out1}" | sed -E 's/.*"session_id":"([^"]*)".*/\1/' || true)
+  sid2=$(grep -m1 '"session_id":' "${out2}" | sed -E 's/.*"session_id":"([^"]*)".*/\1/' || true)
+  dup1=$(grep -c "^event: duplicate$" "${out1}" || true)
+  dup2=$(grep -c "^event: duplicate$" "${out2}" || true)
+  tasks1=$(grep -c "^event: task.started$" "${out1}" || true)
+  tasks2=$(grep -c "^event: task.started$" "${out2}" || true)
+
+  echo "  run1: session=${sid1:-<empty>}  duplicate=${dup1}  tasks=${tasks1}"
+  echo "  run2: session=${sid2:-<empty>}  duplicate=${dup2}  tasks=${tasks2}"
+
+  # PASS conditions (post-Phase 2 idempotency):
+  #   * either response emitted a `duplicate` SSE event, OR
+  #   * both responses share the same non-empty session_id (full replay).
+  # FAIL: two distinct non-empty sessions, both running tasks — the
+  # double-execution scenario the layer was added to prevent.
+  if (( dup1 > 0 || dup2 > 0 )); then
+    local total_tasks=$(( tasks1 + tasks2 ))
+    echo "  ✓ Q_INBOX_REPRO_C: dedup ON — duplicate event emitted; total task.started=${total_tasks}"
+    return 0
+  fi
+  if [[ -n "${sid1}" && "${sid1}" == "${sid2}" ]]; then
+    echo "  ✓ Q_INBOX_REPRO_C: dedup ON — both submits share session_id"
+    return 0
+  fi
+  echo "  ✗ Q_INBOX_REPRO_C: NO DEDUP — two distinct sessions, two billings"
+  echo "    (expected before Phase 2 idempotency lands)"
+  return 1
+}
+
 main() {
+  if [[ "${1:-}" == "dup-check" ]]; then
+    run_dup_check
+    return $?
+  fi
+
   local to_run=( )
   if [[ $# -gt 0 ]]; then
     to_run=( "$@" )

--- a/gateway/package-lock.json
+++ b/gateway/package-lock.json
@@ -24,6 +24,7 @@
         "minimatch": "^10.2.5",
         "remeda": "2.26.0",
         "semver": "^7.6.3",
+        "undici": "^8.3.0",
         "xdg-basedir": "5.1.0",
         "zod": "4.1.8"
       },
@@ -2262,9 +2263,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.1.0.tgz",
-      "integrity": "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/gateway/package-lock.json
+++ b/gateway/package-lock.json
@@ -1304,9 +1304,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -28,6 +28,7 @@
     "minimatch": "^10.2.5",
     "remeda": "2.26.0",
     "semver": "^7.6.3",
+    "undici": "^8.3.0",
     "xdg-basedir": "5.1.0",
     "zod": "4.1.8"
   },

--- a/gateway/src/api/plan-route.ts
+++ b/gateway/src/api/plan-route.ts
@@ -60,6 +60,108 @@ export function formatErrorDetail(e: unknown): {
 
 type ConfigInfo = z.infer<typeof Config>
 
+/* --------------------------------------------------------------------------
+ * Idempotency layer
+ *
+ * Two concurrent /plan calls with identical bodies (the canonical example:
+ * an inbox operator's draft is resubmitted after a timeout) used to produce
+ * two independent sessions with two independent agent fan-outs — every
+ * recipient invoked twice, every billing event doubled. The empirical test
+ * in run_matrix.sh's `dup-check` mode demonstrates the gap.
+ *
+ * Process-local map; keyed by an explicit `Idempotency-Key` header when the
+ * caller supplies one, otherwise by a sha256 of the raw request body. The
+ * entry survives DEDUP_TTL_MS past completion so very-fast resubmits (the
+ * common shape of this bug) get the dedup signal instead of a re-run. After
+ * the TTL a fresh request with the same body becomes a new session — that's
+ * "I meant it this time," not "I clicked submit twice."
+ * -------------------------------------------------------------------------- */
+const DEDUP_TTL_MS = 5 * 60_000
+
+/** Bound on how long a duplicate caller will wait for the original
+ * request's session row to materialize. Longer than typical prepareSession
+ * latency (single-digit ms) but short enough that a stalled upstream
+ * doesn't pin the duplicate caller indefinitely. */
+const DEDUP_SESSION_WAIT_MS = 5_000
+
+/**
+ * `sessionID` is a Promise rather than a bare string so a duplicate caller
+ * that lands in the same event-loop tick as the original — before the
+ * original's prepareSession returns — can still receive a real session id
+ * instead of the placeholder empty string. The original resolves the
+ * promise once prepareSession completes; if it fails, the promise rejects
+ * and the duplicate caller sees an explicit error rather than a stale id.
+ */
+type DedupEntry = {
+  sessionID: Promise<string>
+  resolveSessionID: (id: string) => void
+  rejectSessionID: (err: Error) => void
+  startedAt: number
+  completedAt?: number
+}
+
+function makeDedupEntry(now: number): DedupEntry {
+  let resolveSessionID!: (id: string) => void
+  let rejectSessionID!: (err: Error) => void
+  const sessionID = new Promise<string>((res, rej) => {
+    resolveSessionID = res
+    rejectSessionID = rej
+  })
+  // The promise may settle before any duplicate caller attaches a handler.
+  // Without this, an unhandled rejection from a never-observed entry would
+  // bubble to the Node process exit handler.
+  sessionID.catch(() => {
+    /* observed-or-not, swallowing rejection here is intentional */
+  })
+  return {
+    sessionID,
+    resolveSessionID,
+    rejectSessionID,
+    startedAt: now,
+  }
+}
+
+const dedupMap = new Map<string, DedupEntry>()
+
+/**
+ * Wait up to `timeoutMs` for the in-flight original's sessionID. Returns
+ * `null` if it doesn't settle in time, or if the underlying prepareSession
+ * rejected. Callers treat `null` as "session not yet known" and surface an
+ * empty id to the duplicate consumer — better than blocking the SSE stream.
+ */
+async function waitForSessionID(
+  entry: DedupEntry,
+  timeoutMs: number,
+): Promise<string | null> {
+  return Promise.race([
+    entry.sessionID.catch(() => null),
+    new Promise<null>((res) => setTimeout(() => res(null), timeoutMs)),
+  ])
+}
+
+function dedupKey(idempHeader: string | undefined, rawBody: string): string {
+  if (idempHeader && idempHeader.length > 0) return `hdr:${idempHeader}`
+  return `body:${createHash("sha256").update(rawBody).digest("hex")}`
+}
+
+function gcDedup(now: number): void {
+  for (const [k, v] of dedupMap.entries()) {
+    if (v.completedAt !== undefined && now - v.completedAt > DEDUP_TTL_MS) {
+      dedupMap.delete(k)
+    }
+  }
+}
+
+function findDedupEntry(key: string, now: number): DedupEntry | null {
+  const entry = dedupMap.get(key)
+  if (!entry) return null
+  if (entry.completedAt !== undefined && now - entry.completedAt > DEDUP_TTL_MS) {
+    dedupMap.delete(key)
+    return null
+  }
+  return entry
+}
+
 export const buildPlanHandler = Effect.gen(function* () {
   const planner = yield* PlannerService
   const bus = yield* BusService
@@ -84,14 +186,67 @@ async function handleRequest(
     }
   }
 
-  // 2. Parse body
+  // 2. Parse body. Read raw text first so the idempotency hash keys on the
+  //    exact bytes the caller sent — JSON.stringify(parsed) would re-serialize
+  //    and could drift across runtimes if any field order changed.
+  const rawBody = await c.req.text()
   let request: PlanRequest
   try {
-    const body = await c.req.json()
+    const body = JSON.parse(rawBody)
     request = PlanRequest.parse(body)
   } catch (e) {
     return c.json({ error: "invalid_request", ...formatErrorDetail(e) }, 400)
   }
+
+  // 2c. Idempotency dedup. Check BEFORE prepareSession so a duplicate doesn't
+  //     allocate a fresh session row in Supabase, doesn't enqueue a plan run,
+  //     and doesn't fan out a second copy of the request to every recipient.
+  //     `Idempotency-Key` header beats body hash: when the caller is explicit
+  //     about "this is a retry of submit X", honor it (covers cases where two
+  //     resubmits have small inconsequential differences like a re-stamped
+  //     `session_id`).
+  const idempKey = dedupKey(c.req.header("Idempotency-Key"), rawBody)
+  const now = Date.now()
+  gcDedup(now)
+  const existing = findDedupEntry(idempKey, now)
+  if (existing) {
+    // Block briefly on the in-flight original's sessionID so the duplicate
+    // consumer receives a real id (not the empty placeholder from the
+    // same-event-loop-tick race). The original normally resolves it within
+    // single-digit milliseconds — well under DEDUP_SESSION_WAIT_MS.
+    const resolvedSessionID = await waitForSessionID(
+      existing,
+      DEDUP_SESSION_WAIT_MS,
+    )
+    const sessionID = resolvedSessionID ?? ""
+    return streamSSE(c, async (stream) => {
+      await stream.writeSSE({
+        event: "session",
+        data: JSON.stringify({
+          session_id: sessionID,
+          external_session_id: request.session_id ?? null,
+          created: false,
+        }),
+      })
+      await stream.writeSSE({
+        event: "duplicate",
+        data: JSON.stringify({
+          session_id: sessionID,
+          in_flight: existing.completedAt === undefined,
+          message:
+            existing.completedAt === undefined
+              ? "Plan with identical body is in flight; not re-running."
+              : "Plan with identical body recently completed (within idempotency TTL).",
+        }),
+      })
+      await stream.writeSSE({ event: "done", data: "{}" })
+    })
+  }
+  // Register before prepareSession to close the check-and-set race. Two
+  // requests landing in the same event-loop tick would otherwise both see
+  // no entry; the set is synchronous so whichever runs second loses.
+  const dedupEntry = makeDedupEntry(now)
+  dedupMap.set(idempKey, dedupEntry)
 
   // 2a. Reject catalogs that would produce colliding tool ids — silent
   //     last-write-wins in the AI SDK's toolMap was masking caller bugs
@@ -152,8 +307,18 @@ async function handleRequest(
   try {
     sessionCtx = await Effect.runPromise(planner.prepareSession(request))
   } catch (e) {
+    // Free the dedup slot so the caller can legitimately retry. Without
+    // this, the first attempt's failure would shadow the dedup map and
+    // block every retry within the TTL window. Reject the in-flight
+    // sessionID promise too so any concurrent duplicate caller breaks
+    // out of its waitForSessionID instead of timing out at the 5s bound.
+    dedupEntry.rejectSessionID(e instanceof Error ? e : new Error(String(e)))
+    dedupMap.delete(idempKey)
     return c.json({ error: "session_failed", ...formatErrorDetail(e) }, 500)
   }
+  // Resolve the in-flight sessionID promise so any concurrent duplicate
+  // caller awaiting it receives the real id.
+  dedupEntry.resolveSessionID(sessionCtx.sessionID)
 
   // 4. SSE response
   return streamSSE(c, async (stream) => {
@@ -304,6 +469,11 @@ async function handleRequest(
       // so no PubSub subscriptions leak past this request.
       ac.abort()
       await stream.writeSSE({ event: "done", data: "{}" })
+      // Mark the dedup slot as completed. Subsequent identical bodies inside
+      // DEDUP_TTL_MS see this as "recently completed" and get the dup signal;
+      // beyond the TTL the entry is garbage-collected and a fresh body starts
+      // a new session.
+      dedupEntry.completedAt = Date.now()
     }
   })
 }

--- a/gateway/src/bindu/client/agent-card.ts
+++ b/gateway/src/bindu/client/agent-card.ts
@@ -1,4 +1,5 @@
 import { AgentCard } from "../protocol/agent-card"
+import { getPeerDispatcher } from "./mtls"
 
 /**
  * Fetch and parse a peer's AgentCard from `/.well-known/agent.json`.
@@ -56,7 +57,13 @@ export async function fetchAgentCard(
 
   try {
     const target = new URL(WELL_KNOWN_PATH, peerUrl).toString()
-    const res = await fetch(target, { signal: ac.signal })
+    const peerDispatcher = getPeerDispatcher()
+    const res = await fetch(target, {
+      signal: ac.signal,
+      ...(peerDispatcher
+        ? ({ dispatcher: peerDispatcher } as unknown as RequestInit)
+        : {}),
+    })
     if (!res.ok) {
       cache.set(peerUrl, null)
       return null

--- a/gateway/src/bindu/client/agent-card.ts
+++ b/gateway/src/bindu/client/agent-card.ts
@@ -1,3 +1,4 @@
+import { fetch as undiciFetch } from "undici"
 import { AgentCard } from "../protocol/agent-card"
 import { getPeerDispatcher } from "./mtls"
 
@@ -58,7 +59,11 @@ export async function fetchAgentCard(
   try {
     const target = new URL(WELL_KNOWN_PATH, peerUrl).toString()
     const peerDispatcher = getPeerDispatcher()
-    const res = await fetch(target, {
+    // Route through undici.fetch when a dispatcher is in play —
+    // Node 22's bundled undici 6.x global fetch throws an opaque
+    // "fetch failed" when handed our pinned undici 8.x Agent.
+    const fetcher = peerDispatcher ? (undiciFetch as typeof fetch) : fetch
+    const res = await fetcher(target, {
       signal: ac.signal,
       ...(peerDispatcher
         ? ({ dispatcher: peerDispatcher } as unknown as RequestInit)

--- a/gateway/src/bindu/client/fetch.ts
+++ b/gateway/src/bindu/client/fetch.ts
@@ -1,3 +1,4 @@
+import { fetch as undiciFetch } from "undici"
 import { buildAuthHeaders, type PeerAuth } from "../auth/resolver"
 import type { LocalIdentity } from "../identity/local"
 import type { TokenProvider } from "../identity/hydra-token"
@@ -67,7 +68,14 @@ export interface RpcFailure {
 export type RpcOutcome<T = unknown> = RpcSuccess<T> | RpcFailure
 
 export async function rpc<T = unknown>(input: RpcInput): Promise<RpcOutcome<T>> {
-  const fetcher = input.fetch ?? fetch
+  // Pick fetch flavor based on whether we'll pass an undici dispatcher.
+  // Node 22's bundled undici 6.x global fetch throws an opaque
+  // "fetch failed" when handed our pinned undici 8.x Agent — must route
+  // through undici.fetch in that case. Tests can still inject their own
+  // fetcher via input.fetch.
+  const peerDispatcher = getPeerDispatcher()
+  const fetcher =
+    input.fetch ?? (peerDispatcher ? (undiciFetch as typeof fetch) : fetch)
   const url = stripTrailingSlash(input.peerUrl) + "/"
   const timeoutMs = input.timeoutMs ?? 60_000
 
@@ -89,12 +97,11 @@ export async function rpc<T = unknown>(input: RpcInput): Promise<RpcOutcome<T>> 
       input.identity,
       input.tokenProvider,
     )
-    // Present the gateway's mTLS cert when one is configured via the
-    // BINDU_GATEWAY_TLS_* env (the inbox passes these when spawning).
-    // No cert → undefined dispatcher → default fetch behavior, fine
-    // for HTTP peers. On HTTPS peers signed by our private CA, this
-    // is what makes the handshake succeed.
-    const peerDispatcher = getPeerDispatcher()
+    // peerDispatcher was resolved at the top of the function so we
+    // could pick the right fetch flavor. Present the gateway's mTLS
+    // cert when one is configured via the BINDU_GATEWAY_TLS_* env
+    // (the inbox passes these when spawning). No cert → undefined
+    // dispatcher → default fetch behavior, fine for HTTP peers.
     const resp = await fetcher(url, {
       method: "POST",
       headers: {

--- a/gateway/src/bindu/client/fetch.ts
+++ b/gateway/src/bindu/client/fetch.ts
@@ -2,6 +2,7 @@ import { buildAuthHeaders, type PeerAuth } from "../auth/resolver"
 import type { LocalIdentity } from "../identity/local"
 import type { TokenProvider } from "../identity/hydra-token"
 import { BinduError, JsonRpcResponse, type JsonRpcRequest } from "../protocol/jsonrpc"
+import { getPeerDispatcher } from "./mtls"
 
 /**
  * HTTP transport for Bindu JSON-RPC calls.
@@ -88,6 +89,12 @@ export async function rpc<T = unknown>(input: RpcInput): Promise<RpcOutcome<T>> 
       input.identity,
       input.tokenProvider,
     )
+    // Present the gateway's mTLS cert when one is configured via the
+    // BINDU_GATEWAY_TLS_* env (the inbox passes these when spawning).
+    // No cert → undefined dispatcher → default fetch behavior, fine
+    // for HTTP peers. On HTTPS peers signed by our private CA, this
+    // is what makes the handshake succeed.
+    const peerDispatcher = getPeerDispatcher()
     const resp = await fetcher(url, {
       method: "POST",
       headers: {
@@ -98,6 +105,9 @@ export async function rpc<T = unknown>(input: RpcInput): Promise<RpcOutcome<T>> 
       },
       body: bodyStr,
       signal: ac.signal,
+      ...(peerDispatcher
+        ? ({ dispatcher: peerDispatcher } as unknown as RequestInit)
+        : {}),
     })
 
     if (!resp.ok) {

--- a/gateway/src/bindu/client/mtls.ts
+++ b/gateway/src/bindu/client/mtls.ts
@@ -25,8 +25,19 @@
  * the same caller. Tenant separation lives at a future Phase C2 where
  * the gateway gets its own DID.
  */
-import { existsSync, readFileSync, statSync } from "node:fs"
+import { existsSync, readFileSync, statSync, watchFile, unwatchFile, type Stats } from "node:fs"
+import type { Server as HttpsServer } from "node:https"
+import tls from "node:tls"
 import { Agent } from "undici"
+
+/** Trust bundle = our private step-ca + Node's default Mozilla roots.
+ *  Setting `ca` on undici.Agent.connect REPLACES the default CA store;
+ *  without this concat, gateway calls to public-CA peers would fail
+ *  with UNABLE_TO_VERIFY_LEAF_SIGNATURE. Mirrors withSystemRoots() in
+ *  inbox/server/utils.ts. */
+function withSystemRoots(caBundle: Buffer): string[] {
+  return [...tls.rootCertificates, caBundle.toString("utf8")]
+}
 
 const CERT_ENV = "BINDU_GATEWAY_TLS_CERT"
 const KEY_ENV = "BINDU_GATEWAY_TLS_KEY"
@@ -63,6 +74,44 @@ export function getServerTLSOptions(): TLSServerOptions | undefined {
   }
 }
 
+/**
+ * Watch the TLS cert file and swap the live https.Server's secure context
+ * in-place when step-ca rotates it (~every 16h).
+ *
+ * Without this, `getServerTLSOptions()` is consulted exactly once at boot
+ * and Node's https.Server keeps serving the old cert forever. When the
+ * cert expires the TLS handshake just stops working and operators have
+ * to bounce the gateway by hand.
+ *
+ * `fs.watchFile` polls (1s default) rather than relying on inotify, which
+ * matches how step-ca's renewal CLI atomically replaces the file via
+ * write-and-rename — inotify would miss the original file's events.
+ *
+ * Returns a disposer so callers can cancel the watch on shutdown. No-op
+ * if no cert env is set (plain HTTP boot — nothing to reload).
+ */
+export function attachServerCertReloader(server: HttpsServer): () => void {
+  const paths = readEnvPaths()
+  if (!paths) return () => {}
+  let lastMtime = statSync(paths.cert).mtimeMs
+  const onChange = (curr: Stats) => {
+    if (curr.mtimeMs === lastMtime) return
+    lastMtime = curr.mtimeMs
+    const opts = getServerTLSOptions()
+    if (!opts) return
+    try {
+      server.setSecureContext(opts)
+      console.log(
+        `[bindu-gateway] reloaded TLS cert (mtime=${new Date(curr.mtimeMs).toISOString()})`,
+      )
+    } catch (err) {
+      console.error("[bindu-gateway] cert reload failed:", err)
+    }
+  }
+  watchFile(paths.cert, { interval: 60_000 }, onChange)
+  return () => unwatchFile(paths.cert, onChange)
+}
+
 let cachedPeerDispatcher: { agent: Agent; mtimeMs: number } | null = null
 
 /**
@@ -83,11 +132,12 @@ export function getPeerDispatcher(): Agent | undefined {
     connect: {
       cert: readFileSync(paths.cert),
       key: readFileSync(paths.key),
-      ca: readFileSync(paths.ca),
+      ca: withSystemRoots(readFileSync(paths.ca)),
       // Peer cert SANs are DIDs, not hostnames. Identity is enforced
       // at the application layer via X-DID-Signature (auth/resolver.ts
       // builds these for did_signed peers) and the cert chain still
-      // has to verify against our private CA bundle.
+      // has to verify against our private CA bundle (or the Mozilla
+      // bundle for public-CA peers — see withSystemRoots above).
       checkServerIdentity: () => undefined,
     },
   })

--- a/gateway/src/bindu/client/mtls.ts
+++ b/gateway/src/bindu/client/mtls.ts
@@ -1,0 +1,96 @@
+/**
+ * mTLS plumbing for the gateway, Phase C.
+ *
+ * The gateway is spawned by the inbox; when the inbox has a personal
+ * agent with a real cert from production step-ca, it passes the cert
+ * file paths into the gateway's env. The gateway picks them up here:
+ *
+ *   - getServerTLSOptions() — feeds the https.createServer factory used
+ *     by @hono/node-server, so the gateway serves the planner API over
+ *     TLS. Returns undefined when no cert is configured → plain HTTP,
+ *     today's behavior.
+ *
+ *   - getPeerDispatcher() — undici Agent that the outbound JSON-RPC
+ *     client (fetch.ts) and the agent-card fetcher use, so calls to
+ *     backing Bindu agents present the same cert at the transport
+ *     layer. Mirrors the inbox's buildPeerDispatcher() in
+ *     inbox/server/utils.ts; same file format, same identity.
+ *
+ * Both functions check file mtime so a cert renewal (~16h) is picked
+ * up without a gateway restart, modulo the next call.
+ *
+ * The "co-opt the personal agent's cert" model from the rollout plan:
+ * the gateway shares an identity with the inbox process. From a peer's
+ * perspective, inbox-direct calls and gateway-fanout calls look like
+ * the same caller. Tenant separation lives at a future Phase C2 where
+ * the gateway gets its own DID.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs"
+import { Agent } from "undici"
+
+const CERT_ENV = "BINDU_GATEWAY_TLS_CERT"
+const KEY_ENV = "BINDU_GATEWAY_TLS_KEY"
+const CA_ENV = "BINDU_GATEWAY_TLS_CA"
+
+function readEnvPaths(): { cert: string; key: string; ca: string } | undefined {
+  const cert = process.env[CERT_ENV]
+  const key = process.env[KEY_ENV]
+  const ca = process.env[CA_ENV]
+  if (!cert || !key || !ca) return undefined
+  if (!existsSync(cert) || !existsSync(key) || !existsSync(ca)) return undefined
+  return { cert, key, ca }
+}
+
+export interface TLSServerOptions {
+  cert: Buffer
+  key: Buffer
+  ca: Buffer
+}
+
+/**
+ * Returns the cert/key/ca buffers for https.createServer when the
+ * gateway has been spawned with TLS env. Returns undefined for plain
+ * HTTP (today's default, also the path when the personal agent hasn't
+ * been spawned yet on the inbox side).
+ */
+export function getServerTLSOptions(): TLSServerOptions | undefined {
+  const paths = readEnvPaths()
+  if (!paths) return undefined
+  return {
+    cert: readFileSync(paths.cert),
+    key: readFileSync(paths.key),
+    ca: readFileSync(paths.ca),
+  }
+}
+
+let cachedPeerDispatcher: { agent: Agent; mtimeMs: number } | null = null
+
+/**
+ * Returns an undici Agent that presents the gateway's mTLS cert on
+ * outbound A2A calls. Returns undefined when no cert is configured —
+ * outbound code falls through to the default fetch dispatcher.
+ *
+ * Mtime-cached so cert renewal is picked up on next call.
+ */
+export function getPeerDispatcher(): Agent | undefined {
+  const paths = readEnvPaths()
+  if (!paths) return undefined
+  const mtimeMs = statSync(paths.cert).mtimeMs
+  if (cachedPeerDispatcher && cachedPeerDispatcher.mtimeMs === mtimeMs) {
+    return cachedPeerDispatcher.agent
+  }
+  const agent = new Agent({
+    connect: {
+      cert: readFileSync(paths.cert),
+      key: readFileSync(paths.key),
+      ca: readFileSync(paths.ca),
+      // Peer cert SANs are DIDs, not hostnames. Identity is enforced
+      // at the application layer via X-DID-Signature (auth/resolver.ts
+      // builds these for did_signed peers) and the cert chain still
+      // has to verify against our private CA bundle.
+      checkServerIdentity: () => undefined,
+    },
+  })
+  cachedPeerDispatcher = { agent, mtimeMs }
+  return agent
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -3,7 +3,8 @@ import { createServer as createHttpsServer } from "node:https"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import { serve } from "@hono/node-server"
 import { Hono } from "hono"
-import { getServerTLSOptions } from "./bindu/client/mtls"
+import type { Server as HttpsServer } from "node:https"
+import { attachServerCertReloader, getServerTLSOptions } from "./bindu/client/mtls"
 import * as Config from "./config"
 import * as Bus from "./bus"
 import * as Auth from "./auth"
@@ -329,11 +330,19 @@ export async function main(): Promise<{ close: () => Promise<void> }> {
     : serve({ fetch: app.fetch, port, hostname })
   const scheme = tlsOpts ? "https" : "http"
 
+  // Hot-reload the cert in-place when step-ca rotates it. Without this
+  // the server keeps serving the original cert until expiry breaks
+  // handshakes. No-op when running plain HTTP.
+  const stopCertWatcher = tlsOpts
+    ? attachServerCertReloader(httpServer as unknown as HttpsServer)
+    : () => {}
+
   console.log(`[bindu-gateway] listening on ${scheme}://${hostname}:${port}`)
   console.log(`[bindu-gateway] session mode: ${cfg.gateway.session.mode}`)
 
   return {
     close: async () => {
+      stopCertWatcher()
       httpServer.close()
       await runtime.dispose()
     },

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,7 +1,9 @@
 import "./bindu/identity" // bootstrap ed25519 sha512 hook FIRST
+import { createServer as createHttpsServer } from "node:https"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import { serve } from "@hono/node-server"
 import { Hono } from "hono"
+import { getServerTLSOptions } from "./bindu/client/mtls"
 import * as Config from "./config"
 import * as Bus from "./bus"
 import * as Auth from "./auth"
@@ -312,9 +314,22 @@ export async function main(): Promise<{ close: () => Promise<void> }> {
   }
 
   const { port, hostname } = cfg.gateway.server
-  const httpServer = serve({ fetch: app.fetch, port, hostname })
+  // mTLS when the inbox passes us a cert via BINDU_GATEWAY_TLS_*. Otherwise
+  // plain HTTP (today's default, also the path when no personal agent has
+  // bootstrapped a cert yet on the spawning inbox).
+  const tlsOpts = getServerTLSOptions()
+  const httpServer = tlsOpts
+    ? serve({
+        fetch: app.fetch,
+        port,
+        hostname,
+        createServer: createHttpsServer,
+        serverOptions: tlsOpts,
+      })
+    : serve({ fetch: app.fetch, port, hostname })
+  const scheme = tlsOpts ? "https" : "http"
 
-  console.log(`[bindu-gateway] listening on http://${hostname}:${port}`)
+  console.log(`[bindu-gateway] listening on ${scheme}://${hostname}:${port}`)
   console.log(`[bindu-gateway] session mode: ${cfg.gateway.session.mode}`)
 
   return {

--- a/gateway/src/planner/index.ts
+++ b/gateway/src/planner/index.ts
@@ -14,6 +14,7 @@ import type { PeerDescriptor } from "../bindu/client"
 import type { PeerAuth } from "../bindu/auth/resolver"
 import { newMessageID, type SessionID } from "../session/schema"
 import { buildSkillTool } from "./skill-tool"
+import { buildPriorTaskIdLookup } from "./task-continuity"
 
 /**
  * Planner — turns External's agent catalog into dynamic tools, then runs
@@ -174,6 +175,15 @@ export const PlanRequest = z.object({
    * synthetic user turn so the planner can still reference earlier
    * conversation that was compacted away. */
   prior_summary: z.string().optional(),
+  /** Per-recipient task-id continuity. Optional `{peerName: taskId}` map
+   * the client supplies based on its own event log — the most recent
+   * A2A `taskId` it observed for each peer in this thread on prior /plan
+   * calls. The planner threads each entry into the next outbound
+   * `callPeer` as `referenceTaskIds: [taskId]`, so stateful agents see
+   * the new task chained to its predecessor and can recover prior
+   * artifacts/state. Path A's `history` is text-only and can't carry
+   * tool metadata, hence this side-channel. */
+  prior_task_ids: z.record(z.string(), z.string()).optional(),
 })
 export type PlanRequest = z.infer<typeof PlanRequest>
 
@@ -394,6 +404,31 @@ export const layer = Layer.effect(
           const contextId = ctx.sessionID
           const tools: Def[] = []
 
+          // Resolve the prior-task lookup for cross-turn continuity. Two
+          // sources, in order:
+          //   1. `request.prior_task_ids` — the client (e.g. inbox-server)
+          //      explicitly tells us each peer's most-recent taskId from
+          //      its own event log. Authoritative when present because
+          //      the client owns the cross-call audit trail.
+          //   2. Session-history walk via buildPriorTaskIdLookup. Useful
+          //      in future modes where the gateway persists tool parts
+          //      with metadata; harmless today (Path A history is text-
+          //      only, so the walk returns no entries).
+          // Errors are non-fatal: continuity is a nice-to-have, not a
+          // correctness requirement — silently degrade to "fresh task
+          // per call" so a load-bearing read can't kill the request.
+          const priorTaskIdMap = request.prior_task_ids ?? {}
+          const priorTaskIdFromHistory = yield* sessions
+            .history(ctx.sessionID)
+            .pipe(
+              Effect.map(buildPriorTaskIdLookup),
+              Effect.catch(() =>
+                Effect.succeed(((_: string) => undefined) as ReturnType<typeof buildPriorTaskIdLookup>),
+              ),
+            )
+          const priorTaskId = (peerName: string): string | undefined =>
+            priorTaskIdMap[peerName] ?? priorTaskIdFromHistory(peerName)
+
           for (const ag of request.agents) {
             const peer: PeerDescriptor = {
               name: ag.name,
@@ -402,7 +437,13 @@ export const layer = Layer.effect(
               trust: ag.trust,
             }
             for (const sk of ag.skills) {
-              tools.push(buildSkillTool(peer, sk, { client, contextId }))
+              tools.push(
+                buildSkillTool(peer, sk, {
+                  client,
+                  contextId,
+                  priorTaskId: priorTaskId(ag.name),
+                }),
+              )
             }
           }
 

--- a/gateway/src/planner/skill-tool.ts
+++ b/gateway/src/planner/skill-tool.ts
@@ -32,6 +32,13 @@ export interface BuildToolDeps {
     ) => Effect.Effect<import("../bindu/client").CallPeerOutcome, import("../bindu/protocol/jsonrpc").BinduError>
   }
   contextId: string
+  /** Most recent `taskId` recorded for this peer in the loaded session
+   * history, or undefined if this is the first call. When set, threaded
+   * into `callPeer` as `referenceTaskIds: [prior]` so the recipient sees
+   * the new task chained to its predecessor and can recover prior context.
+   * Computed once by `buildPriorTaskIdLookup` at planner setup so every
+   * skill-tool for the same peer sees the same id. */
+  priorTaskId?: string
 }
 
 export function buildSkillTool(
@@ -88,6 +95,15 @@ export function buildSkillTool(
             input: peerInput,
             contextId: deps.contextId,
             signal: ctx.abort,
+            // Per-recipient task_id continuity: link this turn's task to the
+            // last task we sent to the same peer in this thread, so the
+            // recipient can resolve referenceTaskIds[0] against its own
+            // store and recover prior artifacts/state. On the first turn
+            // priorTaskId is undefined and we fall through to the
+            // single-task-no-references shape.
+            ...(deps.priorTaskId
+              ? { referenceTaskIds: [deps.priorTaskId] }
+              : {}),
           })
           .pipe(Effect.mapError((err) => err as unknown as Error))
 

--- a/gateway/src/planner/task-continuity.ts
+++ b/gateway/src/planner/task-continuity.ts
@@ -1,0 +1,60 @@
+import type { MessageWithParts } from "../session"
+
+/**
+ * Per-recipient `task_id` continuity across turns within one `contextId`.
+ *
+ * Today every gateway → peer call mints a fresh `taskId`, so an agent like
+ * `math_agent` sees turn 2 as a brand-new conversation even though it was
+ * the same operator continuing the same thread. The opencode equivalent is
+ * passing a prior subagent session's `task_id` back to `task()` so the
+ * subagent resumes its own context (see opencode `task.txt` §3 + the
+ * runtime path in `tool/task.ts`).
+ *
+ * In Bindu, the A2A protocol gives us two knobs:
+ *   1. `taskId` — same id reuses the task (server-dependent; some agents
+ *      reject when terminal). Risky.
+ *   2. `referenceTaskIds` — new task that names its predecessor; the
+ *      recipient can look up the prior task's artifacts. Safe across
+ *      implementations.
+ *
+ * We use (2). This helper walks the loaded message history, finds the most
+ * recent completed tool part for each peer, and pulls the stamped `taskId`
+ * out of `state.metadata`. The planner threads the result into each
+ * skill-tool so the next `callPeer` includes `referenceTaskIds: [prior]`.
+ *
+ * Why metadata-not-output: the tool output is a `<remote_content>` envelope
+ * the LLM consumes; appending machine-readable taskIds there would either
+ * leak to the user or confuse the model. Metadata is a side-channel the
+ * gateway controls.
+ */
+
+export type PriorTaskIdLookup = (peerName: string) => string | undefined
+
+/**
+ * Build a per-peer "most recent taskId" lookup from a session's loaded
+ * history. Walks oldest → newest; later entries shadow earlier ones so the
+ * lookup returns the freshest task per peer at the end. Returns a function
+ * (not a Map) so the planner can pass it to many `buildSkillTool` calls
+ * without each one needing to clone or know the map's shape.
+ */
+export function buildPriorTaskIdLookup(
+	history: ReadonlyArray<MessageWithParts>,
+): PriorTaskIdLookup {
+	const taskIdByPeer = new Map<string, string>()
+	for (const msg of history) {
+		if (msg.info.role !== "assistant") continue
+		for (const part of msg.parts) {
+			if (part.type !== "tool") continue
+			if (part.state.status !== "completed") continue
+			const meta = part.state.metadata as
+				| { peer?: unknown; taskId?: unknown }
+				| undefined
+			if (!meta) continue
+			const peer = typeof meta.peer === "string" ? meta.peer : undefined
+			const taskId = typeof meta.taskId === "string" ? meta.taskId : undefined
+			if (!peer || !taskId) continue
+			taskIdByPeer.set(peer, taskId)
+		}
+	}
+	return (peerName) => taskIdByPeer.get(peerName)
+}

--- a/gateway/src/session/doom-loop.ts
+++ b/gateway/src/session/doom-loop.ts
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto"
+
+/**
+ * Detect when the planner LLM is stuck calling the same tool with the same
+ * input over and over. Mirrors opencode's `DOOM_LOOP_THRESHOLD = 3` in
+ * `packages/opencode/src/session/processor.ts` — once three identical
+ * tool+input pairs land in a row, the *next* call is rerouted to a synthetic
+ * "stop retrying" message instead of being executed. The model sees the
+ * message as a tool result and has a chance to pick a different approach or
+ * finalize with what it has.
+ *
+ * This is the cheap safety net for a class of agentic-loop failures that
+ * otherwise grind through `max_steps` (and the user's bill) without making
+ * progress. It does NOT replace `max_steps` — that's the hard cap; this is
+ * the early-exit ramp.
+ *
+ * Threshold rationale: 3 is "thrice is enemy action." Two is a legitimate
+ * retry after a transient error; four-plus risks letting too many tokens
+ * burn before we notice.
+ */
+export const DOOM_LOOP_THRESHOLD = 3
+
+export type ToolCallRecord = {
+	tool: string
+	inputHash: string
+}
+
+/** Stable short hash of a tool's JSON-serializable input. Truncated to 16
+ * hex chars because we only compare for equality across very recent calls
+ * — full SHA-256 is overkill and noisier in logs. */
+export function hashToolInput(input: unknown): string {
+	return createHash("sha256")
+		.update(JSON.stringify(input ?? null))
+		.digest("hex")
+		.slice(0, 16)
+}
+
+/** Returns true when the incoming `(tool, inputHash)` would be the
+ * THRESHOLDth identical call in a row — i.e. the previous (THRESHOLD - 1)
+ * records all match. Callers should treat `true` as "do NOT execute this
+ * tool call; substitute a bail message." */
+export function isDoomLoop(
+	recent: ReadonlyArray<ToolCallRecord>,
+	incoming: ToolCallRecord,
+	threshold: number = DOOM_LOOP_THRESHOLD,
+): boolean {
+	if (threshold < 2) return false
+	const needed = threshold - 1
+	if (recent.length < needed) return false
+	const tail = recent.slice(-needed)
+	return tail.every(
+		(r) => r.tool === incoming.tool && r.inputHash === incoming.inputHash,
+	)
+}
+
+/** Synthetic tool result returned to the LLM in place of executing the
+ * doom-looped call. Phrased as a directive the model can act on
+ * (try a different input, switch tools, or summarize) rather than a
+ * raw error, so the planner can recover within the same agentic turn. */
+export function doomLoopBailMessage(
+	tool: string,
+	threshold: number = DOOM_LOOP_THRESHOLD,
+): string {
+	return [
+		`[gateway:doom-loop] You have called the tool \`${tool}\` with identical input ${threshold} times in a row.`,
+		"Previous attempts produced the same outcome — repeating will not help.",
+		"Take a different approach: change the input, try a different tool, or finalize the answer with the information you already have.",
+	].join(" ")
+}

--- a/gateway/src/session/llm.ts
+++ b/gateway/src/session/llm.ts
@@ -2,6 +2,33 @@ import { Effect, Stream } from "effect"
 import { streamText, type LanguageModel, type ModelMessage, type Tool as AITool, type StopCondition } from "ai"
 
 /**
+ * Injected as a system reminder on the FINAL agentic step when `maxSteps`
+ * is about to be hit. Mirrors opencode's `session/prompt/max-steps.txt`:
+ * instead of letting the AI SDK silently cut off mid-tool-call when the
+ * loop's step cap trips, we let the loop run normally up to `maxSteps - 1`
+ * and force the final step to be tool-free with a summarize-and-stop
+ * instruction. The result is a graceful final assistant turn ("hit the
+ * step budget; here's what got done, here's what didn't") instead of a
+ * truncated `finishReason: "length"` from the model's POV.
+ */
+const MAX_STEPS_SOFT_TERMINATION = [
+  "CRITICAL — MAXIMUM PLANNER STEPS REACHED",
+  "",
+  "The agentic loop's step budget for this request is exhausted. Tools are",
+  "disabled for this step. Respond with text only.",
+  "",
+  "STRICT REQUIREMENTS:",
+  "1. Do NOT call any tools.",
+  "2. Provide a final response that:",
+  "   - States that the maximum number of planner steps was reached.",
+  "   - Summarizes which recipients were invoked so far and what they returned.",
+  "   - Lists any parts of the user's request that could not be completed.",
+  "   - Recommends a next action the user can take (rephrase, re-submit, etc.).",
+  "",
+  "This constraint overrides any prior instruction to call a tool or continue planning.",
+].join("\n")
+
+/**
  * Thin wrapper around AI SDK's `streamText` that returns an Effect Stream
  * of the LLM events.
  *
@@ -68,6 +95,11 @@ export function stream(input: StreamInput): Stream.Stream<StreamEvent, Error> {
 }
 
 function streamTextToEffect(model: LanguageModel, input: StreamInput): Stream.Stream<StreamEvent, Error> {
+  const maxSteps = input.maxSteps
+  // Soft termination only makes sense when maxSteps >= 2 — a 1-step budget
+  // means the FIRST step is already the final step, and we can't both make
+  // the agent useful and forbid it from calling tools.
+  const softTerminate = typeof maxSteps === "number" && maxSteps >= 2
   const result = streamText({
     model,
     system: input.systemPrompt,
@@ -75,8 +107,21 @@ function streamTextToEffect(model: LanguageModel, input: StreamInput): Stream.St
     tools: input.tools,
     temperature: input.temperature,
     topP: input.topP,
-    stopWhen: input.maxSteps ? (stepCountIs(input.maxSteps) as StopCondition<any>) : undefined,
+    stopWhen: maxSteps ? (stepCountIs(maxSteps) as StopCondition<any>) : undefined,
     abortSignal: input.abortSignal,
+    prepareStep: softTerminate
+      ? ({ stepNumber }) => {
+          // On the final permitted step, disable every tool and append a
+          // summarize-and-stop reminder to the system prompt so the model
+          // produces a clean text finish instead of trying to fire a
+          // tool that we'd silently cut off when stopWhen kicks in.
+          if (stepNumber !== maxSteps! - 1) return undefined
+          return {
+            activeTools: [],
+            system: `${input.systemPrompt}\n\n${MAX_STEPS_SOFT_TERMINATION}`,
+          }
+        }
+      : undefined,
   })
 
   // Pull from AI SDK's AsyncIterable<fullStream event>, map each event to

--- a/gateway/src/session/prompt-util.ts
+++ b/gateway/src/session/prompt-util.ts
@@ -4,6 +4,12 @@ import type { Def as ToolDef, Context as ToolContext } from "../tool/tool"
 import type { AssistantMessageInfo } from "./message"
 import type { SessionID, MessageID } from "./schema"
 import type { Info as AgentInfo } from "../agent"
+import {
+	type ToolCallRecord,
+	doomLoopBailMessage,
+	hashToolInput,
+	isDoomLoop,
+} from "./doom-loop"
 
 /**
  * Helpers extracted from `./prompt.ts` — pure/near-pure logic that has no
@@ -54,18 +60,38 @@ export function evtUsage(u: AssistantMessageInfo["tokens"]) {
  * execution into the AI SDK's Promise-based `execute`. Metadata returned by
  * the tool is stashed in `metadataByCall` keyed on toolCallId, because the
  * AI SDK's tool result can only carry a string.
+ *
+ * `recentCalls` is a session-scoped sliding log used by the doom-loop
+ * detector. Each invocation pushes its `(tool, inputHash)`; before pushing,
+ * the helper checks whether the previous (THRESHOLD - 1) entries already
+ * match — if so, the actual `execute` is skipped and a synthetic "stop
+ * retrying" message is returned to the LLM. The model receives it as a
+ * tool result and can recover within the same agentic turn.
  */
 export function wrapTool(
   tool: ToolDef,
   sessionID: SessionID,
   messageID: MessageID,
   metadataByCall: Map<string, Record<string, unknown>>,
+  recentCalls: ToolCallRecord[],
 ): Effect.Effect<[string, any]> {
   return Effect.sync(() => {
     const wrapped = aiTool({
       description: tool.description,
       inputSchema: tool.parameters as any,
       execute: async (args: any, opts: { toolCallId: string; abortSignal?: AbortSignal }) => {
+        const incoming: ToolCallRecord = {
+          tool: tool.id,
+          inputHash: hashToolInput(args),
+        }
+        if (isDoomLoop(recentCalls, incoming)) {
+          // Record the bailed call too so the next identical one still
+          // sees a saturated tail and bails as well. The model has to do
+          // something different to break out.
+          recentCalls.push(incoming)
+          return doomLoopBailMessage(tool.id)
+        }
+        recentCalls.push(incoming)
         const ctx: ToolContext = {
           sessionId: sessionID,
           messageId: messageID,

--- a/gateway/src/session/prompt.ts
+++ b/gateway/src/session/prompt.ts
@@ -192,9 +192,17 @@ export const layer = Layer.effect(
         // SSE stream can surface them.
         const metadataByCall = new Map<string, Record<string, unknown>>()
 
+        // Doom-loop log — every wrapped tool pushes its `(tool, inputHash)`
+        // before executing. wrapTool short-circuits identical chains of
+        // DOOM_LOOP_THRESHOLD length, so this prevents the planner from
+        // grinding through `max_steps` re-calling the same recipient with
+        // the same prompt. Scoped to this prompt invocation so noise from
+        // one user turn can't bleed into the next.
+        const recentToolCalls: import("./doom-loop").ToolCallRecord[] = []
+
         const aiTools = yield* Effect.all(
           (input.tools ?? []).map((t) =>
-            wrapTool(t, input.sessionID, messageID, metadataByCall),
+            wrapTool(t, input.sessionID, messageID, metadataByCall, recentToolCalls),
           ),
         )
         const toolMap: Record<string, any> = {}
@@ -298,6 +306,15 @@ export const layer = Layer.effect(
                 case "tool-result": {
                   const existing = partsByCall.get(evt.toolCallId)
                   if (!existing) return
+                  // Capture the tool's metadata into the persisted tool part
+                  // so subsequent /plan calls in the same session can recover
+                  // it from history. Today the only consumer is per-recipient
+                  // task_id continuity — buildSkillTool stamps each peer call
+                  // with `{peer, skill, taskId, ...}` and the planner reads it
+                  // back on the next turn to chain via `referenceTaskIds`. The
+                  // SSE bridge already gets the metadata directly from the
+                  // bus, so storing here is purely about cross-turn replay.
+                  const metaForPart = metadataByCall.get(evt.toolCallId)
                   existing.state = {
                     status: "completed",
                     input:
@@ -305,6 +322,7 @@ export const layer = Layer.effect(
                         ? existing.state.input
                         : undefined,
                     output: typeof evt.output === "string" ? evt.output : JSON.stringify(evt.output),
+                    ...(metaForPart ? { metadata: metaForPart } : {}),
                     time: {
                       start: existing.state.time?.start ?? Date.now(),
                       end: Date.now(),

--- a/gateway/tests/planner/task-continuity.test.ts
+++ b/gateway/tests/planner/task-continuity.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest"
+import { buildPriorTaskIdLookup } from "../../src/planner/task-continuity"
+import type { MessageWithParts } from "../../src/session"
+import type {
+	AssistantMessageInfo,
+	UserMessageInfo,
+} from "../../src/session/message"
+import type {
+	CallID,
+	MessageID,
+	PartID,
+	SessionID,
+} from "../../src/session/schema"
+
+/**
+ * Guards the cross-turn task_id continuity property. The planner walks
+ * loaded session history once per /plan call and pulls each peer's most
+ * recent taskId so the next callPeer can chain via referenceTaskIds.
+ */
+
+const sid = "sess-test" as SessionID
+const mid = (n: number): MessageID => `msg-${n}` as MessageID
+const pid = (n: number): PartID => `part-${n}` as PartID
+const cid = (n: number): CallID => `call-${n}` as CallID
+
+function user(n: number): MessageWithParts {
+	const info: UserMessageInfo = {
+		id: mid(n),
+		sessionID: sid,
+		role: "user",
+		time: { created: 1000 + n },
+	}
+	return { info, parts: [] }
+}
+
+function assistantWithToolCall(opts: {
+	n: number
+	tool: string
+	peer?: string
+	taskId?: string
+	status?: "completed" | "error" | "pending"
+}): MessageWithParts {
+	const info: AssistantMessageInfo = {
+		id: mid(opts.n),
+		sessionID: sid,
+		role: "assistant",
+		modelID: "x",
+		providerID: "x",
+		agent: "planner",
+		tokens: { input: 0, output: 0, total: 0, cache: { read: 0, write: 0 } },
+		time: { created: 1000 + opts.n, completed: 1000 + opts.n + 1 },
+	}
+	const status = opts.status ?? "completed"
+	const metadata =
+		opts.peer !== undefined || opts.taskId !== undefined
+			? {
+					...(opts.peer !== undefined ? { peer: opts.peer } : {}),
+					...(opts.taskId !== undefined ? { taskId: opts.taskId } : {}),
+				}
+			: undefined
+	const part: import("../../src/session/message").Part =
+		status === "completed"
+			? {
+					id: pid(opts.n),
+					type: "tool" as const,
+					callID: cid(opts.n),
+					tool: opts.tool,
+					state: {
+						status: "completed" as const,
+						input: { x: 1 },
+						output: "ok",
+						...(metadata ? { metadata } : {}),
+						time: { start: 1, end: 2 },
+					},
+				}
+			: status === "error"
+				? {
+						id: pid(opts.n),
+						type: "tool" as const,
+						callID: cid(opts.n),
+						tool: opts.tool,
+						state: {
+							status: "error" as const,
+							input: { x: 1 },
+							error: "boom",
+							time: { start: 1, end: 2 },
+						},
+					}
+				: {
+						id: pid(opts.n),
+						type: "tool" as const,
+						callID: cid(opts.n),
+						tool: opts.tool,
+						state: {
+							status: "pending" as const,
+							input: { x: 1 },
+							time: { start: 1 },
+						},
+					}
+	return { info, parts: [part] }
+}
+
+describe("buildPriorTaskIdLookup", () => {
+	it("returns undefined when history is empty", () => {
+		const lookup = buildPriorTaskIdLookup([])
+		expect(lookup("math")).toBeUndefined()
+	})
+
+	it("returns the taskId for a peer with one prior completed call", () => {
+		const history = [
+			user(1),
+			assistantWithToolCall({ n: 2, tool: "call_math_solve", peer: "math", taskId: "t-1" }),
+		]
+		const lookup = buildPriorTaskIdLookup(history)
+		expect(lookup("math")).toBe("t-1")
+	})
+
+	it("returns the most recent taskId when the peer was called multiple times", () => {
+		const history = [
+			user(1),
+			assistantWithToolCall({ n: 2, tool: "call_math_solve", peer: "math", taskId: "t-1" }),
+			user(3),
+			assistantWithToolCall({ n: 4, tool: "call_math_solve", peer: "math", taskId: "t-2" }),
+		]
+		const lookup = buildPriorTaskIdLookup(history)
+		expect(lookup("math")).toBe("t-2")
+	})
+
+	it("tracks separate taskIds per peer", () => {
+		const history = [
+			user(1),
+			assistantWithToolCall({ n: 2, tool: "call_math_solve", peer: "math", taskId: "t-math" }),
+			user(3),
+			assistantWithToolCall({ n: 4, tool: "call_joke_tell", peer: "joke", taskId: "t-joke" }),
+		]
+		const lookup = buildPriorTaskIdLookup(history)
+		expect(lookup("math")).toBe("t-math")
+		expect(lookup("joke")).toBe("t-joke")
+		expect(lookup("nobody")).toBeUndefined()
+	})
+
+	it("ignores tool parts that did not complete successfully", () => {
+		// Errored / pending parts have no metadata to harvest, so the
+		// lookup falls through to undefined — first call gets a fresh task.
+		const history = [
+			user(1),
+			assistantWithToolCall({
+				n: 2,
+				tool: "call_math_solve",
+				peer: "math",
+				taskId: "t-1",
+				status: "error",
+			}),
+		]
+		const lookup = buildPriorTaskIdLookup(history)
+		expect(lookup("math")).toBeUndefined()
+	})
+
+	it("ignores completed tool parts that have no peer metadata", () => {
+		// Defensive: a tool that wasn't stamped (recipe loader, future
+		// internal tools) shouldn't accidentally pollute the lookup.
+		const history = [
+			user(1),
+			assistantWithToolCall({ n: 2, tool: "load_recipe" }),
+		]
+		const lookup = buildPriorTaskIdLookup(history)
+		expect(lookup("load_recipe")).toBeUndefined()
+	})
+
+	it("ignores user-role messages", () => {
+		// Only assistant turns carry tool results in this gateway's schema;
+		// scanning user turns would be a noop today, but the guard makes
+		// future role additions safe.
+		const history = [user(1), user(2)]
+		const lookup = buildPriorTaskIdLookup(history)
+		expect(lookup("math")).toBeUndefined()
+	})
+})

--- a/gateway/tests/session/doom-loop.test.ts
+++ b/gateway/tests/session/doom-loop.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest"
+import {
+	DOOM_LOOP_THRESHOLD,
+	doomLoopBailMessage,
+	hashToolInput,
+	isDoomLoop,
+	type ToolCallRecord,
+} from "../../src/session/doom-loop"
+
+/**
+ * Guards the "we won't let the planner grind through max_steps re-calling
+ * the same recipient with the same prompt" property. Mirror of opencode's
+ * processor.ts:354-379 doom-loop check, ported to the gateway's tool
+ * wrapper layer.
+ */
+
+const REC = (tool: string, inputHash: string): ToolCallRecord => ({
+	tool,
+	inputHash,
+})
+
+describe("hashToolInput", () => {
+	it("is stable across calls with the same input", () => {
+		expect(hashToolInput({ a: 1, b: "x" })).toBe(hashToolInput({ a: 1, b: "x" }))
+	})
+
+	it("differs when input differs", () => {
+		expect(hashToolInput({ a: 1 })).not.toBe(hashToolInput({ a: 2 }))
+	})
+
+	it("handles nullish input without throwing", () => {
+		expect(hashToolInput(null)).toBe(hashToolInput(undefined))
+	})
+
+	it("returns a 16-char hex string", () => {
+		const h = hashToolInput({ x: 1 })
+		expect(h).toMatch(/^[0-9a-f]{16}$/)
+	})
+})
+
+describe("isDoomLoop", () => {
+	const ham = REC("math.solve", "aaaa")
+
+	it("does not fire on the first call", () => {
+		expect(isDoomLoop([], ham)).toBe(false)
+	})
+
+	it("does not fire on the second identical call (threshold=3 means the third triggers)", () => {
+		expect(isDoomLoop([ham], ham)).toBe(false)
+	})
+
+	it("fires on the third identical call in a row", () => {
+		expect(isDoomLoop([ham, ham], ham)).toBe(true)
+	})
+
+	it("does not fire when the tool name differs", () => {
+		const other = REC("joke.tell", "aaaa")
+		expect(isDoomLoop([ham, ham], other)).toBe(false)
+	})
+
+	it("does not fire when the input hash differs", () => {
+		const otherInput = REC("math.solve", "bbbb")
+		expect(isDoomLoop([ham, ham], otherInput)).toBe(false)
+	})
+
+	it("only looks at the immediate tail (THRESHOLD-1 most recent)", () => {
+		// Older identical entries with a different one in between should
+		// not trip the detector.
+		const interrupt = REC("joke.tell", "aaaa")
+		expect(isDoomLoop([ham, ham, interrupt], ham)).toBe(false)
+	})
+
+	it("respects a custom threshold parameter", () => {
+		expect(isDoomLoop([ham], ham, 2)).toBe(true)
+		expect(isDoomLoop([], ham, 2)).toBe(false)
+	})
+
+	it("returns false when threshold is below the minimum sensible value", () => {
+		expect(isDoomLoop([ham, ham], ham, 1)).toBe(false)
+		expect(isDoomLoop([ham, ham], ham, 0)).toBe(false)
+	})
+})
+
+describe("doomLoopBailMessage", () => {
+	it("mentions the tool by name so the LLM can act on the specific case", () => {
+		const msg = doomLoopBailMessage("math.solve")
+		expect(msg).toContain("math.solve")
+		expect(msg).toContain(String(DOOM_LOOP_THRESHOLD))
+	})
+
+	it("directs the model to change approach rather than just signal failure", () => {
+		const msg = doomLoopBailMessage("math.solve")
+		expect(msg.toLowerCase()).toMatch(/different|change|finalize/)
+	})
+})

--- a/inbox/package-lock.json
+++ b/inbox/package-lock.json
@@ -11,13 +11,13 @@
 			"dependencies": {
 				"@hono/node-server": "^1.13.0",
 				"@phosphor-icons/react": "^2.1.10",
-				"@tanstack/react-query": "^5.99.0",
 				"better-sqlite3": "^11.3.0",
 				"clsx": "^2.1.1",
 				"hono": "^4.7.0",
 				"react": "^19.1.0",
 				"react-dom": "^19.1.0",
 				"react-router": "^7.5.3",
+				"undici": "^8.3.0",
 				"zustand": "^5.0.12"
 			},
 			"devDependencies": {
@@ -1460,32 +1460,6 @@
 			},
 			"peerDependencies": {
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
-			}
-		},
-		"node_modules/@tanstack/query-core": {
-			"version": "5.100.10",
-			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.10.tgz",
-			"integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			}
-		},
-		"node_modules/@tanstack/react-query": {
-			"version": "5.100.10",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.10.tgz",
-			"integrity": "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@tanstack/query-core": "5.100.10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			},
-			"peerDependencies": {
-				"react": "^18 || ^19"
 			}
 		},
 		"node_modules/@types/babel__core": {
@@ -3628,6 +3602,15 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+			"integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/undici-types": {

--- a/inbox/package.json
+++ b/inbox/package.json
@@ -22,6 +22,7 @@
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"react-router": "^7.5.3",
+		"undici": "^8.3.0",
 		"zustand": "^5.0.12"
 	},
 	"devDependencies": {

--- a/inbox/server/index.ts
+++ b/inbox/server/index.ts
@@ -33,7 +33,12 @@ import {
 	writeSettings,
 } from "./db";
 import { spawnPersonalAgent, stopPersonalAgent } from "./personal-agent";
-import { buildPeerDispatcher, pickFreePort, pollHealth } from "./utils";
+import {
+	buildPeerDispatcher,
+	insecureLoopbackDispatcher,
+	pickFreePort,
+	pollHealth,
+} from "./utils";
 
 // Path A: comms is the canonical record, gateway is stateless. We send
 // the most recent N user/assistant turns on every /api/plan call;
@@ -998,7 +1003,36 @@ async function spawnGatewayProcess(): Promise<GatewayHandle> {
 		};
 	}
 
-	const baseUrl = `http://127.0.0.1:${port}`;
+	// Phase C: if the personal agent has bootstrapped a cert from
+	// step-ca, pass its paths into the gateway env so the gateway can
+	// serve over TLS and present the cert on outbound A2A. The
+	// gateway shares the personal agent's identity ("co-opt"
+	// model) — same DID, same cert, simpler rotation. Phase C2 will
+	// give the gateway its own identity.
+	//
+	// Soft fallback: no cert files → plain HTTP gateway (today's
+	// behavior). The inbox handles both via insecureLoopbackDispatcher
+	// for loopback calls regardless of scheme.
+	const personalPkiDir =
+		process.env.BINDU_PERSONAL_PKI_DIR ??
+		`${process.env.HOME}/.bindu/personal/.bindu`;
+	const personalCert = `${personalPkiDir}/tls_cert.pem`;
+	const personalKey = `${personalPkiDir}/tls_key.pem`;
+	const personalCa = `${personalPkiDir}/ca_bundle.pem`;
+	const haveCert =
+		existsSync(personalCert) &&
+		existsSync(personalKey) &&
+		existsSync(personalCa);
+	const scheme = haveCert ? "https" : "http";
+	const tlsEnv: Record<string, string> = haveCert
+		? {
+				BINDU_GATEWAY_TLS_CERT: personalCert,
+				BINDU_GATEWAY_TLS_KEY: personalKey,
+				BINDU_GATEWAY_TLS_CA: personalCa,
+			}
+		: {};
+
+	const baseUrl = `${scheme}://127.0.0.1:${port}`;
 	const id = `gateway-spawned-${port}`;
 	const child = spawn("npm", ["start"], {
 		cwd: gatewayDir,
@@ -1012,6 +1046,7 @@ async function spawnGatewayProcess(): Promise<GatewayHandle> {
 			// Hydra was unreachable). When Hydra is healthy, this object
 			// is empty and the gateway uses whatever's in .env.local.
 			...hydraOverride,
+			...tlsEnv,
 		},
 		stdio: ["ignore", "pipe", "pipe"],
 		detached: false,
@@ -1338,6 +1373,10 @@ app.post("/api/plan", async (c) => {
 					if (GATEWAY_API_KEY) {
 						planHeaders.Authorization = `Bearer ${GATEWAY_API_KEY}`;
 					}
+					// Spawned gateway may be HTTPS now (Phase C — see
+					// spawnGatewayProcess). Its cert SAN is the DID, not
+					// 127.0.0.1, so we route loopback calls through the
+					// insecure dispatcher that skips hostname verify.
 					upstream = await fetch(`${gatewayUrl}/plan`, {
 						method: "POST",
 						headers: planHeaders,
@@ -1348,7 +1387,8 @@ app.post("/api/plan", async (c) => {
 							history: fullHistory,
 							prior_summary: priorSummary,
 						}),
-					});
+						dispatcher: insecureLoopbackDispatcher,
+					} as RequestInit & { dispatcher: typeof insecureLoopbackDispatcher });
 				} catch (err) {
 					fatal((err as Error).message, "gateway-unreachable");
 					return;

--- a/inbox/server/index.ts
+++ b/inbox/server/index.ts
@@ -33,10 +33,15 @@ import {
 	writeSettings,
 } from "./db";
 import { spawnPersonalAgent, stopPersonalAgent } from "./personal-agent";
+// `dispatcherFetch` MUST be used whenever an undici dispatcher is passed —
+// Node's bundled undici (6.x) global fetch and our pinned undici@8 dispatcher
+// don't interop. See utils.ts.
 import {
 	buildPeerDispatcher,
+	dispatcherFetch,
 	insecureLoopbackDispatcher,
 	pickFreePort,
+	pickPeerDispatcher,
 	pollHealth,
 } from "./utils";
 
@@ -167,6 +172,24 @@ async function fetchWellKnown(base: string) {
 		),
 	]);
 	return { did: didR as unknown, agentCard: cardR as unknown };
+}
+
+/** Pull the DID string for a given agentId, normalising between the two
+ *  shapes the inbox stores DIDs in:
+ *    - `me` (personal agent): a flat string in personal_agent.did
+ *    - everyone else: a parsed DID document object in agents.did with `.id`
+ *  Used by pickPeerDispatcher() callers to enable Option C identity
+ *  pinning when the DID is known, with insecure-loopback fallback during
+ *  the cold-start window when it isn't. Returns null when no DID is on
+ *  record (typical for HTTP peers, ecosystem agents the inbox hasn't
+ *  resolved yet, etc.). */
+function resolveExpectedDid(
+	agentId: string,
+	row?: AgentRecord | null,
+): string | null {
+	if (agentId === "me") return readPersonalAgent()?.did ?? null;
+	const did = (row?.did as { id?: string } | null)?.id;
+	return typeof did === "string" ? did : null;
 }
 
 async function resolveAgent(
@@ -317,8 +340,21 @@ app.get("/api/agents/:agentId/live", async (c) => {
 	if (!base) {
 		return c.json({ error: "no-url-for-agent", id }, 404);
 	}
+
+	// pickPeerDispatcher handles three cases: DID-pinned for known-DID
+	// loopback children, insecure-loopback fallback during the cold-start
+	// window, and undefined (default fetch with system CA roots) for
+	// external peers. See utils.ts for the matrix.
+	const expectedDid = resolveExpectedDid(id, row);
+	const dispatcher = pickPeerDispatcher(base, expectedDid);
+
 	const fetchJson = async (path: string) => {
-		const r = await fetch(`${base}${path}`);
+		const r = await fetch(
+			`${base}${path}`,
+			(dispatcher ? { dispatcher } : {}) as RequestInit & {
+				dispatcher?: typeof insecureLoopbackDispatcher;
+			},
+		);
 		if (!r.ok) throw new Error(`${path} → HTTP ${r.status}`);
 		return r.json();
 	};
@@ -787,14 +823,21 @@ app.post("/api/compose", async (c) => {
 	try {
 		const rpcBody = JSON.stringify(rpc);
 		const peerDispatcher = buildPeerDispatcher();
-		const r = await fetch(base, {
-			method: "POST",
-			headers: await a2aHeaders(rpcBody),
-			body: rpcBody,
-			...(peerDispatcher
-				? ({ dispatcher: peerDispatcher } as unknown as RequestInit)
-				: {}),
-		});
+		// Dispatcher path goes through undici's fetch (must match the
+		// Agent's undici version); the no-dispatcher branch keeps global
+		// fetch so we don't shadow it for the whole file.
+		const r = peerDispatcher
+			? await dispatcherFetch(base, {
+					method: "POST",
+					headers: await a2aHeaders(rpcBody),
+					body: rpcBody,
+					dispatcher: peerDispatcher,
+				})
+			: await fetch(base, {
+					method: "POST",
+					headers: await a2aHeaders(rpcBody),
+					body: rpcBody,
+				});
 		upstreamStatus = r.status;
 		upstreamBody = await r.json().catch(() => null);
 	} catch (err) {
@@ -866,7 +909,16 @@ app.post("/api/compose", async (c) => {
  * comms exits, SIGTERM cascades. We intentionally don't try to
  * persist these across restarts; that's a phase-3 concern.
  */
-const spawnedGateways = new Map<string, ChildProcess>();
+interface SpawnedGateway {
+	child: ChildProcess;
+	/** True iff this gateway was started with BINDU_GATEWAY_TLS_* in its
+	 * env (Phase C). False means it serves plain HTTP and presents no
+	 * client cert on outbound A2A. We track this so that when the personal
+	 * agent comes up AFTER a gateway was already spawned, recycleStaleGateways
+	 * can SIGTERM the HTTP one so the next /api/plan respawns it with TLS. */
+	hasTls: boolean;
+}
+const spawnedGateways = new Map<string, SpawnedGateway>();
 
 type GatewayHandle =
 	| {
@@ -954,9 +1006,9 @@ async function spawnGatewayProcess(): Promise<GatewayHandle> {
 	// Idempotency: reuse an alive spawned gateway if we have one.
 	// Misclick-protection; also makes a second /api/plan call within a
 	// session land on the same process so session continuity holds.
-	for (const [id, child] of spawnedGateways.entries()) {
+	for (const [id, entry] of spawnedGateways.entries()) {
 		const row = readAgent(id);
-		if (row?.url && child.exitCode === null) {
+		if (row?.url && entry.child.exitCode === null) {
 			const alive = await pollHealth(row.url, 1000);
 			if (alive) {
 				return {
@@ -1084,7 +1136,7 @@ async function spawnGatewayProcess(): Promise<GatewayHandle> {
 	writeAgent({ id, url: baseUrl, source: "manual", addedAt });
 	resolveAgent(id).catch(() => {});
 
-	spawnedGateways.set(id, child);
+	spawnedGateways.set(id, { child, hasTls: haveCert });
 	child.once("exit", () => {
 		spawnedGateways.delete(id);
 		// Drop the row from Contacts too — otherwise the sidebar keeps
@@ -1129,7 +1181,7 @@ async function ensureGateway(): Promise<GatewayHandle> {
 // Without this, child processes outlive their parent and the operator
 // has to `pkill -f 'gateway/src/index.ts'` to clean up.
 const cleanupSpawned = () => {
-	for (const child of spawnedGateways.values()) {
+	for (const { child } of spawnedGateways.values()) {
 		if (child.exitCode === null) {
 			try {
 				child.kill("SIGTERM");
@@ -1142,6 +1194,31 @@ const cleanupSpawned = () => {
 	// is safe even if nothing's running.
 	stopPersonalAgent();
 };
+
+/** SIGTERM any spawned gateway that was started before the personal
+ *  agent had a cert on disk. These gateways serve plain HTTP and
+ *  present no client cert outbound — once the personal agent is up
+ *  with mTLS the next /api/plan would route to a stale HTTP gateway,
+ *  silently losing Phase C end-to-end. We kill them so the next
+ *  spawnGatewayProcess re-evaluates `haveCert` and boots over TLS.
+ *
+ *  Safe to call repeatedly: gateways already on TLS are left alone,
+ *  and a freshly-killed gateway's `exit` listener cleans up the map
+ *  + the Contacts row. */
+function recycleStaleGateways(): number {
+	let killed = 0;
+	for (const { child, hasTls } of spawnedGateways.values()) {
+		if (hasTls) continue;
+		if (child.exitCode !== null) continue;
+		try {
+			child.kill("SIGTERM");
+			killed += 1;
+		} catch {
+			/* already exiting — ignore */
+		}
+	}
+	return killed;
+}
 process.once("SIGINT", () => {
 	cleanupSpawned();
 	process.exit(0);
@@ -1262,10 +1339,22 @@ app.post("/api/plan", async (c) => {
 					const row = readAgent(id);
 					if (!row?.url) continue;
 					let skills: SkillDescriptor[] = [];
+					// Same dispatcher selection as /api/agents/:id/live —
+					// without it, fetching /agent/skills on an HTTPS loopback
+					// agent (the personal agent under Phase A) fails TLS verify
+					// and the skill catalog quietly empties. The planner's
+					// "fewer than two callable agents" gate then trips.
+					const skillsBase = row.url.replace(/\/+$/, "");
+					const skillsDispatcher = pickPeerDispatcher(
+						skillsBase,
+						resolveExpectedDid(id, row),
+					);
 					try {
-						const r = await fetch(
-							`${row.url.replace(/\/+$/, "")}/agent/skills`,
-						);
+						const r = skillsDispatcher
+							? await dispatcherFetch(`${skillsBase}/agent/skills`, {
+									dispatcher: skillsDispatcher,
+								})
+							: await fetch(`${skillsBase}/agent/skills`);
 						if (r.ok) {
 							// Bindu's /agent/skills returns `{skills: [...], total: N}`
 							// (wrapped object). Earlier code assumed a bare array and
@@ -1377,7 +1466,7 @@ app.post("/api/plan", async (c) => {
 					// spawnGatewayProcess). Its cert SAN is the DID, not
 					// 127.0.0.1, so we route loopback calls through the
 					// insecure dispatcher that skips hostname verify.
-					upstream = await fetch(`${gatewayUrl}/plan`, {
+					upstream = await dispatcherFetch(`${gatewayUrl}/plan`, {
 						method: "POST",
 						headers: planHeaders,
 						body: JSON.stringify({
@@ -1388,7 +1477,7 @@ app.post("/api/plan", async (c) => {
 							prior_summary: priorSummary,
 						}),
 						dispatcher: insecureLoopbackDispatcher,
-					} as RequestInit & { dispatcher: typeof insecureLoopbackDispatcher });
+					});
 				} catch (err) {
 					fatal((err as Error).message, "gateway-unreachable");
 					return;
@@ -1616,14 +1705,18 @@ app.post("/api/events/:id/action", async (c) => {
 		try {
 			const msgBody = JSON.stringify(msg);
 			const peerDispatcher = buildPeerDispatcher();
-			const r = await fetch(base, {
-				method: "POST",
-				headers: await a2aHeaders(msgBody),
-				body: msgBody,
-				...(peerDispatcher
-					? ({ dispatcher: peerDispatcher } as unknown as RequestInit)
-					: {}),
-			});
+			const r = peerDispatcher
+				? await dispatcherFetch(base, {
+						method: "POST",
+						headers: await a2aHeaders(msgBody),
+						body: msgBody,
+						dispatcher: peerDispatcher,
+					})
+				: await fetch(base, {
+						method: "POST",
+						headers: await a2aHeaders(msgBody),
+						body: msgBody,
+					});
 			return c.json({ ok: r.ok, status: r.status, delivered: r.ok });
 		} catch (err) {
 			return c.json({ ok: false, error: (err as Error).message }, 502);
@@ -1720,6 +1813,17 @@ app.post("/api/me/spawn", async (c) => {
 	// route outbound through the personal agent (Phase 5).
 	if (result.row.url) {
 		AGENT_URLS["me"] = result.row.url;
+	}
+	// Phase C cold-start fix: if a gateway was already running on plain
+	// HTTP (spawned before the personal agent had a cert), SIGTERM it so
+	// the next /api/plan respawns it with BINDU_GATEWAY_TLS_* env. Without
+	// this the gateway stays HTTP for its whole lifetime, silently
+	// disabling Phase C even after the personal agent comes up healthy.
+	const recycled = recycleStaleGateways();
+	if (recycled > 0) {
+		console.log(
+			`[me/spawn] recycled ${recycled} HTTP gateway(s) so next plan respawns with TLS`,
+		);
 	}
 	return c.json(result.row);
 });

--- a/inbox/server/index.ts
+++ b/inbox/server/index.ts
@@ -33,7 +33,7 @@ import {
 	writeSettings,
 } from "./db";
 import { spawnPersonalAgent, stopPersonalAgent } from "./personal-agent";
-import { pickFreePort, pollHealth } from "./utils";
+import { buildPeerDispatcher, pickFreePort, pollHealth } from "./utils";
 
 // Path A: comms is the canonical record, gateway is stateless. We send
 // the most recent N user/assistant turns on every /api/plan call;
@@ -145,9 +145,21 @@ const AGENT_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
 
 async function fetchWellKnown(base: string) {
+	// Discovery hits the peer's HTTPS endpoint when the peer is
+	// mTLS-enabled. Present our personal-agent cert if we have one;
+	// otherwise fall through to the default dispatcher (works for
+	// HTTP peers and any HTTPS peer with a publicly-trusted cert).
+	const dispatcher = buildPeerDispatcher();
+	const init = (dispatcher ? { dispatcher } : {}) as RequestInit & {
+		dispatcher?: ReturnType<typeof buildPeerDispatcher>;
+	};
 	const [didR, cardR] = await Promise.all([
-		fetch(`${base}/.well-known/did.json`).then((r) => (r.ok ? r.json() : null)),
-		fetch(`${base}/.well-known/agent.json`).then((r) => (r.ok ? r.json() : null)),
+		fetch(`${base}/.well-known/did.json`, init).then((r) =>
+			r.ok ? r.json() : null,
+		),
+		fetch(`${base}/.well-known/agent.json`, init).then((r) =>
+			r.ok ? r.json() : null,
+		),
 	]);
 	return { did: didR as unknown, agentCard: cardR as unknown };
 }
@@ -769,10 +781,14 @@ app.post("/api/compose", async (c) => {
 	let upstreamError: string | null = null;
 	try {
 		const rpcBody = JSON.stringify(rpc);
+		const peerDispatcher = buildPeerDispatcher();
 		const r = await fetch(base, {
 			method: "POST",
 			headers: await a2aHeaders(rpcBody),
 			body: rpcBody,
+			...(peerDispatcher
+				? ({ dispatcher: peerDispatcher } as unknown as RequestInit)
+				: {}),
 		});
 		upstreamStatus = r.status;
 		upstreamBody = await r.json().catch(() => null);
@@ -1559,10 +1575,14 @@ app.post("/api/events/:id/action", async (c) => {
 		};
 		try {
 			const msgBody = JSON.stringify(msg);
+			const peerDispatcher = buildPeerDispatcher();
 			const r = await fetch(base, {
 				method: "POST",
 				headers: await a2aHeaders(msgBody),
 				body: msgBody,
+				...(peerDispatcher
+					? ({ dispatcher: peerDispatcher } as unknown as RequestInit)
+					: {}),
 			});
 			return c.json({ ok: r.ok, status: r.status, delivered: r.ok });
 		} catch (err) {

--- a/inbox/server/index.ts
+++ b/inbox/server/index.ts
@@ -1813,6 +1813,18 @@ app.post("/api/me/spawn", async (c) => {
 	// route outbound through the personal agent (Phase 5).
 	if (result.row.url) {
 		AGENT_URLS["me"] = result.row.url;
+		// Also sync the ecosystem `agents` row. Each spawn picks a fresh
+		// free port, so the prior row's url goes stale immediately and
+		// the inspector (`/api/agents/:id/live`, which reads from this
+		// table) ends up fetching a dead port and surfacing "fetch
+		// failed" across all four panels.
+		writeAgent({
+			id: "me",
+			url: result.row.url,
+			did: result.row.did ?? undefined,
+			resolvedAt: new Date().toISOString(),
+			source: "manual",
+		});
 	}
 	// Phase C cold-start fix: if a gateway was already running on plain
 	// HTTP (spawned before the personal agent had a cert), SIGTERM it so

--- a/inbox/server/index.ts
+++ b/inbox/server/index.ts
@@ -40,6 +40,7 @@ import {
 	buildPeerDispatcher,
 	dispatcherFetch,
 	insecureLoopbackDispatcher,
+	isLoopbackHttpsUrl,
 	pickFreePort,
 	pickPeerDispatcher,
 	pollHealth,
@@ -156,20 +157,31 @@ const AGENT_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
 async function fetchWellKnown(base: string) {
 	// Discovery hits the peer's HTTPS endpoint when the peer is
-	// mTLS-enabled. Present our personal-agent cert if we have one;
-	// otherwise fall through to the default dispatcher (works for
-	// HTTP peers and any HTTPS peer with a publicly-trusted cert).
-	const dispatcher = buildPeerDispatcher();
-	const init = (dispatcher ? { dispatcher } : {}) as RequestInit & {
-		dispatcher?: ReturnType<typeof buildPeerDispatcher>;
-	};
+	// mTLS-enabled. Present our personal-agent cert if we have one
+	// (peers may require client cert); otherwise fall back to the
+	// insecure-loopback dispatcher for spawned 127.0.0.1 children
+	// (their cert SAN is a DID, not the hostname); plain global
+	// fetch for HTTP peers and HTTPS peers with publicly-trusted
+	// certs.
+	//
+	// Route through dispatcherFetch whenever a dispatcher is in
+	// play — Node 22's bundled undici 6.x global fetch can't accept
+	// our pinned undici 8.x dispatcher and throws an opaque
+	// "fetch failed".
+	const peerCertDispatcher = buildPeerDispatcher();
+	const dispatcher =
+		peerCertDispatcher ??
+		(isLoopbackHttpsUrl(base) ? insecureLoopbackDispatcher : undefined);
+
+	const get = (path: string) =>
+		(dispatcher
+			? dispatcherFetch(`${base}${path}`, { dispatcher })
+			: fetch(`${base}${path}`)
+		).then((r) => (r.ok ? r.json() : null));
+
 	const [didR, cardR] = await Promise.all([
-		fetch(`${base}/.well-known/did.json`, init).then((r) =>
-			r.ok ? r.json() : null,
-		),
-		fetch(`${base}/.well-known/agent.json`, init).then((r) =>
-			r.ok ? r.json() : null,
-		),
+		get("/.well-known/did.json"),
+		get("/.well-known/agent.json"),
 	]);
 	return { did: didR as unknown, agentCard: cardR as unknown };
 }
@@ -349,12 +361,15 @@ app.get("/api/agents/:agentId/live", async (c) => {
 	const dispatcher = pickPeerDispatcher(base, expectedDid);
 
 	const fetchJson = async (path: string) => {
-		const r = await fetch(
-			`${base}${path}`,
-			(dispatcher ? { dispatcher } : {}) as RequestInit & {
-				dispatcher?: typeof insecureLoopbackDispatcher;
-			},
-		);
+		// When the personal agent serves HTTPS (mTLS on), `dispatcher` is the
+		// DID-pinned loopback agent; global `fetch` (Node-bundled undici 6.x)
+		// can't accept our pinned undici 8.x dispatcher and throws an opaque
+		// "fetch failed". Route through dispatcherFetch (undici.fetch) when
+		// we have one; fall back to global fetch on plain HTTP for external
+		// peers that don't need a dispatcher.
+		const r = dispatcher
+			? await dispatcherFetch(`${base}${path}`, { dispatcher })
+			: await fetch(`${base}${path}`);
 		if (!r.ok) throw new Error(`${path} → HTTP ${r.status}`);
 		return r.json();
 	};

--- a/inbox/server/personal-agent.ts
+++ b/inbox/server/personal-agent.ts
@@ -18,7 +18,7 @@
  * post-spawn via `/.well-known/did.json`.
  */
 
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync, chmodSync, openSync, closeSync } from "node:fs";
 import { resolve as pathResolve } from "node:path";
 import {
@@ -28,11 +28,22 @@ import {
 	readSettings,
 	writePersonalAgent,
 } from "./db";
-import { insecureLoopbackDispatcher, pickFreePort, pollHealth } from "./utils";
+// `dispatcherFetch` MUST be used whenever an undici dispatcher is passed —
+// Node's bundled undici (6.x) global fetch and our pinned undici@8 dispatcher
+// don't interop. See utils.ts.
+import {
+	dispatcherFetch,
+	insecureLoopbackDispatcher,
+	pickFreePort,
+	pollHealth,
+} from "./utils";
 
 /** Pick the first non-empty string from a list of candidates. Used to
- * layer "settings table → process.env → default" without `??` falling
- * through on empty strings (which `??` treats as truthy). */
+ * layer "settings table → process.env → default". `??` would short-
+ * circuit on null/undefined only, treating `""` as a real value and
+ * locking in an empty secret — this helper treats empty strings as
+ * absent, so a blank field in the Settings tab correctly falls through
+ * to the env var or default. */
 function firstNonEmpty(...vals: (string | null | undefined)[]): string {
 	for (const v of vals) if (typeof v === "string" && v.length > 0) return v;
 	return "";
@@ -264,7 +275,12 @@ config = {
     "name": "${agentName}",
     "description": f"Personal agent for {PERSONA['name']}",
     "deployment": {
-        "url": "https://localhost:${port}",
+        # 127.0.0.1, not localhost — the inbox tracks the agent URL
+        # as https://127.0.0.1:<port> and "localhost" can resolve to
+        # ::1 on some systems, which breaks loopback dispatchers that
+        # only match the IPv4 form. Cert SAN is the DID either way,
+        # so hostname verify is bypassed at the dispatcher layer.
+        "url": "https://127.0.0.1:${port}",
         "expose": True,
         "cors_origins": ["${corsOrigin}"],
     },
@@ -473,7 +489,7 @@ export async function spawnPersonalAgent(
 		? ["uv", ["run", "python", paths.agentPy]]
 		: existsSync(venvPython)
 			? [venvPython, [paths.agentPy]]
-			: [process.execPath === "" ? "python" : "python3", [paths.agentPy]];
+			: ["python3", [paths.agentPy]];
 
 	const child = spawn(argv[0], argv[1], {
 		cwd: binduRepo,
@@ -551,9 +567,9 @@ export async function spawnPersonalAgent(
 	// first — it's the cheapest probe and the response is small.
 	let did: string | null = null;
 	const loopbackFetch = (path: string) =>
-		fetch(`${baseUrl}${path}`, {
+		dispatcherFetch(`${baseUrl}${path}`, {
 			dispatcher: insecureLoopbackDispatcher,
-		} as RequestInit & { dispatcher: typeof insecureLoopbackDispatcher });
+		});
 	try {
 		const r = await loopbackFetch("/health");
 		if (r.ok) {
@@ -626,12 +642,8 @@ export function stopPersonalAgent(): { ok: boolean; wasAlive: boolean } {
  * trying to spawn it — spawn errors are async and don't compose well
  * with our spawn flow. `which uv` is synchronous and fast. */
 function commandExists(cmd: string): boolean {
-	const which = spawn.bind(null);
-	void which;
 	try {
-		const result = require("node:child_process").spawnSync("which", [cmd], {
-			stdio: "ignore",
-		}) as { status: number | null };
+		const result = spawnSync("which", [cmd], { stdio: "ignore" });
 		return result.status === 0;
 	} catch {
 		return false;

--- a/inbox/server/personal-agent.ts
+++ b/inbox/server/personal-agent.ts
@@ -150,8 +150,9 @@ function renderAgentPy(opts: {
 	webhookUrl: string;
 	tools: PersonalAgentTools;
 	corsOrigin: string;
+	scheme: "http" | "https";
 }): string {
-	const { slug, agentName, port, webhookUrl, tools, corsOrigin } = opts;
+	const { slug, agentName, port, webhookUrl, tools, corsOrigin, scheme } = opts;
 	// Header lists the user-facing facts so a human dropping into the
 	// file knows what changed and why. Persona is loaded at runtime so
 	// the user can edit persona.json (or re-run the wizard) without
@@ -168,16 +169,25 @@ function renderAgentPy(opts: {
 # webhook:     ${webhookUrl}
 # tools:       ${Object.keys(tools).length ? Object.keys(tools).join(", ") : "(none connected)"}
 
-import json
-import os
+# Load .env BEFORE importing bindu. bindu/settings.py constructs
+# \`app_settings = Settings()\` at module import time — any env var set
+# after that import (via a later load_dotenv) lands in os.environ but
+# never makes it into the singleton. The personal agent ships with
+# MTLS__ENABLED=true; if .env loads too late, mtls.enabled defaults to
+# False, the agent silently serves plain HTTP on https://… URL, and
+# the inbox spawn poller hangs on the HTTPS handshake.
 from pathlib import Path
 
 from dotenv import load_dotenv
-from bindu.penguin.bindufy import bindufy
-from agno.agent import Agent
-from agno.models.openrouter import OpenRouter
 
 load_dotenv(Path(__file__).parent / ".env")
+
+import json  # noqa: E402
+import os  # noqa: E402
+
+from agno.agent import Agent  # noqa: E402
+from agno.models.openrouter import OpenRouter  # noqa: E402
+from bindu.penguin.bindufy import bindufy  # noqa: E402
 
 PERSONA = json.loads((Path(__file__).parent / "persona.json").read_text())
 
@@ -276,11 +286,11 @@ config = {
     "description": f"Personal agent for {PERSONA['name']}",
     "deployment": {
         # 127.0.0.1, not localhost — the inbox tracks the agent URL
-        # as https://127.0.0.1:<port> and "localhost" can resolve to
+        # as <scheme>://127.0.0.1:<port> and "localhost" can resolve to
         # ::1 on some systems, which breaks loopback dispatchers that
-        # only match the IPv4 form. Cert SAN is the DID either way,
+        # only match the IPv4 form. With mTLS on, cert SAN is the DID,
         # so hostname verify is bypassed at the dispatcher layer.
-        "url": "https://127.0.0.1:${port}",
+        "url": "${scheme}://127.0.0.1:${port}",
         "expose": True,
         "cors_origins": ["${corsOrigin}"],
     },
@@ -393,6 +403,14 @@ export async function spawnPersonalAgent(
 		pipedreamAccessToken = (await mintPipedreamAccessToken().catch(() => "")) ?? "";
 	}
 
+	// mTLS is gated behind BINDU_PERSONAL_MTLS=1. Default off because the
+	// public Hydra (hydra.getbindu.com) doesn't currently whitelist the
+	// `step-ca` audience that the OIDC provisioner requires — bootstrap
+	// fails, bindu silently falls back to plain HTTP, and the spawner
+	// (which polls https://) hangs forever. Once Hydra is configured to
+	// accept aud=step-ca on client_credentials grants, flip this on (or
+	// expose it via the Settings tab).
+	const mtlsEnabled = process.env.BINDU_PERSONAL_MTLS === "1";
 	writePersona(paths, row.persona);
 	writeEnvFile(paths, {
 		OPENROUTER_API_KEY: openrouterKey,
@@ -416,15 +434,7 @@ export async function spawnPersonalAgent(
 			process.env.HYDRA__ADMIN_URL ?? "https://hydra-admin.getbindu.com",
 		HYDRA__PUBLIC_URL:
 			process.env.HYDRA__PUBLIC_URL ?? "https://hydra.getbindu.com",
-		// mTLS is on by default for every personal agent. The agent
-		// exchanges its Hydra OIDC token (audience=step-ca) for a 24h
-		// X.509 cert from step-ca and serves uvicorn over TLS.
-		// REQUIRE_CLIENT_CERT is soft for now — the inbox itself talks
-		// to its own agent on loopback without presenting a client cert
-		// (Phase B will flip that). Mode "hybrid" keeps Hydra
-		// introspection on inbound so the auth gate still has identity
-		// to work with even when no peer cert reaches the middleware.
-		MTLS__ENABLED: "true",
+		MTLS__ENABLED: mtlsEnabled ? "true" : "false",
 		MTLS__MODE: "hybrid",
 		MTLS__REQUIRE_CLIENT_CERT: "false",
 		MTLS__CA_URL: process.env.MTLS__CA_URL ?? "https://ca.getbindu.com",
@@ -443,6 +453,7 @@ export async function spawnPersonalAgent(
 			webhookUrl,
 			tools: row.tools,
 			corsOrigin,
+			scheme: mtlsEnabled ? "https" : "http",
 		}),
 		"utf8",
 	);
@@ -468,11 +479,12 @@ export async function spawnPersonalAgent(
 		};
 	}
 
-	// Personal agents serve over HTTPS now (mTLS by default — see the
-	// MTLS__* env vars below). The cert is real, but its SAN is the DID,
-	// not 127.0.0.1, so callers on the loopback skip hostname
-	// verification via insecureLoopbackDispatcher.
-	const baseUrl = `https://127.0.0.1:${port}`;
+	// Scheme follows mtlsEnabled (see writeEnvFile above). With mTLS on,
+	// the cert is real but its SAN is the DID, not 127.0.0.1 — callers
+	// on the loopback skip hostname verification via
+	// insecureLoopbackDispatcher. With mTLS off, plain HTTP loopback.
+	const scheme = mtlsEnabled ? "https" : "http";
+	const baseUrl = `${scheme}://127.0.0.1:${port}`;
 	const now = new Date().toISOString();
 	writePersonalAgent({
 		...row,

--- a/inbox/server/personal-agent.ts
+++ b/inbox/server/personal-agent.ts
@@ -28,7 +28,7 @@ import {
 	readSettings,
 	writePersonalAgent,
 } from "./db";
-import { pickFreePort, pollHealth } from "./utils";
+import { insecureLoopbackDispatcher, pickFreePort, pollHealth } from "./utils";
 
 /** Pick the first non-empty string from a list of candidates. Used to
  * layer "settings table → process.env → default" without `??` falling
@@ -264,7 +264,7 @@ config = {
     "name": "${agentName}",
     "description": f"Personal agent for {PERSONA['name']}",
     "deployment": {
-        "url": "http://localhost:${port}",
+        "url": "https://localhost:${port}",
         "expose": True,
         "cors_origins": ["${corsOrigin}"],
     },
@@ -400,6 +400,21 @@ export async function spawnPersonalAgent(
 			process.env.HYDRA__ADMIN_URL ?? "https://hydra-admin.getbindu.com",
 		HYDRA__PUBLIC_URL:
 			process.env.HYDRA__PUBLIC_URL ?? "https://hydra.getbindu.com",
+		// mTLS is on by default for every personal agent. The agent
+		// exchanges its Hydra OIDC token (audience=step-ca) for a 24h
+		// X.509 cert from step-ca and serves uvicorn over TLS.
+		// REQUIRE_CLIENT_CERT is soft for now — the inbox itself talks
+		// to its own agent on loopback without presenting a client cert
+		// (Phase B will flip that). Mode "hybrid" keeps Hydra
+		// introspection on inbound so the auth gate still has identity
+		// to work with even when no peer cert reaches the middleware.
+		MTLS__ENABLED: "true",
+		MTLS__MODE: "hybrid",
+		MTLS__REQUIRE_CLIENT_CERT: "false",
+		MTLS__CA_URL: process.env.MTLS__CA_URL ?? "https://ca.getbindu.com",
+		MTLS__CA_ROOT_URL:
+			process.env.MTLS__CA_ROOT_URL ??
+			"https://ca.getbindu.com/roots.pem",
 	});
 	writeFileSync(
 		paths.agentPy,
@@ -437,7 +452,11 @@ export async function spawnPersonalAgent(
 		};
 	}
 
-	const baseUrl = `http://127.0.0.1:${port}`;
+	// Personal agents serve over HTTPS now (mTLS by default — see the
+	// MTLS__* env vars below). The cert is real, but its SAN is the DID,
+	// not 127.0.0.1, so callers on the loopback skip hostname
+	// verification via insecureLoopbackDispatcher.
+	const baseUrl = `https://127.0.0.1:${port}`;
 	const now = new Date().toISOString();
 	writePersonalAgent({
 		...row,
@@ -531,8 +550,12 @@ export async function spawnPersonalAgent(
 	// payload exposes `application.agent_did` directly. Try health
 	// first — it's the cheapest probe and the response is small.
 	let did: string | null = null;
+	const loopbackFetch = (path: string) =>
+		fetch(`${baseUrl}${path}`, {
+			dispatcher: insecureLoopbackDispatcher,
+		} as RequestInit & { dispatcher: typeof insecureLoopbackDispatcher });
 	try {
-		const r = await fetch(`${baseUrl}/health`);
+		const r = await loopbackFetch("/health");
 		if (r.ok) {
 			const j = (await r.json()) as {
 				application?: { agent_did?: string };
@@ -547,7 +570,7 @@ export async function spawnPersonalAgent(
 	}
 	if (!did) {
 		try {
-			const r = await fetch(`${baseUrl}/.well-known/agent.json`);
+			const r = await loopbackFetch("/.well-known/agent.json");
 			if (r.ok) {
 				const j = (await r.json()) as {
 					capabilities?: { extensions?: Array<{ uri?: string }> };

--- a/inbox/server/utils.ts
+++ b/inbox/server/utils.ts
@@ -1,4 +1,7 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
 import net from "node:net";
+import { homedir } from "node:os";
+import path from "node:path";
 import { Agent } from "undici";
 
 /** Loopback-only HTTPS dispatcher.
@@ -14,6 +17,60 @@ import { Agent } from "undici";
 export const insecureLoopbackDispatcher = new Agent({
 	connect: { rejectUnauthorized: false },
 });
+
+/* -------------------------------------------------------------------------- */
+/*  Peer-A2A dispatcher (Phase B)                                             */
+/* -------------------------------------------------------------------------- */
+
+/** Resolve the personal agent's PKI dir. The personal-agent spawner writes
+ *  cert/key/CA-bundle here once the agent has bootstrapped (Phase A wired
+ *  the env that triggers the bootstrap). */
+const PERSONAL_PKI_DIR =
+	process.env.BINDU_PERSONAL_PKI_DIR ??
+	path.join(homedir(), ".bindu", "personal", ".bindu");
+const CERT_PATH = path.join(PERSONAL_PKI_DIR, "tls_cert.pem");
+const KEY_PATH = path.join(PERSONAL_PKI_DIR, "tls_key.pem");
+const CA_PATH = path.join(PERSONAL_PKI_DIR, "ca_bundle.pem");
+
+let cachedPeerDispatcher: { agent: Agent; mtimeMs: number } | null = null;
+
+/** Returns an undici Agent that presents the personal agent's mTLS cert
+ *  on outbound A2A calls and trusts peers signed by the same private CA.
+ *
+ *  Behavior:
+ *    - If cert files don't exist yet (personal agent not spawned): returns
+ *      undefined → caller falls back to the default (no client cert).
+ *    - On HTTP destinations the dispatcher options are ignored; works.
+ *    - On HTTPS destinations we present the cert and trust ONLY the
+ *      bundled CA. Cert SANs are DIDs, not hostnames, so hostname
+ *      verification is disabled — identity is enforced at the app layer
+ *      via X-DID-Signature (a2aHeaders) and the cert chain still has
+ *      to reach our Root CA.
+ *    - File mtime is checked on every call; the cert renews every ~16h
+ *      and we pick the new one up automatically without restart.
+ */
+export function buildPeerDispatcher(): Agent | undefined {
+	if (!existsSync(CERT_PATH) || !existsSync(KEY_PATH) || !existsSync(CA_PATH)) {
+		return undefined;
+	}
+	const mtimeMs = statSync(CERT_PATH).mtimeMs;
+	if (cachedPeerDispatcher && cachedPeerDispatcher.mtimeMs === mtimeMs) {
+		return cachedPeerDispatcher.agent;
+	}
+	const agent = new Agent({
+		connect: {
+			cert: readFileSync(CERT_PATH),
+			key: readFileSync(KEY_PATH),
+			ca: readFileSync(CA_PATH),
+			// Peer cert SANs are DIDs (did:bindu:...), not hostnames. We
+			// rely on (a) chain verification against our private CA and
+			// (b) app-layer DID signature verification via a2aHeaders.
+			checkServerIdentity: () => undefined,
+		},
+	});
+	cachedPeerDispatcher = { agent, mtimeMs };
+	return agent;
+}
 
 /** Ask the OS for an unused TCP port on 127.0.0.1. Used by both the
  * gateway spawner (index.ts) and the personal-agent spawner so we don't

--- a/inbox/server/utils.ts
+++ b/inbox/server/utils.ts
@@ -2,7 +2,53 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import net from "node:net";
 import { homedir } from "node:os";
 import path from "node:path";
-import { Agent } from "undici";
+import tls from "node:tls";
+import {
+	Agent,
+	fetch as undiciFetch,
+	type Dispatcher,
+	type RequestInit as UndiciRequestInit,
+} from "undici";
+
+/** Like `fetch`, but accepts an undici `dispatcher` and routes through
+ * undici's own fetch implementation so the dispatcher contract matches.
+ *
+ * Why this exists: Node 22 ships a bundled undici (6.x) used by global
+ * `fetch`. Our `package.json` pins undici@8 because we need the v8
+ * dispatcher API (Agent options around TLS, ALPN, etc.). Cross-version
+ * passing — a global-fetch call with an undici-8 Agent as `dispatcher` —
+ * fails at runtime with `"invalid onRequestStart method"` because the
+ * dispatcher protocol drifted between v6 and v8.
+ *
+ * Calling sites that need a dispatcher MUST go through this helper.
+ * Sites that don't pass a dispatcher can keep using the global `fetch`
+ * — those paths don't trip the version mismatch. Cast on return is a
+ * type-only fix: at runtime, undici's Response is a Web-spec Response,
+ * but the .d.ts types disagree on field nullability for `body` and
+ * `headers`, which would otherwise infect every caller. */
+export async function dispatcherFetch(
+	url: string,
+	init: UndiciRequestInit & { dispatcher: Dispatcher },
+): Promise<Response> {
+	const res = await undiciFetch(url, init);
+	return res as unknown as Response;
+}
+
+/** Trust bundle = our private step-ca + Node's default Mozilla roots.
+ *
+ *  Setting `ca` on undici.Agent.connect REPLACES Node's default CA store
+ *  rather than augmenting it (Node TLS docs). If we passed just our
+ *  step-ca bundle, every HTTPS call through this dispatcher to a peer
+ *  with a public CA (Let's Encrypt, DigiCert, etc.) would fail with
+ *  UNABLE_TO_VERIFY_LEAF_SIGNATURE. Concatenating the system roots
+ *  preserves the dispatcher's ability to reach public-CA peers while
+ *  still trusting our private CA.
+ *
+ *  `tls.rootCertificates` is the Mozilla bundle Node ships. Free to call;
+ *  the array is computed once and frozen at process start. */
+function withSystemRoots(caBundle: Buffer): string[] {
+	return [...tls.rootCertificates, caBundle.toString("utf8")];
+}
 
 /** Loopback-only HTTPS dispatcher.
  *
@@ -61,7 +107,7 @@ export function buildPeerDispatcher(): Agent | undefined {
 		connect: {
 			cert: readFileSync(CERT_PATH),
 			key: readFileSync(KEY_PATH),
-			ca: readFileSync(CA_PATH),
+			ca: withSystemRoots(readFileSync(CA_PATH)),
 			// Peer cert SANs are DIDs (did:bindu:...), not hostnames. We
 			// rely on (a) chain verification against our private CA and
 			// (b) app-layer DID signature verification via a2aHeaders.
@@ -70,6 +116,121 @@ export function buildPeerDispatcher(): Agent | undefined {
 	});
 	cachedPeerDispatcher = { agent, mtimeMs };
 	return agent;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  DID-pinned dispatcher (Option C)                                          */
+/* -------------------------------------------------------------------------- */
+
+/** Per-DID cache so we don't re-build a TLS Agent on every inspector hit.
+ *  Keyed by `<expectedDid>@<mtimeMs>` so cert rotation invalidates entries
+ *  the same way buildPeerDispatcher does. */
+const didPinnedCache = new Map<string, Agent>();
+
+/** Parse the comma-separated `subjectaltname` string Node hands to
+ *  checkServerIdentity into the list of underlying values. Format is
+ *  `URI:did:bindu:..., DNS:foo, IP Address:127.0.0.1` — we strip the
+ *  type prefix so a caller can match on the raw URI/DNS/IP string. */
+function parseSans(subjectaltname: string | undefined): string[] {
+	if (!subjectaltname) return [];
+	return subjectaltname
+		.split(",")
+		.map((s) => s.trim())
+		.map((s) => s.replace(/^(URI|DNS|IP Address|email):/i, ""));
+}
+
+/** Loopback HTTPS dispatcher that pins BOTH the cert chain (to our private
+ *  CA) AND the peer's identity (to a specific DID present in the cert SAN).
+ *
+ *  This is the secure choice for talking to a known-DID spawned child like
+ *  the personal agent. Stronger than buildPeerDispatcher() because it
+ *  rejects valid-but-wrong-DID certs from our own CA — i.e. it survives
+ *  a hypothetical "someone else got a cert from step-ca" scenario.
+ *
+ *  Returns undefined when cert files aren't on disk yet (first-spawn
+ *  window). Callers fall back to insecureLoopbackDispatcher in that case
+ *  — there's no DID to pin against before the agent has bootstrapped.
+ */
+export function buildLoopbackDispatcherForDid(
+	expectedDid: string,
+): Agent | undefined {
+	if (!existsSync(CERT_PATH) || !existsSync(KEY_PATH) || !existsSync(CA_PATH)) {
+		return undefined;
+	}
+	const mtimeMs = statSync(CERT_PATH).mtimeMs;
+	const cacheKey = `${expectedDid}@${mtimeMs}`;
+	const cached = didPinnedCache.get(cacheKey);
+	if (cached) return cached;
+
+	const agent = new Agent({
+		connect: {
+			cert: readFileSync(CERT_PATH),
+			key: readFileSync(KEY_PATH),
+			ca: withSystemRoots(readFileSync(CA_PATH)),
+			// Two-layer identity check: chain must reach our private CA
+			// (handled by `ca` above + Node's default chain verify), AND
+			// the cert SAN must include the DID we expected. Without the
+			// SAN check, any cert from our CA would be accepted — defeating
+			// the point of pinning. The cert object Node hands us exposes
+			// SANs as a comma-separated string in `subjectaltname`.
+			checkServerIdentity: (_hostname, cert) => {
+				const sans = parseSans(cert.subjectaltname);
+				if (sans.includes(expectedDid)) return undefined;
+				return new Error(
+					`cert SAN [${sans.join(", ")}] does not include expected DID ${expectedDid}`,
+				);
+			},
+		},
+	});
+	didPinnedCache.set(cacheKey, agent);
+	return agent;
+}
+
+/** Heuristic: is this URL a loopback HTTPS destination we spawned?
+ *  Used by callers that want to pick between the DID-pinned dispatcher
+ *  (loopback child) and default fetch (external peer with public CA). */
+export function isLoopbackHttpsUrl(url: string): boolean {
+	try {
+		const u = new URL(url);
+		if (u.protocol !== "https:") return false;
+		return u.hostname === "127.0.0.1" || u.hostname === "localhost" || u.hostname === "::1";
+	} catch {
+		return false;
+	}
+}
+
+/** Pick the right undici dispatcher for a server-side fetch to a Bindu
+ *  agent endpoint (well-known docs, /agent/skills, /health, etc.). Three
+ *  buckets:
+ *
+ *    1. Loopback HTTPS spawned child (the personal agent today, the
+ *       gateway tomorrow). Cert is signed by our private step-ca and
+ *       the SAN is a DID, not the hostname. Plain fetch fails both
+ *       chain verify and hostname verify. Returns a DID-pinned
+ *       dispatcher if `expectedDid` is known, otherwise the insecure
+ *       loopback dispatcher (rejectUnauthorized:false) as a cold-start
+ *       fallback.
+ *
+ *    2. External HTTPS peer (public CA). Returns undefined → caller
+ *       uses plain fetch, Node verifies against Mozilla roots. The
+ *       DID-pinned dispatcher would reject these since their certs
+ *       are not from our private CA.
+ *
+ *    3. HTTP destination. Returns undefined → plain fetch; dispatcher
+ *       wouldn't do anything useful here anyway.
+ *
+ *  Returning undefined is a feature: callers can spread the result as
+ *  `...(d ? { dispatcher: d } : {})` and the type system stays clean.
+ */
+export function pickPeerDispatcher(
+	base: string,
+	expectedDid: string | null,
+): Agent | undefined {
+	if (!isLoopbackHttpsUrl(base)) return undefined;
+	if (expectedDid) {
+		return buildLoopbackDispatcherForDid(expectedDid) ?? insecureLoopbackDispatcher;
+	}
+	return insecureLoopbackDispatcher;
 }
 
 /** Ask the OS for an unused TCP port on 127.0.0.1. Used by both the
@@ -109,14 +270,14 @@ export async function pollHealth(
 	while (Date.now() - start < timeoutMs) {
 		if (signal?.aborted) return false;
 		try {
-			const r = await fetch(`${url}/health`, {
-				signal,
+			const r = await dispatcherFetch(`${url}/health`, {
+				signal: signal ?? undefined,
 				// Spawned children may be on HTTPS with a DID-named cert;
 				// see insecureLoopbackDispatcher above. Peers on the public
 				// internet are unaffected (their certs verify normally
 				// regardless of this dispatcher).
 				dispatcher: insecureLoopbackDispatcher,
-			} as RequestInit & { dispatcher: Agent });
+			});
 			if (r.ok) return true;
 		} catch {
 			/* ECONNREFUSED while the child is still booting — keep trying */

--- a/inbox/server/utils.ts
+++ b/inbox/server/utils.ts
@@ -1,4 +1,19 @@
 import net from "node:net";
+import { Agent } from "undici";
+
+/** Loopback-only HTTPS dispatcher.
+ *
+ * Inbox subprocesses (the personal agent today, the gateway tomorrow) now
+ * default to mTLS. Their cert is real — signed by the production Bindu
+ * Intermediate CA — but its CN/SAN is the agent's DID, not "127.0.0.1",
+ * so Node's stock hostname verification rejects it. We're calling our own
+ * spawned-child on the loopback interface, so we deliberately skip the
+ * verify here. Outbound-to-peers (Phase B) gets a properly verifying
+ * dispatcher with a CA bundle + client cert.
+ */
+export const insecureLoopbackDispatcher = new Agent({
+	connect: { rejectUnauthorized: false },
+});
 
 /** Ask the OS for an unused TCP port on 127.0.0.1. Used by both the
  * gateway spawner (index.ts) and the personal-agent spawner so we don't
@@ -37,7 +52,14 @@ export async function pollHealth(
 	while (Date.now() - start < timeoutMs) {
 		if (signal?.aborted) return false;
 		try {
-			const r = await fetch(`${url}/health`, { signal });
+			const r = await fetch(`${url}/health`, {
+				signal,
+				// Spawned children may be on HTTPS with a DID-named cert;
+				// see insecureLoopbackDispatcher above. Peers on the public
+				// internet are unaffected (their certs verify normally
+				// regardless of this dispatcher).
+				dispatcher: insecureLoopbackDispatcher,
+			} as RequestInit & { dispatcher: Agent });
 			if (r.ok) return true;
 		} catch {
 			/* ECONNREFUSED while the child is still booting — keep trying */

--- a/inbox/server/utils.ts
+++ b/inbox/server/utils.ts
@@ -174,8 +174,16 @@ export function buildLoopbackDispatcherForDid(
 			// the point of pinning. The cert object Node hands us exposes
 			// SANs as a comma-separated string in `subjectaltname`.
 			checkServerIdentity: (_hostname, cert) => {
+				// step-ca's Hydra OIDC provisioner emits the DID as a URL
+				// fragment on the issuer URL — e.g.
+				// `https://hydra.getbindu.com#did:bindu:...` — not a bare
+				// `did:bindu:...` URI. Accept both forms: a literal match,
+				// OR a fragment whose value equals expectedDid.
 				const sans = parseSans(cert.subjectaltname);
-				if (sans.includes(expectedDid)) return undefined;
+				const match = sans.some(
+					(san) => san === expectedDid || san.split("#")[1] === expectedDid,
+				);
+				if (match) return undefined;
 				return new Error(
 					`cert SAN [${sans.join(", ")}] does not include expected DID ${expectedDid}`,
 				);

--- a/inbox/src/components/AgentInfoModal.tsx
+++ b/inbox/src/components/AgentInfoModal.tsx
@@ -11,6 +11,7 @@ import { Modal } from "./Modal";
 import { ModalCloseButton } from "./ModalCloseButton";
 import { isGateway as isGatewayByName } from "~/lib/agent-kind";
 import type { EcosystemAgent } from "~/lib/api-types";
+import { didToEmail } from "~/lib/format";
 
 interface Props {
 	open: boolean;
@@ -104,7 +105,11 @@ export function AgentInfoModal({ open, onClose, agent }: Props) {
 		agent.agentCard?.name ??
 		agent.id;
 	const did = agent.did?.id ?? null;
-	const subline = did ?? agent.url ?? agent.id;
+	// Prefer the Gmail-shape rendering of the DID; the full DID lives in
+	// the title attribute below so power users can still copy the raw
+	// form. Non-bindu DIDs (didToEmail returns null) fall through to the
+	// raw DID; non-DID agents (HTTP peers, mocks) fall through to URL/id.
+	const subline = (did && didToEmail(did)) ?? did ?? agent.url ?? agent.id;
 
 	const skills =
 		snap?.skills.ok && Array.isArray(snap.skills.data) ? snap.skills.data : [];
@@ -134,7 +139,10 @@ export function AgentInfoModal({ open, onClose, agent }: Props) {
 						<h2 className="truncate text-[14px] font-medium text-slate-900">
 							{cardName}
 						</h2>
-						<div className="truncate font-mono text-[10px] text-slate-500">
+						<div
+							className="truncate font-mono text-[10px] text-slate-500"
+							title={did ?? undefined}
+						>
 							{subline}
 						</div>
 					</div>

--- a/inbox/src/components/AgentPicker.tsx
+++ b/inbox/src/components/AgentPicker.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import clsx from "clsx";
 import { XIcon } from "@phosphor-icons/react";
-import { shortDid } from "~/lib/format";
+import { didToEmail, shortDid } from "~/lib/format";
 import { isGateway } from "~/lib/agent-kind";
 import type { EcosystemAgent } from "~/lib/api-types";
 
@@ -179,7 +179,7 @@ export function AgentPicker({
 								<div className="min-w-0 flex-1">
 									<div className="truncate text-slate-900">{name}</div>
 									<div className="truncate font-mono text-[10px] text-slate-500">
-										{did ? shortDid(did) : a.id}
+										{did ? (didToEmail(did) ?? shortDid(did)) : a.id}
 									</div>
 								</div>
 							</li>

--- a/inbox/src/components/ComposeModal.tsx
+++ b/inbox/src/components/ComposeModal.tsx
@@ -118,8 +118,13 @@ export function ComposeModal({ open, onClose }: Props) {
 			.then((j: EcosystemAgent[]) => {
 				const filtered = j.filter((a) => a.id !== OUTBOX_AGENT_ID);
 				setAgents(filtered);
-				if (draftToLoad?.agentId) {
-					setSelected([draftToLoad.agentId]);
+				// Restore the FULL recipient list from the draft. Previously
+				// drafts only kept one agent — reopening a multi-recipient
+				// draft would silently collapse to the first pick, which is
+				// how the math+joke compose lost joke_agent in the inbox log.
+				if (draftToLoad?.agentIds?.length) {
+					const known = new Set(filtered.map((a) => a.id));
+					setSelected(draftToLoad.agentIds.filter((id) => known.has(id)));
 				} else {
 					setSelected([]);
 				}
@@ -134,12 +139,10 @@ export function ComposeModal({ open, onClose }: Props) {
 			if (draftId) deleteDraft(draftId);
 			return;
 		}
-		// Drafts still carry a single agentId — only the first pick
-		// persists. Multi-recipient draft support is a phase-2 problem.
 		const id = draftId ?? crypto.randomUUID();
 		saveDraft({
 			id,
-			agentId: selected[0],
+			agentIds: [...selected],
 			text: trimmed,
 			savedAt: new Date().toISOString(),
 		});

--- a/inbox/src/components/ComposeModal.tsx
+++ b/inbox/src/components/ComposeModal.tsx
@@ -17,7 +17,7 @@ import { ModalCloseButton } from "./ModalCloseButton";
 import { postJson } from "~/lib/fetch";
 import { postSse } from "~/lib/sse";
 import { OUTBOX_AGENT_ID } from "~/lib/constants";
-import { shortDid } from "~/lib/format";
+import { didToEmail, shortDid } from "~/lib/format";
 import type { EcosystemAgent, PersonalAgent } from "~/lib/api-types";
 
 interface Props {
@@ -672,7 +672,7 @@ function FromDidStrip({ me }: { me: PersonalAgent | null | undefined }) {
 					<span className="text-fg">{personaName ?? "you"}</span>
 				</div>
 				<code className="truncate text-fg-dim" title={me.did}>
-					{shortDid(me.did, 8)}
+					{didToEmail(me.did) ?? shortDid(me.did, 8)}
 				</code>
 			</div>
 		);

--- a/inbox/src/components/DraftList.tsx
+++ b/inbox/src/components/DraftList.tsx
@@ -38,7 +38,10 @@ export function DraftList() {
 						<div className="min-w-0 flex-1">
 							<div className="flex items-center gap-2">
 								<span className="truncate text-[13px] font-semibold text-fg">
-									To: {d.agentId}
+									To:{" "}
+									{d.agentIds.length === 1
+										? d.agentIds[0]
+										: `${d.agentIds.length} agents`}
 								</span>
 								<span className="rounded-full bg-rose-50 px-1.5 py-0.5 text-[10px] font-medium text-rose-700">
 									Draft

--- a/inbox/src/components/EventRow.tsx
+++ b/inbox/src/components/EventRow.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import clsx from "clsx";
 import { InfoIcon, PaperPlaneTiltIcon } from "@phosphor-icons/react";
 import { useUI } from "~/state";
-import { kindGlyph, shortDid, stateMeta, trustMeta } from "~/lib/format";
+import { didToEmail, kindGlyph, shortDid, stateMeta, trustMeta } from "~/lib/format";
 import { postJson } from "~/lib/fetch";
 import type { StreamEvent } from "~/types";
 
@@ -42,8 +42,12 @@ export function EventRow({ event, attentionLane }: Props) {
 				<div className="min-w-0 flex-1">
 					<div className="flex flex-wrap items-center gap-x-2 gap-y-1">
 						<span className="text-[13px] text-fg">{event.counterparty.name}</span>
-						<span className="text-[10px] text-fg-dim">
-							{shortDid(event.counterparty.did)}
+						<span
+							className="text-[10px] text-fg-dim"
+							title={event.counterparty.did}
+						>
+							{didToEmail(event.counterparty.did) ??
+								shortDid(event.counterparty.did)}
 						</span>
 						<span
 							className={clsx(

--- a/inbox/src/components/Sidebar.tsx
+++ b/inbox/src/components/Sidebar.tsx
@@ -18,7 +18,7 @@ import {
 	IdentificationCardIcon,
 } from "@phosphor-icons/react";
 import { useUI } from "~/state";
-import { shortDid } from "~/lib/format";
+import { didToEmail, shortDid } from "~/lib/format";
 import { isGateway } from "~/lib/agent-kind";
 import { AddAgentModal } from "./AddAgentModal";
 import { AgentInfoModal } from "./AgentInfoModal";
@@ -328,8 +328,11 @@ function ContactRow({
 	const name = agent.agentCard?.name ?? agent.id;
 	const didFromCard = pickDidFromCard(agent.agentCard);
 	const realDid = agent.did?.id ?? didFromCard;
+	// Prefer the Gmail-shape email rendering of the DID (joke_agent rendered
+	// as gateway_test_fleet+joke_agent@getbindu.com). Falls back to the
+	// truncated DID for non-bindu DID methods, then to the URL.
 	const subline = realDid
-		? shortDid(realDid)
+		? (didToEmail(realDid) ?? shortDid(realDid))
 		: agent.url ?? "no URL yet";
 	return (
 		<div
@@ -522,7 +525,9 @@ function PersonalAgentAliveCard({ me }: { me: PersonalAgent }) {
 						className="truncate text-[10px] text-fg-dim"
 						title={me.did ?? undefined}
 					>
-						{me.did ? shortDid(me.did) : "DID generated on start"}
+						{me.did
+							? (didToEmail(me.did) ?? shortDid(me.did))
+							: "DID generated on start"}
 					</div>
 				</div>
 				{status !== "alive" && status !== "starting" && (

--- a/inbox/src/components/ThreadView.tsx
+++ b/inbox/src/components/ThreadView.tsx
@@ -6,6 +6,7 @@ import { eventsInThread, shortContextId } from "~/lib/threads";
 import { EventRow } from "./EventRow";
 import { useAllEvents } from "~/lib/hooks";
 import { postJson } from "~/lib/fetch";
+import { postSse } from "~/lib/sse";
 import { OUTBOX_AGENT_ID } from "~/lib/constants";
 import type { StreamEvent } from "~/types";
 
@@ -32,12 +33,18 @@ export function ThreadView({ contextId }: Props) {
 	const counterpartyName = first?.counterparty.name ?? "—";
 	const agentLanes = Array.from(new Set(ordered.map((e) => e.agentId)));
 
-	// Derive the target agent for the reply: prefer the recipient declared
-	// on an outbound event (operator-canonical), else the first non-outbox
-	// lane (the agent processing this context). Mock-data threads have no
-	// outbound + no non-outbox lane events to draw from — replies stay
-	// disabled in that case.
-	const replyTarget = useMemo(() => deriveReplyTarget(ordered), [ordered]);
+	// Derive the full recipient set for replies. When the thread was
+	// originally a multi-agent compose, every reply should fan back out
+	// to the same roster — otherwise turn 2 sticks to whichever agent
+	// happened to answer first (the bug seen in the math+joke log: the
+	// user asked "now write a joke with the result" and the inbox sent
+	// it back to math_agent only, who correctly refused). The planner
+	// re-evaluates per turn against the full roster, so we hand it the
+	// whole set and let it pick.
+	const replyRecipients = useMemo(
+		() => deriveReplyRecipients(ordered),
+		[ordered],
+	);
 
 	return (
 		<>
@@ -88,37 +95,58 @@ export function ThreadView({ contextId }: Props) {
 				)}
 			</div>
 
-			<ReplyBox contextId={contextId} target={replyTarget} />
+			<ReplyBox contextId={contextId} recipients={replyRecipients} />
 		</>
 	);
 }
 
-function deriveReplyTarget(events: StreamEvent[]): string | null {
-	// First preference: an outbound event with to_agent_id field.
+function deriveReplyRecipients(events: StreamEvent[]): string[] {
+	// Collect every distinct recipient seen on this thread, preserving
+	// insertion order. Two sources contribute:
+	//   1. `to_agent_id` from outbound /api/compose events (one peer per
+	//      event), and `plan_agents` from `plan-question` events (the
+	//      roster of a prior multi-agent compose — recorded verbatim by
+	//      inbox/server's /api/plan handler).
+	//   2. Any non-outbox lane the thread has lit up. That covers
+	//      mock-data threads and any peer that replied without an
+	//      explicit outbound first.
+	// Without (1)'s `plan_agents`, a multi-agent thread would collapse
+	// to a single recipient on first reply — exactly the sticky-routing
+	// bug.
+	const seen = new Set<string>();
+	const out: string[] = [];
+	const add = (id: unknown) => {
+		if (typeof id !== "string" || id.length === 0) return;
+		if (seen.has(id)) return;
+		seen.add(id);
+		out.push(id);
+	};
 	for (const e of events) {
 		if (e.agentId !== OUTBOX_AGENT_ID) continue;
-		const to = e.payloadJson?.to_agent_id;
-		if (typeof to === "string" && to.length > 0) return to;
+		add(e.payloadJson?.to_agent_id);
+		const planAgents = (e.payloadJson as { plan_agents?: unknown })
+			?.plan_agents;
+		if (Array.isArray(planAgents)) for (const a of planAgents) add(a);
 	}
-	// Fallback: the first non-outbox lane is the agent processing this thread.
 	for (const e of events) {
-		if (e.agentId !== OUTBOX_AGENT_ID) return e.agentId;
+		if (e.agentId === OUTBOX_AGENT_ID) continue;
+		add(e.agentId);
 	}
-	return null;
+	return out;
 }
 
 function ReplyBox({
 	contextId,
-	target,
+	recipients,
 }: {
 	contextId: string;
-	target: string | null;
+	recipients: string[];
 }) {
 	const [text, setText] = useState("");
 	const [status, setStatus] = useState<"idle" | "sending" | "error">("idle");
 	const [errMsg, setErrMsg] = useState<string | null>(null);
 
-	if (!target) {
+	if (recipients.length === 0) {
 		return (
 			<div className="border-t border-(--color-border-soft) bg-slate-50 px-6 py-3 text-[11px] text-fg-dim">
 				Replies aren't available for this thread (no agent target identified).
@@ -126,6 +154,7 @@ function ReplyBox({
 		);
 	}
 
+	const isMulti = recipients.length >= 2;
 	const canSubmit = text.trim().length > 0 && status !== "sending";
 
 	async function handleSend(e: React.FormEvent) {
@@ -133,8 +162,57 @@ function ReplyBox({
 		if (!canSubmit) return;
 		setStatus("sending");
 		setErrMsg(null);
+
+		// Multi-recipient thread → /api/plan. The gateway's planner
+		// re-evaluates the roster per turn (verified empirically against
+		// the gateway_test_fleet: turn 2 "now tell me a joke about that
+		// result" routed to joke alone even with math also in the
+		// catalog). Passing `sessionId: contextId` keeps the thread
+		// stitched in the inbox; /api/plan also records the question as
+		// a `plan-question` outbox event for thread display.
+		//
+		// We drain the SSE so the connection closes cleanly, but ignore
+		// frame-level state — the inbox already shows live progress via
+		// webhook ingestion from each peer agent. This keeps ReplyBox
+		// thin (no embedded planner UI) and matches its compose-modal
+		// counterpart's "fire and let the webhooks paint" behavior.
+		if (isMulti) {
+			try {
+				const res = await postSse(
+					"/api/plan",
+					{
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							question: text.trim(),
+							agentIds: recipients,
+							sessionId: contextId,
+						}),
+					},
+					() => {},
+				);
+				if (!res.ok) {
+					const j = (await res.json().catch(() => ({}))) as {
+						detail?: string;
+						error?: string;
+					};
+					setStatus("error");
+					setErrMsg(j.detail ?? j.error ?? `HTTP ${res.status}`);
+					return;
+				}
+			} catch (err) {
+				setStatus("error");
+				setErrMsg((err as Error).message);
+				return;
+			}
+			setText("");
+			setStatus("idle");
+			return;
+		}
+
+		// Single-recipient thread → direct A2A.
 		const r = await postJson("/api/compose", {
-			agentId: target,
+			agentId: recipients[0],
 			text: text.trim(),
 			contextId,
 		});
@@ -147,6 +225,10 @@ function ReplyBox({
 		setStatus("idle");
 	}
 
+	const replyingTo = isMulti
+		? `${recipients.length} agents`
+		: recipients[0];
+
 	return (
 		<form
 			onSubmit={handleSend}
@@ -154,7 +236,7 @@ function ReplyBox({
 		>
 			<div className="mb-1.5 flex items-center justify-between text-[10px] text-fg-dim">
 				<span>
-					Replying to <span className="text-fg-muted">{target}</span> on this thread
+					Replying to <span className="text-fg-muted">{replyingTo}</span> on this thread
 				</span>
 				{status === "error" && errMsg && (
 					<span className="text-rose-700">✗ {errMsg}</span>

--- a/inbox/src/lib/format.ts
+++ b/inbox/src/lib/format.ts
@@ -12,6 +12,43 @@ export function shortDid(did: string, tailChars = 6): string {
 	return parts.slice(0, -1).join(":") + ":" + last.slice(0, tailChars) + "…";
 }
 
+/** Render a bindu DID as a Gmail-shape address.
+ *
+ * Bindu DIDs are `did:bindu:<author>:<name>:<uuid>` where `<author>` was
+ * sanitised by `bindu/extensions/did/did_agent_extension.py:_sanitize`
+ * (lowercase, space→`_`, `@`→`_at_`, `.`→`_`). Reverse the transform
+ * and present the result as `<agent_name>+<operator_local>@<domain>`
+ * (Gmail subaddress style), so the operator's identity stays the base
+ * email and the agent name lives in the `+` slot — same shape as
+ * `you+filter@gmail.com`.
+ *
+ * Returns `null` for inputs that aren't bindu DIDs (e.g. external DID
+ * methods, plain agent_ids) so callers can fall back to `shortDid`.
+ *
+ * Examples:
+ *   did:bindu:gateway_test_fleet_at_getbindu_com:joke_agent:47191e40-…
+ *     → "gateway_test_fleet+joke_agent@getbindu.com"
+ *   did:bindu:you_at_local:leonard-hofstadter:53f9d49f-…
+ *     → "you+leonard-hofstadter@local"
+ */
+export function didToEmail(did: string): string | null {
+	const parts = did.split(":");
+	if (parts.length < 4 || parts[0] !== "did" || parts[1] !== "bindu") {
+		return null;
+	}
+	const author = parts[2];
+	const name = parts[3];
+	const atIdx = author.indexOf("_at_");
+	if (atIdx === -1) {
+		// Author wasn't an email-shaped string (e.g. legacy plain author).
+		// Show name@author verbatim — readable, lossless.
+		return `${name}@${author}`;
+	}
+	const local = author.slice(0, atIdx);
+	const domain = author.slice(atIdx + "_at_".length).replace(/_/g, ".");
+	return `${name}+${local}@${domain}`;
+}
+
 /** Normalise a free-form name into a URL/agent-id-safe slug.
  *
  * Used wherever the UI mints an id from a human-readable name. Falls

--- a/inbox/src/state.ts
+++ b/inbox/src/state.ts
@@ -4,7 +4,13 @@ import type { PersonalAgent } from "~/lib/api-types";
 
 export interface Draft {
 	id: string;
-	agentId: string;
+	/** Recipients the draft is addressed to. Multi-recipient drafts were
+	 * previously collapsed to a single `agentId: string` field, which
+	 * broke the inbox's multi-agent compose flow when a draft was
+	 * resubmitted (the operator picked N agents, saved, reopened, and
+	 * only the first one was reloaded). `loadDrafts` migrates legacy
+	 * entries in-place so old localStorage payloads keep working. */
+	agentIds: string[];
 	text: string;
 	contextId?: string;
 	savedAt: string;
@@ -98,13 +104,36 @@ function loadDrafts(): Draft[] {
 		if (!raw) return [];
 		const arr = JSON.parse(raw) as unknown;
 		if (!Array.isArray(arr)) return [];
-		return arr.filter(
-			(d): d is Draft =>
-				!!d &&
-				typeof (d as Draft).id === "string" &&
-				typeof (d as Draft).agentId === "string" &&
-				typeof (d as Draft).text === "string",
-		);
+		const out: Draft[] = [];
+		for (const d of arr) {
+			if (!d || typeof d !== "object") continue;
+			const row = d as Record<string, unknown>;
+			if (typeof row.id !== "string" || typeof row.text !== "string") continue;
+			// Migrate legacy single-recipient drafts (agentId: string) to the
+			// multi-recipient shape (agentIds: string[]). Without this, a
+			// user with an old draft in localStorage would lose it on first
+			// reload after upgrading.
+			let agentIds: string[];
+			if (Array.isArray(row.agentIds)) {
+				agentIds = (row.agentIds as unknown[]).filter(
+					(v): v is string => typeof v === "string" && v.length > 0,
+				);
+			} else if (typeof row.agentId === "string" && row.agentId.length > 0) {
+				agentIds = [row.agentId];
+			} else {
+				continue;
+			}
+			if (agentIds.length === 0) continue;
+			out.push({
+				id: row.id,
+				agentIds,
+				text: row.text,
+				contextId:
+					typeof row.contextId === "string" ? row.contextId : undefined,
+				savedAt: typeof row.savedAt === "string" ? row.savedAt : "",
+			});
+		}
+		return out;
 	} catch {
 		return [];
 	}


### PR DESCRIPTION
## Why

Three phases of the rollout to make auth + DID + mTLS on by default for every Bindu Inbox + gateway. End state of this PR: the personal agent boots with mTLS, the inbox uses that cert for outbound A2A, and the gateway (when spawned by the inbox) shares the same cert.

After this lands locally:

```
[browser] → [inbox UI :3775] → [inbox API :3787]
                                      │
                                      │ spawns
                                      ▼
                          ~/.bindu/personal/.bindu/
                          ├── tls_cert.pem   ┐
                          ├── tls_key.pem    │ Phase A
                          ├── ca_bundle.pem  ┘
                          │
              ┌───────────┴────────────┐
              ▼                        ▼
       Phase B                  Phase C (spawn env)
       inbox → peer            inbox → gateway, gateway → peer
       buildPeerDispatcher     getPeerDispatcher (gateway side)
                               serve over HTTPS (gateway side)
```

Subsequent phases:
- **D** — operator login. Skipped per your "no auth on my Mac" call.
- **E** — \`bindu-inbox-deploy\` (infragrid) for production.
- **F** — harden \`BINDU_COMMS_TOKEN\` + \`/api/me/identity\`.

## Files

| repo / file | what | phase |
|---|---|---|
| \`inbox/package.json\` | adds \`undici\` runtime dep | A |
| \`inbox/server/personal-agent.ts\` | spawn env adds 5 \`MTLS__*\` vars; agent URL flips to \`https://\`; loopback probes use insecure dispatcher | A |
| \`inbox/server/utils.ts\` | \`insecureLoopbackDispatcher\` (A) + \`buildPeerDispatcher\` (B) | A+B |
| \`inbox/server/index.ts\` | peer dispatcher on outbound A2A; loopback dispatcher on /plan; pass cert paths into gateway env when spawning | A+B+C |
| \`gateway/package.json\` | adds \`undici\` runtime dep | C |
| \`gateway/src/bindu/client/mtls.ts\` | new — \`getServerTLSOptions\` + \`getPeerDispatcher\` | C |
| \`gateway/src/index.ts\` | https.createServer when TLS env is set | C |
| \`gateway/src/bindu/client/fetch.ts\` | JSON-RPC POSTs use the peer dispatcher | C |
| \`gateway/src/bindu/client/agent-card.ts\` | well-known fetch uses the peer dispatcher | C |

## Soft-mode escape hatches everywhere

* No personal agent yet → cert files missing → every dispatcher returns undefined → plain HTTP → today's behavior. No breakage when the inbox first boots before the user runs the wizard.
* \`REQUIRE_CLIENT_CERT=false\` on the personal agent → uvicorn TLS is CERT_OPTIONAL → loopback callers without a cert still work. Production-track Phase B will flip this.
* Pre-existing TypeScript error in \`gateway/src/planner/index.ts:318\` is on \`main\`, not introduced here — verified by stashing my diff and re-running tsc.

## Test plan

- [x] \`tsc --noEmit\` clean on inbox (one pre-existing error in gateway/planner, unrelated)
- [x] Bindu unit tests still green
- [ ] **You** locally on your Mac:
  - [ ] Pull the branch, start the inbox
  - [ ] Spawn the personal agent → expect cert files at \`~/.bindu/personal/.bindu/\`
  - [ ] Compose to a peer (Phase B path) → expect 200, outbound carries cert
  - [ ] Multi-agent compose to fan out via the gateway (Phase C path) → gateway boots with TLS, /plan succeeds
- [ ] Follow-ups: Phase E (production deploy), Phase F (API gate hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway can run with HTTPS/mTLS and hot-reload certs when TLS credentials exist.
  * Outbound agent-to-agent requests may use peer-aware mTLS dispatching.
  * Thread replies and drafts support multi-recipient workflows.
  * /plan gains in-process idempotency for duplicate submissions.
  * Doom-loop detection prevents repeated identical tool calls; final-step soft-termination reduces interrupted tool use.

* **Chores**
  * Added undici networking dependency and loopback dispatcher support.
  * Examples updated to load env vars earlier and use loopback HTTPS URLs.

* **Tests**
  * Added unit tests for task-continuity and doom-loop behaviors.

* **Documentation**
  * Added Star History badge to README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->