### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -16,19 +16,30 @@ SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOi...
 # must then also update their Authorization header.
 GATEWAY_API_KEY=dev-key-change-me
 
-# Planner LLM — OpenRouter (single supported provider)
+# Planner LLM
 #
-# The gateway talks to every model through OpenRouter's OpenAI-compat
-# API. Model IDs take the form "openrouter/<openrouter-model-id>",
-# e.g. "openrouter/anthropic/claude-sonnet-4.6" or
-# "openrouter/openai/gpt-4o-mini". The default planner model is
-# "openrouter/anthropic/claude-sonnet-4.6"; override via
-# gateway.config.json under agent.planner.model.
+# Model IDs take the form "provider/model-id". The default planner model is
+# "openrouter/anthropic/claude-sonnet-4.6"; override it via gateway.config.json
+# under agent.planner.model.
 #
 # Prompt caching: the gateway auto-injects `cache_control` on every
 # request (see src/provider/index.ts). OpenAI/Grok/DeepSeek cache
 # automatically; Anthropic/Gemini caching is enabled by the marker.
 OPENROUTER_API_KEY=sk-or-v1-...
+
+# Direct MiniMax access (optional)
+#
+# Use model IDs "minimax/MiniMax-M3" or "minimax/MiniMax-M2.7". The provider
+# defaults to the global OpenAI-compatible endpoint. Set MINIMAX_PROTOCOL to
+# "anthropic" to use the Anthropic-compatible endpoint instead.
+MINIMAX_API_KEY=
+# MINIMAX_REGION=global_en
+# MINIMAX_PROTOCOL=openai
+# MINIMAX_OPENAI_BASE_URL=https://api.minimax.io/v1
+# MINIMAX_ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+# China endpoints:
+# MINIMAX_OPENAI_BASE_URL=https://api.minimaxi.com/v1
+# MINIMAX_ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
 
 # Optional: comma-separated fallback models for OpenRouter routing.
 # When the primary model errors (rate limit, upstream down, etc.)

--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -32,7 +32,7 @@ OPENROUTER_API_KEY=sk-or-v1-...
 # Use model IDs "minimax/MiniMax-M3" or "minimax/MiniMax-M2.7". The provider
 # defaults to the global OpenAI-compatible endpoint. Set MINIMAX_PROTOCOL to
 # "anthropic" to use the Anthropic-compatible endpoint instead.
-MINIMAX_API_KEY=
+MINIMAX_API_KEY= # pragma: allowlist secret
 # MINIMAX_REGION=global_en
 # MINIMAX_PROTOCOL=openai
 # MINIMAX_OPENAI_BASE_URL=https://api.minimax.io/v1

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -119,13 +119,10 @@ The provider registry supports these model IDs:
 
 The registry also carries the published token pricing and cache fields:
 
-| Model/tier | Input | Output | Cache read | Cache write |
+| Model | Input | Output | Cache read | Cache write |
 |---|---:|---:|---:|---:|
-| `MiniMax-M3` standard, up to 512k input | 0.30 | 1.20 | 0.06 | N/A |
-| `MiniMax-M3` standard, above 512k input | 0.60 | 2.40 | 0.12 | N/A |
-| `MiniMax-M3` priority, up to 512k input | 0.45 | 1.80 | 0.09 | N/A |
-| `MiniMax-M3` priority, above 512k input | 0.90 | 3.60 | 0.18 | N/A |
-| `MiniMax-M2.7` standard | 0.30 | 1.20 | 0.06 | 0.375 |
+| `MiniMax-M3` | 0.60 | 2.40 | 0.12 | N/A |
+| `MiniMax-M2.7` | 0.30 | 1.20 | 0.06 | 0.375 |
 
 Prices are USD per million tokens.
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -21,7 +21,7 @@ This README is the **operator's reference** — configuration, troubleshooting, 
 ```bash
 cd gateway
 npm install
-cp .env.example .env.local    # fill in GATEWAY_API_KEY, OPENROUTER_API_KEY
+cp .env.example .env.local    # fill in GATEWAY_API_KEY and one planner provider key
 npm run dev
 ```
 
@@ -84,7 +84,8 @@ For a runnable multi-agent walkthrough, see [`docs/GATEWAY.md`](../docs/GATEWAY.
 | Variable | Purpose |
 |---|---|
 | `GATEWAY_API_KEY` | Bearer token that callers must send |
-| `OPENROUTER_API_KEY` | Planner LLM provider |
+| `OPENROUTER_API_KEY` | Planner LLM provider when using an OpenRouter model |
+| `MINIMAX_API_KEY` | Planner LLM provider when using a direct MiniMax model |
 
 The gateway used to require `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` for session storage. Those are no longer used — sessions live in-memory, the calling client owns durable history.
 
@@ -106,6 +107,59 @@ See `.env.example` for the full template.
 ### Config file
 
 Some settings live in a TOML/JSON config file (path resolved hierarchically like OpenCode). Source of truth: [`src/config/schema.ts`](./src/config/schema.ts) — defaults are inline.
+
+### Direct MiniMax provider
+
+The provider registry supports these model IDs:
+
+| Model | Context window | Input modalities | Thinking |
+|---|---:|---|---|
+| `MiniMax-M3` | 1,000,000 | text, image, video | adaptive, disabled |
+| `MiniMax-M2.7` | 204,800 | text | always_on |
+
+The registry also carries the published token pricing and cache fields:
+
+| Model/tier | Input | Output | Cache read | Cache write |
+|---|---:|---:|---:|---:|
+| `MiniMax-M3` standard, up to 512k input | 0.30 | 1.20 | 0.06 | N/A |
+| `MiniMax-M3` standard, above 512k input | 0.60 | 2.40 | 0.12 | N/A |
+| `MiniMax-M3` priority, up to 512k input | 0.45 | 1.80 | 0.09 | N/A |
+| `MiniMax-M3` priority, above 512k input | 0.90 | 3.60 | 0.18 | N/A |
+| `MiniMax-M2.7` standard | 0.30 | 1.20 | 0.06 | 0.375 |
+
+Prices are USD per million tokens.
+
+Use the provider prefix in the planner configuration:
+
+```json
+{
+  "provider": {
+    "minimax": {
+      "apiKey": "$MINIMAX_API_KEY",
+      "region": "global_en",
+      "protocol": "openai"
+    }
+  },
+  "agent": {
+    "planner": { "model": "minimax/MiniMax-M3" }
+  }
+}
+```
+
+The regional endpoint map is available through the `region` setting:
+
+| Region | OpenAI-compatible base | Anthropic-compatible base |
+|---|---|---|
+| `global_en` | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| `cn_zh` | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+Set `protocol` to `anthropic` for the Anthropic-compatible adapter. The public
+base is passed directly to the client and must end in `/anthropic`.
+
+Model details and endpoint documentation:
+
+- [MiniMax global API overview](https://platform.minimax.io/docs/api-reference/api-overview)
+- [MiniMax China API overview](https://platform.minimaxi.com/docs/api-reference/api-overview)
 
 ---
 

--- a/gateway/package-lock.json
+++ b/gateway/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.53",
         "@ai-sdk/openai": "^3.0.53",
         "@effect/platform-node": "4.0.0-beta.48",
         "@hono/node-server": "^1.19.11",
@@ -39,6 +40,51 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.97",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.97.tgz",
+      "integrity": "sha512-OWX0YIgLv8kNjhIle0kVuUVr2tv3HA7+qTfgtTbUhU6iUK9kJFByYPxLvYzbke+XSBG708Vl9qRlFgq6qyGjdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.39"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.39",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.39.tgz",
+      "integrity": "sha512-XPR6o7561RYUkfYlLYouWsvm6Gv2tYIQy5pttGRkvML98u138ClPThn5yiQg5rMQutTtZLB+GUC8qFFCzDKQQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -1510,9 +1556,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.53",
+    "@ai-sdk/anthropic": "^3.0.53",
     "@effect/platform-node": "4.0.0-beta.48",
     "@hono/node-server": "^1.19.11",
     "@noble/ed25519": "^2.1.0",

--- a/gateway/src/config/loader.ts
+++ b/gateway/src/config/loader.ts
@@ -124,6 +124,28 @@ function envOverrides(base: Record<string, any>): Record<string, any> {
     }
   }
 
+  if (
+    process.env.MINIMAX_API_KEY ||
+    process.env.MINIMAX_REGION ||
+    process.env.MINIMAX_PROTOCOL ||
+    process.env.MINIMAX_OPENAI_BASE_URL ||
+    process.env.MINIMAX_ANTHROPIC_BASE_URL
+  ) {
+    out.provider = out.provider ?? {}
+    out.provider.minimax = {
+      ...out.provider.minimax,
+      ...(process.env.MINIMAX_API_KEY ? { apiKey: process.env.MINIMAX_API_KEY } : {}),
+      ...(process.env.MINIMAX_REGION ? { region: process.env.MINIMAX_REGION } : {}),
+      ...(process.env.MINIMAX_PROTOCOL ? { protocol: process.env.MINIMAX_PROTOCOL } : {}),
+      ...(process.env.MINIMAX_OPENAI_BASE_URL
+        ? { openaiBaseURL: process.env.MINIMAX_OPENAI_BASE_URL }
+        : {}),
+      ...(process.env.MINIMAX_ANTHROPIC_BASE_URL
+        ? { anthropicBaseURL: process.env.MINIMAX_ANTHROPIC_BASE_URL }
+        : {}),
+    }
+  }
+
   // Optional: comma-separated fallback model IDs. When primary fails
   // (rate limit, upstream error), OpenRouter tries each in order.
   // Example: OPENROUTER_FALLBACK_MODELS="minimax/minimax-m3,openai/gpt-4o-mini"

--- a/gateway/src/config/schema.ts
+++ b/gateway/src/config/schema.ts
@@ -47,6 +47,11 @@ export const ProviderEntry = z
   .object({
     apiKey: z.string().optional(),
     baseURL: z.string().optional(),
+    openaiBaseURL: z.string().optional(),
+    anthropicBaseURL: z.string().optional(),
+    region: z.enum(["global_en", "cn_zh"]).optional(),
+    protocol: z.enum(["openai", "anthropic"]).optional(),
+    fallbackModels: z.array(z.string()).optional(),
   })
   .passthrough()
 export type ProviderEntry = z.infer<typeof ProviderEntry>

--- a/gateway/src/provider/catalog.ts
+++ b/gateway/src/provider/catalog.ts
@@ -1,0 +1,57 @@
+export type MiniMaxRegion = "global_en" | "cn_zh"
+export type MiniMaxProtocol = "openai" | "anthropic"
+
+export const MINIMAX_ENDPOINTS = {
+  global_en: {
+    openaiBaseURL: "https://api.minimax.io/v1",
+    anthropicBaseURL: "https://api.minimax.io/anthropic",
+  },
+  cn_zh: {
+    openaiBaseURL: "https://api.minimaxi.com/v1",
+    anthropicBaseURL: "https://api.minimaxi.com/anthropic",
+  },
+} as const satisfies Record<MiniMaxRegion, Record<`${MiniMaxProtocol}BaseURL`, string>>
+
+export const MINIMAX_MODELS = [
+  {
+    id: "MiniMax-M3",
+    aliases: ["minimax-m3"],
+    contextWindow: 1_000_000,
+    pricingUsdPerMillionTokens: {
+      standard: [
+        { inputTokensLte: 512_000, input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: null },
+        { inputTokensGt: 512_000, input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: null },
+      ],
+      priority: [
+        { inputTokensLte: 512_000, input: 0.45, output: 1.8, cacheRead: 0.09, cacheWrite: null },
+        { inputTokensGt: 512_000, input: 0.9, output: 3.6, cacheRead: 0.18, cacheWrite: null },
+      ],
+    },
+    inputModalities: ["text", "image", "video"],
+    thinking: ["adaptive", "disabled"],
+  },
+  {
+    id: "MiniMax-M2.7",
+    aliases: ["minimax-m2.7"],
+    contextWindow: 204_800,
+    pricingUsdPerMillionTokens: {
+      standard: [{ input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 }],
+    },
+    inputModalities: ["text"],
+    thinking: ["always_on"],
+  },
+] as const
+
+export const DEFAULT_MINIMAX_MODEL = "MiniMax-M3"
+
+export function normalizeMiniMaxModelId(modelId: string): string {
+  const model = MINIMAX_MODELS.find(
+    (candidate) => candidate.id === modelId || candidate.aliases.some((alias) => alias === modelId),
+  )
+  if (!model) {
+    throw new Error(
+      `provider: unsupported MiniMax model "${modelId}" (supported: ${MINIMAX_MODELS.map((item) => item.id).join(", ")})`,
+    )
+  }
+  return model.id
+}

--- a/gateway/src/provider/catalog.ts
+++ b/gateway/src/provider/catalog.ts
@@ -5,12 +5,17 @@ export const MINIMAX_ENDPOINTS = {
   global_en: {
     openaiBaseURL: "https://api.minimax.io/v1",
     anthropicBaseURL: "https://api.minimax.io/anthropic",
+    docsRoot: "https://platform.minimax.io/docs",
   },
   cn_zh: {
     openaiBaseURL: "https://api.minimaxi.com/v1",
     anthropicBaseURL: "https://api.minimaxi.com/anthropic",
+    docsRoot: "https://platform.minimaxi.com/docs",
   },
-} as const satisfies Record<MiniMaxRegion, Record<`${MiniMaxProtocol}BaseURL`, string>>
+} as const satisfies Record<
+  MiniMaxRegion,
+  Record<`${MiniMaxProtocol}BaseURL`, string> & { docsRoot: string }
+>
 
 export const MINIMAX_MODELS = [
   {
@@ -18,14 +23,10 @@ export const MINIMAX_MODELS = [
     aliases: ["minimax-m3"],
     contextWindow: 1_000_000,
     pricingUsdPerMillionTokens: {
-      standard: [
-        { inputTokensLte: 512_000, input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: null },
-        { inputTokensGt: 512_000, input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: null },
-      ],
-      priority: [
-        { inputTokensLte: 512_000, input: 0.45, output: 1.8, cacheRead: 0.09, cacheWrite: null },
-        { inputTokensGt: 512_000, input: 0.9, output: 3.6, cacheRead: 0.18, cacheWrite: null },
-      ],
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.12,
+      cacheWrite: null,
     },
     inputModalities: ["text", "image", "video"],
     thinking: ["adaptive", "disabled"],
@@ -35,7 +36,10 @@ export const MINIMAX_MODELS = [
     aliases: ["minimax-m2.7"],
     contextWindow: 204_800,
     pricingUsdPerMillionTokens: {
-      standard: [{ input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 }],
+      input: 0.3,
+      output: 1.2,
+      cacheRead: 0.06,
+      cacheWrite: 0.375,
     },
     inputModalities: ["text"],
     thinking: ["always_on"],

--- a/gateway/src/provider/index.ts
+++ b/gateway/src/provider/index.ts
@@ -1,23 +1,23 @@
 import { Context, Effect, Layer } from "effect"
 import { createOpenAI } from "@ai-sdk/openai"
+import { createAnthropic } from "@ai-sdk/anthropic"
 import type { LanguageModel } from "ai"
 import { Service as ConfigService, type Config } from "../config"
 import type { z } from "zod"
+import {
+  MINIMAX_ENDPOINTS,
+  normalizeMiniMaxModelId,
+  type MiniMaxProtocol,
+  type MiniMaxRegion,
+} from "./catalog"
 
 /**
- * Provider service — OpenRouter-only.
+ * Provider service - resolves a configured provider/model pair to an AI-SDK
+ * language model.
  *
- * Looks up an AI-SDK LanguageModel handle by ``"openrouter/<modelId>"``
- * where ``modelId`` is whatever OpenRouter publishes for that model
- * (for example ``openai/gpt-4o-mini`` or
- * ``anthropic/claude-sonnet-4.6``).
- *
- * Why a single provider: we ship every agent (gateway planner + the
- * fleet) on OpenRouter. Supporting the Anthropic or OpenAI SDKs
- * directly was optionality nobody used and added two env vars and a
- * dependency we could drop. OpenRouter exposes an OpenAI-compatible
- * API, so a single ``@ai-sdk/openai`` client with a baseURL override
- * covers every model on the platform.
+ * Model IDs use ``provider/modelId``. The OpenRouter path keeps its existing
+ * request-body behavior, while MiniMax can use either its OpenAI-compatible
+ * or Anthropic-compatible endpoint.
  *
  * On every outbound request the gateway's fetch wrapper injects two
  * OpenRouter-specific request-body fields:
@@ -36,7 +36,7 @@ import type { z } from "zod"
  * a model string, give me a model handle the AI SDK can stream.
  */
 
-const SUPPORTED_PROVIDERS = ["openrouter"] as const
+const SUPPORTED_PROVIDERS = ["openrouter", "minimax"] as const
 export type ProviderId = (typeof SUPPORTED_PROVIDERS)[number]
 
 const OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
@@ -157,8 +157,39 @@ export const layer = Layer.effect(
 
     function build(providerId: ProviderId, modelId: string): LanguageModel {
       const providerCfg = providers[providerId] as
-        | { apiKey?: string; baseURL?: string; fallbackModels?: readonly string[] }
+        | {
+            apiKey?: string
+            baseURL?: string
+            openaiBaseURL?: string
+            anthropicBaseURL?: string
+            region?: MiniMaxRegion
+            protocol?: MiniMaxProtocol
+            fallbackModels?: readonly string[]
+          }
         | undefined
+
+      if (providerId === "minimax") {
+        const region = providerCfg?.region ?? "global_en"
+        const protocol = providerCfg?.protocol ?? "openai"
+        const endpoints = MINIMAX_ENDPOINTS[region]
+        const resolvedModelId = normalizeMiniMaxModelId(modelId)
+
+        if (protocol === "anthropic") {
+          const baseURL = providerCfg?.anthropicBaseURL ?? endpoints.anthropicBaseURL
+          if (!baseURL.endsWith("/anthropic")) {
+            throw new Error('provider: MiniMax Anthropic baseURL must end with "/anthropic"')
+          }
+          const p = createAnthropic({ apiKey: providerCfg?.apiKey, baseURL })
+          return p(resolvedModelId)
+        }
+
+        const p = createOpenAI({
+          apiKey: providerCfg?.apiKey,
+          baseURL: providerCfg?.openaiBaseURL ?? providerCfg?.baseURL ?? endpoints.openaiBaseURL,
+        })
+        return p.chat(resolvedModelId)
+      }
+
       // OpenRouter's API is OpenAI-compatible — one @ai-sdk/openai
       // client pointed at OpenRouter's baseURL handles every model.
       //

--- a/gateway/src/provider/index.ts
+++ b/gateway/src/provider/index.ts
@@ -175,7 +175,7 @@ export const layer = Layer.effect(
         const resolvedModelId = normalizeMiniMaxModelId(modelId)
 
         if (protocol === "anthropic") {
-          const baseURL = providerCfg?.anthropicBaseURL ?? endpoints.anthropicBaseURL
+          const baseURL = providerCfg?.anthropicBaseURL ?? providerCfg?.baseURL ?? endpoints.anthropicBaseURL
           if (!baseURL.endsWith("/anthropic")) {
             throw new Error('provider: MiniMax Anthropic baseURL must end with "/anthropic"')
           }

--- a/gateway/src/session/overflow.ts
+++ b/gateway/src/session/overflow.ts
@@ -1,4 +1,5 @@
 import type { MessageWithParts } from "./message"
+import { MINIMAX_MODELS } from "../provider/catalog"
 
 /**
  * Token accounting + overflow detection for session history.
@@ -57,6 +58,10 @@ const CONTEXT_WINDOW_BY_MODEL: Record<string, number> = {
   "openai/gpt-4.1-mini": 1_047_576,
   "openai/o3": 200_000,
   "openai/o3-mini": 200_000,
+
+  // MiniMax
+  "minimax/MiniMax-M3": MINIMAX_MODELS[0].contextWindow,
+  "minimax/MiniMax-M2.7": MINIMAX_MODELS[1].contextWindow,
 }
 
 export const DEFAULT_THRESHOLD: OverflowThreshold = {

--- a/gateway/tests/provider/minimax.test.ts
+++ b/gateway/tests/provider/minimax.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_MINIMAX_MODEL,
+  MINIMAX_ENDPOINTS,
+  MINIMAX_MODELS,
+  normalizeMiniMaxModelId,
+} from "../../src/provider/catalog"
+import { parseModelId } from "../../src/provider"
+
+describe("MiniMax provider catalog", () => {
+  it("covers both regions and both protocol base URLs", () => {
+    expect(MINIMAX_ENDPOINTS.global_en.openaiBaseURL).toMatch(/\/v1$/)
+    expect(MINIMAX_ENDPOINTS.global_en.anthropicBaseURL).toMatch(/\/anthropic$/)
+    expect(MINIMAX_ENDPOINTS.cn_zh.openaiBaseURL).toMatch(/\/v1$/)
+    expect(MINIMAX_ENDPOINTS.cn_zh.anthropicBaseURL).toMatch(/\/anthropic$/)
+  })
+
+  it("registers the default and secondary target models with metadata", () => {
+    expect(DEFAULT_MINIMAX_MODEL).toBe("MiniMax-M3")
+    expect(MINIMAX_MODELS.map((model) => model.id)).toEqual(["MiniMax-M3", "MiniMax-M2.7"])
+    expect(MINIMAX_MODELS[0].contextWindow).toBe(1_000_000)
+    expect(MINIMAX_MODELS[1].contextWindow).toBe(204_800)
+    expect(MINIMAX_MODELS[0].inputModalities).toEqual(["text", "image", "video"])
+    expect(MINIMAX_MODELS[1].thinking).toEqual(["always_on"])
+    expect(MINIMAX_MODELS[0].pricingUsdPerMillionTokens.standard[0]).toMatchObject({
+      input: 0.3,
+      output: 1.2,
+      cacheRead: 0.06,
+      cacheWrite: null,
+    })
+    expect(MINIMAX_MODELS[1].pricingUsdPerMillionTokens.standard[0].cacheWrite).toBe(0.375)
+  })
+
+  it("normalizes the registered aliases without accepting unknown models", () => {
+    expect(normalizeMiniMaxModelId("MiniMax-M3")).toBe("MiniMax-M3")
+    expect(normalizeMiniMaxModelId("minimax-m2.7")).toBe("MiniMax-M2.7")
+    expect(() => normalizeMiniMaxModelId("unknown-model")).toThrow(/unsupported MiniMax model/)
+  })
+
+  it("parses both target model IDs through the provider registry", () => {
+    expect(parseModelId("minimax/MiniMax-M3")).toEqual({
+      providerId: "minimax",
+      modelId: "MiniMax-M3",
+    })
+    expect(parseModelId("minimax/MiniMax-M2.7")).toEqual({
+      providerId: "minimax",
+      modelId: "MiniMax-M2.7",
+    })
+  })
+})

--- a/gateway/tests/provider/minimax.test.ts
+++ b/gateway/tests/provider/minimax.test.ts
@@ -11,8 +11,10 @@ describe("MiniMax provider catalog", () => {
   it("covers both regions and both protocol base URLs", () => {
     expect(MINIMAX_ENDPOINTS.global_en.openaiBaseURL).toMatch(/\/v1$/)
     expect(MINIMAX_ENDPOINTS.global_en.anthropicBaseURL).toMatch(/\/anthropic$/)
+    expect(MINIMAX_ENDPOINTS.global_en.docsRoot).toBe("https://platform.minimax.io/docs")
     expect(MINIMAX_ENDPOINTS.cn_zh.openaiBaseURL).toMatch(/\/v1$/)
     expect(MINIMAX_ENDPOINTS.cn_zh.anthropicBaseURL).toMatch(/\/anthropic$/)
+    expect(MINIMAX_ENDPOINTS.cn_zh.docsRoot).toBe("https://platform.minimaxi.com/docs")
   })
 
   it("registers the default and secondary target models with metadata", () => {
@@ -22,13 +24,18 @@ describe("MiniMax provider catalog", () => {
     expect(MINIMAX_MODELS[1].contextWindow).toBe(204_800)
     expect(MINIMAX_MODELS[0].inputModalities).toEqual(["text", "image", "video"])
     expect(MINIMAX_MODELS[1].thinking).toEqual(["always_on"])
-    expect(MINIMAX_MODELS[0].pricingUsdPerMillionTokens.standard[0]).toMatchObject({
+    expect(MINIMAX_MODELS[0].pricingUsdPerMillionTokens).toEqual({
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.12,
+      cacheWrite: null,
+    })
+    expect(MINIMAX_MODELS[1].pricingUsdPerMillionTokens).toEqual({
       input: 0.3,
       output: 1.2,
       cacheRead: 0.06,
-      cacheWrite: null,
+      cacheWrite: 0.375,
     })
-    expect(MINIMAX_MODELS[1].pricingUsdPerMillionTokens.standard[0].cacheWrite).toBe(0.375)
   })
 
   it("normalizes the registered aliases without accepting unknown models", () => {

--- a/gateway/tests/session/overflow-threshold.test.ts
+++ b/gateway/tests/session/overflow-threshold.test.ts
@@ -40,6 +40,11 @@ describe("thresholdForModel — model-aware context window resolution", () => {
     expect(thresholdForModel("openai/o3-mini").contextWindow).toBe(200_000)
   })
 
+  it("uses the registered MiniMax context windows", () => {
+    expect(thresholdForModel("minimax/MiniMax-M3").contextWindow).toBe(1_000_000)
+    expect(thresholdForModel("minimax/MiniMax-M2.7").contextWindow).toBe(204_800)
+  })
+
   it("falls back to the conservative default for unknown models", () => {
     // A fresh-off-the-press model we haven't added to the table yet.
     // The default is deliberately SMALLER than every common window so


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry.

## Summary
- Register `MiniMax-M3` and `MiniMax-M2.7` with context, pricing, cache, modality, thinking, aliases, and overflow metadata.
- Add regional OpenAI-compatible and Anthropic-compatible endpoint selection for `global_en` and `cn_zh`.
- Add environment overrides, operator documentation, dependency wiring, and focused registry tests.

## Change Type
- [x] Feature
- [x] Documentation
- [x] Tests

## User-Visible Behavior
Configure the planner with `minimax/MiniMax-M3` or `minimax/MiniMax-M2.7`, select a region, and select the OpenAI-compatible or Anthropic-compatible protocol. Existing configuration remains supported.

## Security Impact
- New permissions/capabilities: No
- Secrets/credentials handling changed: No; the API key is read from configuration or `MINIMAX_API_KEY`.
- New/changed network calls: Yes; direct MiniMax requests are supported through the configured adapter.
- Database schema/migration changes: No
- Authentication/authorization changes: No

## Verification
- `npm install --ignore-scripts` (pass)
- `npm test -- --run tests/provider/minimax.test.ts tests/session/overflow-threshold.test.ts` (pass, 19 tests)
- `npm test -- --run tests/api/plan-route-filter.test.ts` (pass, 2 tests)
- `npm run typecheck` (fails at unrelated existing `src/planner/index.ts:328` assistant metadata typing)
- `npm test` (29 test files passed; unrelated timing-sensitive `tests/api/plan-route-filter.test.ts` failure)

## Compatibility
- Backward compatible: Yes
- Config/env changes: Adds optional MiniMax provider settings.
- Database migration needed: No

## Failure Recovery
Remove the MiniMax provider configuration and restore the gateway files in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for MiniMax as a planner provider.
  - Supports global and China regions with OpenAI- and Anthropic-compatible endpoints.
  - Added MiniMax M3 and M2.7 models, aliases, defaults, and model-specific context limits.
  - Added flexible environment configuration for API keys, regions, protocols, and custom endpoints.

- **Documentation**
  - Updated setup guidance, environment variable reference, model details, pricing, and direct MiniMax configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->