### PR TITLE
feat(examples): add crewai-agent — multi-agent research crew

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -43,6 +43,7 @@ Where you see what bindu was actually built for.
 | Folder | What it is | Notable |
 | --- | --- | --- |
 | [`agent_swarm/`](agent_swarm/) | Planner → Researcher → Summarizer → Critic → Reflection. | 5-stage in-process chain. |
+| [`crewai-agent/`](crewai-agent/) | Researcher + Writer crew — any topic in, clean summary out. | CrewAI. |
 | [`ag2_research_team/`](ag2_research_team/) | researcher / analyst / writer under AutoPattern GroupChat. | AG2 (AutoGen) with LLM-driven speaker selection. |
 | [`cerina_bindu/`](cerina_bindu/cbt/) | CBT exercise generator: Drafter → SafetyGuardian → ClinicalCritic, supervised. | Real LangGraph `StateGraph`. |
 | [`langgraph_blog_writing_agent/`](langgraph_blog_writing_agent/) | Plan → fan out → reduce, map-reduce style. | LangGraph `Send` for fan-out. |

--- a/examples/crewai-agent/.env.example
+++ b/examples/crewai-agent/.env.example
@@ -1,0 +1,1 @@
+OPENROUTER_API_KEY=your_openrouter_api_key_here  # pragma: allowlist secret

--- a/examples/crewai-agent/README.md
+++ b/examples/crewai-agent/README.md
@@ -1,0 +1,45 @@
+# CrewAI Research Agent
+
+A two-agent CrewAI crew wrapped with Bindu. Send any topic — a Researcher gathers key facts, a Writer turns them into a clean summary. Served over A2A with a DID identity.
+
+## Prerequisites
+
+- `OPENROUTER_API_KEY` — get one at https://openrouter.ai/keys
+
+## Setup
+
+```bash
+cp .env.example .env
+# fill in your OPENROUTER_API_KEY
+uv sync --extra agents
+```
+
+## Run
+
+```bash
+uv run examples/crewai-agent/main.py
+# http://localhost:3773
+```
+
+## Talk to it
+
+```bash
+curl -sS http://localhost:3773/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "message/send",
+    "id": "00000000-0000-0000-0000-000000000004",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "What is quantum computing?"}],
+        "kind": "message",
+        "messageId": "00000000-0000-0000-0000-000000000001",
+        "contextId": "00000000-0000-0000-0000-000000000002",
+        "taskId": "00000000-0000-0000-0000-000000000003"
+      },
+      "configuration": {"acceptedOutputModes": ["application/json"]}
+    }
+  }'
+```

--- a/examples/crewai-agent/main.py
+++ b/examples/crewai-agent/main.py
@@ -1,13 +1,19 @@
-from bindu.penguin.bindufy import bindufy
-from crewai import Agent, Task, Crew, LLM
-from dotenv import load_dotenv
 import os
+
+from crewai import Agent, Crew, LLM, Task
+from dotenv import load_dotenv
+
+from bindu.penguin.bindufy import bindufy
 
 load_dotenv()
 
+openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
+if not openrouter_api_key:
+    raise RuntimeError("OPENROUTER_API_KEY environment variable is required")
+
 llm = LLM(
     model="openrouter/openai/gpt-4o-mini",
-    api_key=os.getenv("OPENROUTER_API_KEY"),
+    api_key=openrouter_api_key,
 )
 
 researcher = Agent(
@@ -28,6 +34,9 @@ writer = Agent(
 
 
 def handler(messages):
+    if not messages:
+        return "No messages received. Please provide a topic to research."
+
     last = messages[-1]
     query = last.get("content", "") if isinstance(last, dict) else str(last)
 

--- a/examples/crewai-agent/main.py
+++ b/examples/crewai-agent/main.py
@@ -1,0 +1,73 @@
+from bindu.penguin.bindufy import bindufy
+from crewai import Agent, Task, Crew, LLM
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+llm = LLM(
+    model="openrouter/openai/gpt-4o-mini",
+    api_key=os.getenv("OPENROUTER_API_KEY"),
+)
+
+researcher = Agent(
+    role="Researcher",
+    goal="Research the given topic and gather key facts and insights.",
+    backstory="You are an expert researcher who finds accurate, concise information on any topic.",
+    llm=llm,
+    verbose=False,
+)
+
+writer = Agent(
+    role="Writer",
+    goal="Write a clear and engaging summary based on the research provided.",
+    backstory="You are a skilled writer who turns raw research into readable, well-structured summaries.",
+    llm=llm,
+    verbose=False,
+)
+
+
+def handler(messages):
+    last = messages[-1]
+    query = last.get("content", "") if isinstance(last, dict) else str(last)
+
+    if not query.strip():
+        return "Please provide a topic to research."
+
+    research_task = Task(
+        description=f"Research this topic thoroughly: {query}",
+        expected_output="A list of key facts, insights, and important points about the topic.",
+        agent=researcher,
+    )
+
+    write_task = Task(
+        description="Using the research provided, write a clear 3-5 paragraph summary.",
+        expected_output="A well-structured, readable summary of the topic.",
+        agent=writer,
+    )
+
+    crew = Crew(
+        agents=[researcher, writer],
+        tasks=[research_task, write_task],
+        verbose=False,
+    )
+
+    result = crew.kickoff()
+    return str(result)
+
+
+config = {
+    "author": "your.email@example.com",
+    "name": "crewai_research_agent",
+    "description": "A two-agent CrewAI crew that researches any topic and writes a clear summary.",
+    "deployment": {
+        "url": "http://localhost:3773",
+        "expose": True,
+        "cors_origins": ["*"],
+    },
+    "skills": ["skills/crewai-research"],
+    "auth": {"enabled": False},
+}
+
+if __name__ == "__main__":
+    bindufy(config, handler)

--- a/examples/crewai-agent/skills/crewai-research/skill.yaml
+++ b/examples/crewai-agent/skills/crewai-research/skill.yaml
@@ -1,0 +1,27 @@
+id: crewai-research
+name: CrewAI Research Skill
+version: 1.0.0
+author: your.email@example.com
+description: >
+  A two-agent CrewAI crew that researches any topic and returns a structured summary.
+  A Researcher agent gathers key facts and insights, then a Writer agent turns them
+  into a clear, readable summary.
+
+tags:
+  - crewai
+  - research
+  - multi-agent
+  - openrouter
+  - summarization
+
+input_modes:
+  - text/plain
+
+output_modes:
+  - text/plain
+
+examples:
+  - input: "What is quantum computing?"
+    output: |
+      Quantum computing is a type of computation that harnesses quantum mechanical
+      phenomena such as superposition and entanglement...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dependencies = [
 agents = [
     "ag2[openai]>=0.11.0",
     "agno>=2.5.2",
+    "crewai>=0.130.0",
     "langchain>=1.2.9",
     "langchain-openai>=1.1.8",
     "langgraph>=1.0.8",


### PR DESCRIPTION
## Summary

- **Problem**: README lists CrewAI as a supported framework but no example existed in `examples/`
- **Why it matters**: Every other listed framework (Agno, LangChain, LangGraph, AG2) already has a working example — CrewAI was the only gap
- **What changed**: Added `examples/crewai-agent/` with a two-agent research crew (Researcher + Writer) wrapped with `bindufy()`, added `crewai>=0.130.0` to agents extras in `pyproject.toml`, added row to `examples/README.md`
- **What did NOT change**: No core framework code touched

## Change Type

- [x] Feature

## Scope

- [x] Documentation

## Linked Issue/PR

- Closes #561

## User-Visible / Behavior Changes

New example at `examples/crewai-agent/` — runnable with `uv run examples/crewai-agent/main.py`.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/credentials handling changed? `No`
- New/changed network calls? `No`
- Database schema/migration changes? `No`
- Authentication/authorization changes? `No`

## Verification

### Environment

- OS: Windows 11
- Python version: 3.14.3
- Storage backend: memory (default)
- Scheduler backend: memory (default)

### Steps to Test

1. `uv sync --extra agents`
2. `cp examples/crewai-agent/.env.example examples/crewai-agent/.env` and set `OPENROUTER_API_KEY`
3. `uv run examples/crewai-agent/main.py`
4. Send a curl request to `http://localhost:3773/`

### Expected Behavior

- Agent starts with a DID identity on port 3773
- CrewAI Researcher + Writer crew processes the query and returns a summary

### Actual Behavior

- Could not fully run end-to-end (no `OPENROUTER_API_KEY` available) but syntax and structure verified

## Evidence

- [x] Test output / logs — `1093 passed, 3 failed` (3 failures are pre-existing Windows-specific bugs unrelated to this PR: file permission `chmod 600` not supported on Windows, and `README.md` encoding issue with `cp1252`)
- [x] Pre-commit hooks pass

## Human Verification

- **Verified scenarios**: Syntax check passes, pattern matches existing examples (`langgraph_blog_writing_agent`, `pdf_research_agent`)
- **Edge cases checked**: Empty message input handled, handler signature matches Bindu's required `messages` parameter
- **What you did NOT verify**: Full end-to-end run (no API key)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`

## Failure Recovery

- How to disable/revert: delete `examples/crewai-agent/` folder and revert `pyproject.toml` + `examples/README.md`
- No runtime impact — example only

## Risks and Mitigations

- `None`

## Checklist

- [x] Tests pass (`uv run pytest`) — 1093 passed, 3 pre-existing Windows failures
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [x] Documentation updated (`examples/README.md`)
- [x] Security impact assessed
- [x] Backward compatibility considered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CrewAI multi-agent example (Researcher + Writer) that produces clean research summaries and can be run locally via a JSON-RPC endpoint.

* **Documentation**
  * Added full README with prerequisites, setup, run instructions, and example requests.

* **Chores**
  * Added an environment variable template for API keys and updated optional agent dependencies to support CrewAI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetBindu/Bindu/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->