### PR TITLE
chore: remove pointless conditional type in finishReason cast

### DIFF
--- a/gateway/src/session/llm.ts
+++ b/gateway/src/session/llm.ts
@@ -170,7 +170,7 @@ function mapEvent(evt: any): StreamEvent | null {
     case "finish":
       return {
         type: "finish",
-        finishReason: (evt.finishReason ?? "unknown") as StreamEvent["type"] extends "finish" ? any : any,
+        finishReason: evt.finishReason ?? "unknown",
         usage: {
           inputTokens: evt.totalUsage?.inputTokens,
           outputTokens: evt.totalUsage?.outputTokens,


### PR DESCRIPTION
Simplifies the finishReason field in gateway/src/session/llm.ts. The conditional type StreamEvent["type"] extends "finish" ? any : any always evaluates to any regardless of the condition, so it adds no type safety. Since evt is already typed as any in this function, no cast is needed at all — removed entirely. Addresses map-finish-reason-pointless-ternary from bugs/known-issues.md (note: the issue doc references prompt.ts/mapFinishReason, but the actual pattern lives in llm.ts's mapEvent function — the docs appear slightly stale).