### PR TITLE
fix(x402): gate artifact delivery on settlement success (#562)

### DIFF
--- a/bindu/server/workers/manifest_worker.py
+++ b/bindu/server/workers/manifest_worker.py
@@ -484,9 +484,22 @@ class ManifestWorker(Worker):
             )
             artifacts = self.build_artifacts(results)
 
-            # Handle payment settlement if payment context is available
+            # Handle payment settlement if payment context is available.
+            # Verify-ok does not imply settle-ok: between verify and settle the
+            # payer can double-spend, the facilitator can fail, or the EIP-3009
+            # validBefore window can lapse. If settlement does not succeed,
+            # withhold the artifact and mark the task failed — otherwise the
+            # client walks away with paid output the agent never got paid for
+            # (issue #562).
             if payment_context:
                 settlement_metadata = await self._settle_payment(payment_context)
+                settled_ok = (
+                    settlement_metadata.get(app_settings.x402.meta_status_key)
+                    == app_settings.x402.status_completed
+                )
+                if not settled_ok:
+                    await self._handle_settlement_failure(task, settlement_metadata)
+                    return
                 if additional_metadata:
                     additional_metadata.update(settlement_metadata)
                 else:
@@ -528,6 +541,37 @@ class ManifestWorker(Worker):
             await self.storage.update_task(task["id"], state=state)
             await self._notify_lifecycle(task["id"], task["context_id"], state, True)
 
+    async def _handle_settlement_failure(
+        self, task: Task, settlement_metadata: dict[str, Any]
+    ) -> None:
+        """Mark task failed after settlement failure; withhold the paid artifact.
+
+        Called from the completed branch when ``_settle_payment`` reports a
+        non-success status. The agent already did the work, so we cannot
+        recover the LLM cost — but we can refuse to deliver the artifact to
+        the unpaid client. ``settlement_metadata`` carries the recovery
+        fields (nonce, authorization, network) that an operator/reconciler
+        needs to reason about the on-chain state.
+        """
+        error_text = settlement_metadata.get(
+            app_settings.x402.meta_error_key, "settlement failed"
+        )
+        error_message = MessageConverter.to_protocol_messages(
+            f"Payment settlement failed; output withheld. Reason: {error_text}",
+            task["id"],
+            task["context_id"],
+        )
+        self._add_state_change_event(
+            from_state="working", to_state="failed", error="settlement_failed"
+        )
+        await self.storage.update_task(
+            task["id"],
+            state="failed",
+            new_messages=error_message,
+            metadata=settlement_metadata,
+        )
+        await self._notify_lifecycle(task["id"], task["context_id"], "failed", True)
+
     async def _handle_task_failure(self, task: Task, error: str) -> None:
         """Handle task execution failure.
 
@@ -564,10 +608,32 @@ class ManifestWorker(Worker):
         Returns:
             Metadata dict containing settlement information to attach to task
         """
+        # Pull the EIP-3009 fields out of the raw dict up front so they end
+        # up in every failure return path. Validation or facilitator errors
+        # otherwise strip the nonce/authorization, and we lose any chance to
+        # reconcile a half-settled transaction later (issue #562).
+        payment_payload_dict = payment_context.get("payment_payload", {}) or {}
+        scheme_payload = payment_payload_dict.get("payload", {}) or {}
+        authorization = scheme_payload.get("authorization", {}) or {}
+        nonce = authorization.get("nonce")
+        network = payment_payload_dict.get("network")
+
+        def _failure_metadata(reason: str) -> dict[str, Any]:
+            md: dict[str, Any] = {
+                app_settings.x402.meta_status_key: app_settings.x402.status_failed,
+                app_settings.x402.meta_error_key: reason,
+            }
+            if nonce is not None:
+                md["x402_nonce"] = nonce
+            if authorization:
+                md["x402_authorization"] = authorization
+            if network is not None:
+                md["x402_network"] = network
+            return md
+
         try:
             from x402 import PaymentPayload, PaymentRequirements
 
-            payment_payload_dict = payment_context["payment_payload"]
             payment_requirements_dict = payment_context["payment_requirements"]
 
             # Convert dicts back to Pydantic models (they were serialized in a2a_protocol)
@@ -598,17 +664,11 @@ class ManifestWorker(Worker):
             else:
                 error_reason = settle_response.error_reason or "Unknown error"
                 logger.error(f"Payment settlement failed: {error_reason}")
-                return {
-                    app_settings.x402.meta_status_key: app_settings.x402.status_failed,
-                    app_settings.x402.meta_error_key: error_reason,
-                }
+                return _failure_metadata(error_reason)
 
         except Exception as e:
             logger.error(f"Error settling payment: {e}", exc_info=True)
-            return {
-                app_settings.x402.meta_status_key: app_settings.x402.status_failed,
-                app_settings.x402.meta_error_key: str(e),
-            }
+            return _failure_metadata(str(e))
 
     async def _notify_artifact(
         self, task_id: UUID, context_id: UUID, artifact: Artifact

--- a/docs/PAYMENT.md
+++ b/docs/PAYMENT.md
@@ -471,6 +471,8 @@ That's it. Same code, same wallet, same payment shape — just real USDC on Base
 * **Each new task needs a new payment.** A finished task doesn't grant credit toward the next one. Within a single conversation, the same caller pays per task. If a task returns `"input_required"`, no new payment is needed to continue *that* task — but completing it and starting another is a fresh payment.
 * **Watch the facilitator.** If the facilitator goes down, your paid endpoints can't accept new requests. Either run your own, or accept the dependency consciously.
 * **Sessions expire.** A payment session — the browser flow where a caller clicks through MetaMask — expires after 60 seconds by default. Configurable.
+* **Verify is not settle.** When a caller sends `X-PAYMENT`, the facilitator's `/verify` confirms the signature is good and the wallet has enough USDC *right now*. The actual on-chain transfer happens later, when the task completes and Bindu calls `/settle`. Between those two calls, three things can go wrong: the payer drains the wallet to somewhere else, the facilitator can't broadcast, or the EIP-3009 `validBefore` window expires. In all three cases the work has already run — and as of [#562](https://github.com/GetBindu/Bindu/pull/562), Bindu refuses to deliver the artifact. The task ends in `failed`, no artifact is pushed, and `task.metadata` carries the EIP-3009 `nonce` and signed authorization so an operator can reconcile against the chain.
+* **Parallel-nonce double-spend is a known gap.** A payer with $1 USDC who sends two requests in parallel — each with a *different* nonce — passes verify twice (both see the same $1 balance). The first `/settle` succeeds, the second reverts on insufficient balance. The replay defense in `nonce_store.py` only catches identical nonces, not parallel ones. You eat the LLM cost of the second call. Two mitigations if this hurts you: keep `max_timeout_seconds` short so the window for parallel calls is small, or run your own facilitator with balance reservation.
 
 ## When something doesn't work
 
@@ -478,6 +480,7 @@ That's it. Same code, same wallet, same payment shape — just real USDC on Base
 * `"error": "Payment verification failed"` → the facilitator said no. Either the signature is wrong, the chain is wrong, or your facilitator doesn't know the chain you're asking for. Check the agent's server logs for the underlying error.
 * `"error": "Payment nonce already used (replay)"` → the caller is sending the same authorization twice. They need to sign a fresh one for each request.
 * `"error": "No matching payment requirements found"` → the payment payload doesn't match anything in your `execution_cost`. Usually a network or asset mismatch.
+* Task ends in `failed` with message `Payment settlement failed; output withheld.` → verify passed but `/settle` did not. Look at `task.metadata` — `x402.payment.error` is the facilitator's reason, `x402_nonce` and `x402_authorization` are what you need to ask the facilitator whether the on-chain transfer actually went through.
 
 ## Where to look in the code
 

--- a/tests/unit/server/workers/test_manifest_worker.py
+++ b/tests/unit/server/workers/test_manifest_worker.py
@@ -756,6 +756,189 @@ class TestManifestWorker:
             assert result is not None
 
     @pytest.mark.asyncio
+    async def test_settle_failure_does_not_deliver_artifact(self):
+        """Verify-ok + settle-fail must NOT deliver paid output.
+
+        Reproduces the leak in issue #562: today, if facilitator.settle fails
+        after verify already passed, the worker still transitions the task to
+        completed and pushes the artifact. The fix gates artifact delivery on
+        settle success — task is marked failed and no artifact is notified.
+        """
+        mock_manifest = Mock()
+        mock_manifest.did_extension = Mock()
+        mock_manifest.did_extension.did = "did:example:123"
+        mock_manifest.x402_extension = Mock()
+        mock_scheduler = Mock()
+        mock_storage = AsyncMock()
+
+        task_id = uuid4()
+        context_id = uuid4()
+        task = cast(
+            Task,
+            {
+                "id": task_id,
+                "context_id": context_id,
+                "status": {"state": "working", "timestamp": "2024-01-01T00:00:00Z"},
+            },
+        )
+
+        worker = ManifestWorker(
+            manifest=mock_manifest, scheduler=mock_scheduler, storage=mock_storage
+        )
+
+        # Simulate facilitator-reported settlement failure.
+        worker._settle_payment = AsyncMock(  # type: ignore[method-assign] # ty: ignore[invalid-assignment]
+            return_value={
+                "x402.payment.status": "payment-failed",
+                "x402.payment.error": "transfer reverted: insufficient balance",
+            }
+        )
+        worker._notify_artifact = AsyncMock()  # type: ignore[method-assign] # ty: ignore[invalid-assignment]
+
+        payment_context = {
+            "payment_payload": {
+                "payload": {
+                    "authorization": {
+                        "nonce": "0xdeadbeef",
+                        "from": "0xMallory",
+                        "to": "0xAlice",
+                        "value": "1000000",
+                    }
+                },
+            },
+            "payment_requirements": {},
+        }
+
+        await worker._handle_terminal_state(
+            task, "Paid summary contents", "completed", payment_context=payment_context
+        )
+
+        # The task must NOT end in "completed" — that's the leak.
+        update_calls = mock_storage.update_task.call_args_list
+        terminal_states = [call.kwargs.get("state") for call in update_calls]
+        assert "completed" not in terminal_states, (
+            f"Settle failed but task still marked completed: {terminal_states}"
+        )
+        assert "failed" in terminal_states
+
+        # And the artifact must not have been pushed to the client.
+        worker._notify_artifact.assert_not_called()  # ty: ignore[unresolved-attribute]
+
+    @pytest.mark.asyncio
+    async def test_settle_exception_persists_recovery_metadata(self):
+        """When settle raises, the task metadata must carry enough to reconcile.
+
+        Issue #562 calls out that today we lose the EIP-3009 nonce and signed
+        authorization on a settle exception (just str(e) is stored). A
+        recovery worker or operator can't tell whether the on-chain transfer
+        actually went through. The fix persists nonce + authorization.
+        """
+        from unittest.mock import patch
+
+        import asyncio
+
+        mock_manifest = Mock()
+        mock_manifest.x402_extension = Mock()
+        mock_scheduler = Mock()
+        mock_storage = AsyncMock()
+
+        worker = ManifestWorker(
+            manifest=mock_manifest, scheduler=mock_scheduler, storage=mock_storage
+        )
+
+        payment_context = {
+            "payment_payload": {
+                "payload": {
+                    "authorization": {
+                        "nonce": "0xdeadbeef",
+                        "from": "0xCarol",
+                        "to": "0xAlice",
+                        "value": "1000000",
+                        "validBefore": "1735000300",
+                    }
+                },
+                "network": "base-sepolia",
+            },
+            "payment_requirements": {},
+        }
+
+        # Patch on the x402 module — `_settle_payment` does a local
+        # `from x402 import PaymentPayload, PaymentRequirements`, which
+        # resolves the attribute on x402 at call time.
+        with (
+            patch("x402.PaymentPayload") as mock_pp,
+            patch("x402.PaymentRequirements") as mock_pr,
+            patch(
+                "bindu.server.workers.manifest_worker.HTTPFacilitatorClient"
+            ) as mock_fac_class,
+        ):
+            mock_pp.model_validate = Mock(return_value=Mock())
+            mock_pr.model_validate = Mock(return_value=Mock())
+            mock_fac = AsyncMock()
+            mock_fac.settle = AsyncMock(side_effect=asyncio.TimeoutError("upstream"))
+            mock_fac_class.return_value = mock_fac
+
+            result = await worker._settle_payment(payment_context)
+
+        assert result["x402.payment.status"] == "payment-failed"
+        # Reconciliation needs the nonce and the full authorization block —
+        # str(e) alone is not enough.
+        assert result.get("x402_nonce") == "0xdeadbeef"
+        assert result.get("x402_authorization", {}).get("from") == "0xCarol"
+        assert result.get("x402_network") == "base-sepolia"
+
+    @pytest.mark.asyncio
+    async def test_settle_success_unchanged(self):
+        """Regression: happy path still delivers artifact and marks completed."""
+        mock_manifest = Mock()
+        mock_manifest.did_extension = Mock()
+        mock_manifest.did_extension.did = "did:example:123"
+        mock_manifest.x402_extension = Mock()
+        mock_scheduler = Mock()
+        mock_storage = AsyncMock()
+
+        task_id = uuid4()
+        context_id = uuid4()
+        task = cast(
+            Task,
+            {
+                "id": task_id,
+                "context_id": context_id,
+                "status": {"state": "working", "timestamp": "2024-01-01T00:00:00Z"},
+            },
+        )
+
+        worker = ManifestWorker(
+            manifest=mock_manifest, scheduler=mock_scheduler, storage=mock_storage
+        )
+
+        worker._settle_payment = AsyncMock(  # type: ignore[method-assign] # ty: ignore[invalid-assignment]
+            return_value={
+                "x402.payment.status": "payment-completed",
+                "x402.payment.receipts": [{"tx_hash": "0xreceipt"}],
+            }
+        )
+        worker._notify_artifact = AsyncMock()  # type: ignore[method-assign] # ty: ignore[invalid-assignment]
+
+        payment_context = {
+            "payment_payload": {"payload": {"authorization": {"nonce": "0xfeed"}}},
+            "payment_requirements": {},
+        }
+
+        await worker._handle_terminal_state(
+            task, "Paid result", "completed", payment_context=payment_context
+        )
+
+        # Task completed.
+        update_calls = mock_storage.update_task.call_args_list
+        terminal_states = [call.kwargs.get("state") for call in update_calls]
+        assert "completed" in terminal_states
+        assert "failed" not in terminal_states
+
+        # Artifact was pushed.
+        worker._notify_artifact.assert_called()  # ty: ignore[unresolved-attribute]
+
+    @pytest.mark.asyncio
     async def test_build_complete_message_history_with_context_disabled(self):
         """Test building message history with context-based history disabled."""
         mock_manifest = Mock()


### PR DESCRIPTION
## Summary
- Closes the verify→execute→settle leak reported in #562: a settle failure (or exception) used to leave the task marked `completed` with the artifact already pushed, so a payer who double-spent or whose settlement timed out walked away with paid output.
- Artifact delivery is now gated on `_settle_payment` returning `payment-completed`; on failure the task transitions to `failed` via a new `_handle_settlement_failure` helper and no artifact is notified.
- `_settle_payment` now persists the EIP-3009 nonce, full authorization block, and network in failure metadata so an operator can reconcile a half-settled transaction against the chain instead of seeing only `str(e)`.

## Behavior change
- **Before**: settle-fail → task `completed`, artifact pushed, `task.metadata["x402.payment.status"] = "payment-failed"` buried in metadata.
- **After**: settle-fail → task `failed`, no artifact pushed, message body explains "Payment settlement failed; output withheld", and `task.metadata` carries `x402_nonce`, `x402_authorization`, `x402_network` for reconciliation.

## What's deliberately out of scope
- No settle-before-execute / balance reservation — the parallel-nonce double-spend race is documented in `docs/PAYMENT.md` as a known limitation.
- No retry-on-transient-error in the worker — a settle that the facilitator rejected as reverted won't get better by retrying. Network timeouts belong in a follow-up reconciliation job that uses the new recovery metadata.
- No new task substates — payment status continues to live in `task.metadata`.

## Test plan
- [x] `uv run pytest tests/unit/server/workers/test_manifest_worker.py` — 31 passed (28 existing + 3 new).
- [x] `uv run pytest tests/unit/server/` — 376 passed.
- [x] `uv run pytest tests/unit/extensions/x402/ tests/unit/server/middleware/x402/ tests/unit/server/workers/test_manifest_worker.py` — 111 passed.
- [x] `uv run ruff check` on touched files — clean.
- [x] Pre-commit hooks (ruff, ruff-format, ty, bandit, detect-secrets, pydocstyle) — all pass.
- [ ] Manual smoke test against a real facilitator before merge (recommended).

The three new tests are the contract:
- `test_settle_failure_does_not_deliver_artifact` — facilitator returns `success=False`, asserts task is `failed` and `_notify_artifact` was not called.
- `test_settle_exception_persists_recovery_metadata` — facilitator raises `TimeoutError`, asserts `x402_nonce` / `x402_authorization` / `x402_network` are persisted.
- `test_settle_success_unchanged` — happy-path regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks with failed payment settlements now properly withhold artifacts and mark tasks as failed with reconciliation details recorded.

* **Documentation**
  * Clarified the distinction between payment verification and settlement timing; documented failure scenarios and troubleshooting guidance.

* **Tests**
  * Added unit tests validating payment settlement failure handling and recovery metadata persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->