### PR TITLE
fix: resolve UnicodeDecodeError in minimax tests on Windows

### DIFF
--- a/tests/unit/test_minimax_example.py
+++ b/tests/unit/test_minimax_example.py
@@ -28,13 +28,13 @@ class TestMiniMaxExampleFile:
 
     def test_example_is_valid_python(self):
         """Verify the example is valid Python syntax."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(EXAMPLE_PATH))
         assert tree is not None
 
     def test_example_has_docstring(self):
         """Verify the example has a module docstring."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         tree = ast.parse(source)
         docstring = ast.get_docstring(tree)
         assert docstring is not None
@@ -42,33 +42,33 @@ class TestMiniMaxExampleFile:
 
     def test_example_imports_bindufy(self):
         """Verify the example imports bindufy."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "from bindu.penguin.bindufy import bindufy" in source
 
     def test_example_imports_openailike(self):
         """Verify the example uses OpenAILike for MiniMax."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "from agno.models.openai import OpenAILike" in source
 
     def test_example_has_minimax_base_url(self):
         """Verify the example uses the correct MiniMax API URL."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "https://api.minimax.io/v1" in source
 
     def test_example_uses_minimax_m3(self):
         """Verify the example uses MiniMax-M3 model."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "MiniMax-M3" in source
 
     def test_example_reads_api_key_from_env(self):
         """Verify the example reads MINIMAX_API_KEY from env."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "MINIMAX_API_KEY" in source
         assert 'os.getenv("MINIMAX_API_KEY")' in source
 
     def test_example_has_config_dict(self):
         """Verify the example has a config dictionary with required fields."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert '"name"' in source
         assert '"author"' in source
         assert '"description"' in source
@@ -76,27 +76,27 @@ class TestMiniMaxExampleFile:
 
     def test_example_has_handler_function(self):
         """Verify the example defines a handler function."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "def handler(" in source
 
     def test_example_calls_bindufy(self):
         """Verify the example calls bindufy."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "bindufy(config, handler)" in source
 
     def test_example_has_main_guard(self):
         """Verify the example has __main__ guard."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert 'if __name__ == "__main__":' in source
 
     def test_example_uses_duckduckgo_tools(self):
         """Verify the example includes search tools."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "DuckDuckGoTools" in source
 
     def test_example_loads_dotenv(self):
         """Verify the example loads .env file."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "load_dotenv()" in source
 
 
@@ -105,17 +105,17 @@ class TestEnvExampleFile:
 
     def test_env_example_has_minimax_key(self):
         """Verify .env.example includes MINIMAX_API_KEY."""
-        content = ENV_EXAMPLE_PATH.read_text()
+        content = ENV_EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "MINIMAX_API_KEY" in content
 
     def test_env_example_has_minimax_section(self):
         """Verify .env.example has a MiniMax section header."""
-        content = ENV_EXAMPLE_PATH.read_text()
+        content = ENV_EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "MiniMax" in content
 
     def test_env_example_has_platform_url(self):
         """Verify .env.example references the MiniMax platform."""
-        content = ENV_EXAMPLE_PATH.read_text()
+        content = ENV_EXAMPLE_PATH.read_text(encoding="utf-8")
         assert "platform.minimaxi.com" in content
 
 
@@ -130,7 +130,7 @@ class TestMiniMaxModelConstants:
             "MiniMax-M2.7-highspeed",
         }
         # Parse the example to check the model used
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         for model in valid_models:
             # At least M3 should be referenced
             if model == "MiniMax-M3":
@@ -138,13 +138,13 @@ class TestMiniMaxModelConstants:
 
     def test_minimax_api_url_format(self):
         """Verify MiniMax API URL follows OpenAI-compatible format."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         # Should end with /v1 (OpenAI-compatible pattern)
         assert "api.minimax.io/v1" in source
 
     def test_example_does_not_hardcode_api_key(self):
         """Verify no API key is hardcoded in the example."""
-        source = EXAMPLE_PATH.read_text()
+        source = EXAMPLE_PATH.read_text(encoding="utf-8")
         # Should use os.getenv, not a hardcoded string
         assert "sk-" not in source.replace("sk-or-v1", "")  # exclude OpenRouter pattern
         assert 'api_key="' not in source
@@ -155,26 +155,26 @@ class TestReadmeUpdates:
 
     def test_main_readme_mentions_minimax(self):
         """Verify main README mentions MiniMax."""
-        readme = (Path(__file__).parent.parent.parent / "README.md").read_text()
+        readme = (Path(__file__).parent.parent.parent / "README.md").read_text(encoding="utf-8")
         assert "MiniMax" in readme
 
     def test_main_readme_has_minimax_api_key(self):
         """Verify main README mentions MINIMAX_API_KEY."""
-        readme = (Path(__file__).parent.parent.parent / "README.md").read_text()
+        readme = (Path(__file__).parent.parent.parent / "README.md").read_text(encoding="utf-8")
         assert "MINIMAX_API_KEY" in readme
 
     def test_examples_readme_mentions_minimax(self):
         """Verify examples README lists the MiniMax example."""
         readme = (
             Path(__file__).parent.parent.parent / "examples" / "README.md"
-        ).read_text()
+        ).read_text(encoding="utf-8")
         assert "minimax_example.py" in readme
 
     def test_examples_readme_mentions_minimax_env(self):
         """Verify examples README mentions MINIMAX_API_KEY in env vars."""
         readme = (
             Path(__file__).parent.parent.parent / "examples" / "README.md"
-        ).read_text()
+        ).read_text(encoding="utf-8")
         assert "MINIMAX_API_KEY" in readme
 
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: Running `pytest` on a Windows environment triggers a `UnicodeDecodeError` (`'charmap' codec can't decode byte...`) in `tests/unit/test_minimax_example.py`.
- **Why it matters**: Windows uses a different default system encoding (like `cp1252`), causing failures when `Path.read_text()` attempts to parse special characters (like emojis or arrows) in the `README.md` files during tests. This blocks Windows users from successfully running the local test suite.
- **What changed**: Added explicit `encoding="utf-8"` arguments to all `Path.read_text()` calls within `tests/unit/test_minimax_example.py`.
- **What did NOT change** (scope boundary): No application logic, agent configurations, or API interactions were modified. This is strictly a test-suite file-reading fix.

## Change Type (select all that apply)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [x] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Server / API endpoints
- [ ] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [ ] CLI / utilities
- [x] Tests
- [ ] Documentation
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # 
- Related #

## User-Visible / Behavior Changes

`None`

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/credentials handling changed? `No`
- New/changed network calls? `No`
- Database schema/migration changes? `No`
- Authentication/authorization changes? `No`
- **If any `Yes`, explain risk + mitigation**: N/A

## Verification

### Environment

- OS: Windows 11
- Python version: 3.12+ (via `uv`)
- Storage backend: N/A
- Scheduler backend: N/A

### Steps to Test

1. Clone the repository on a Windows machine.
2. Run `uv sync --dev` to set up the environment.
3. Execute the specific test file: `uv run pytest tests/unit/test_minimax_example.py`

### Expected Behavior

- All 24 tests in the file pass successfully (with 3 tests correctly skipping if `MINIMAX_API_KEY` is not set), and the files are read using UTF-8 encoding.

### Actual Behavior

- Tests pass cleanly without `UnicodeDecodeError` crashing the suite.

## Evidence (attach at least one)

- [x] Failing test before + passing after
- [x] Test output / logs
- [x] Screenshot / recording
- [ ] Performance metrics (if relevant)

## Human Verification (required)

What you personally verified (not just CI):

- **Verified scenarios**: Executed `test_minimax_example.py` locally on a Windows environment and verified the elimination of `UnicodeDecodeError`.
- **Edge cases checked**: Ensured integration tests correctly skip when the `MINIMAX_API_KEY` environment variable is not present.
- **What you did NOT verify**: Execution on Linux/macOS (though explicit UTF-8 encoding is the standard and perfectly safe for POSIX systems).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`
- **If yes, exact upgrade steps**: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit.
- Files/config to restore: `tests/unit/test_minimax_example.py`
- Known bad symptoms reviewers should watch for: Text parsing failures in the test suite on Unix systems (highly unlikely).

## Risks and Mitigations

`None`

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [ ] Documentation updated (if needed)
- [x] Security impact assessed
- [x] Human verification completed
- [x] Backward compatibility considered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test file handling to consistently use UTF-8 encoding when reading example, environment, and README files.
  * Existing assertions and integration behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->