### PR TITLE
test: cover full x402 paid message lifecycle

### DIFF
--- a/tests/integration/x402/test_e2e_scenarios.py
+++ b/tests/integration/x402/test_e2e_scenarios.py
@@ -537,8 +537,10 @@ async def test_full_http_paid_message_send_settles_and_completes():
     assert len(manifest.calls) == 1
     assert task.get("artifacts")
 
-    history_metadata = task["history"][0].get("metadata") or {}
-    assert "_payment_context" not in history_metadata
+    history = task.get("history") or []
+    assert history
+    for history_entry in history:
+        assert "_payment_context" not in (history_entry.get("metadata") or {})
 
     meta = task.get("metadata") or {}
     assert (

--- a/tests/integration/x402/test_e2e_scenarios.py
+++ b/tests/integration/x402/test_e2e_scenarios.py
@@ -418,6 +418,7 @@ async def test_scenario_3_parallel_nonce_double_spend():
 
 @pytest.mark.asyncio
 async def test_full_http_paid_message_send_settles_and_completes():
+    """Exercise the paid HTTP path from x402 verification through task completion."""
     describe("Full HTTP paid message/send lifecycle")
     logger.info("Real ASGI request enters X402Middleware and agent_run_endpoint.")
     logger.info(
@@ -456,6 +457,7 @@ async def test_full_http_paid_message_send_settles_and_completes():
             endpoint_app = SimpleNamespace(task_manager=manager)
 
             async def endpoint(request: Request):
+                """Route the in-process ASGI request into Bindu's A2A endpoint."""
                 return await agent_run_endpoint(cast(Any, endpoint_app), request)
 
             asgi_app = Starlette(

--- a/tests/integration/x402/test_e2e_scenarios.py
+++ b/tests/integration/x402/test_e2e_scenarios.py
@@ -43,6 +43,7 @@ from bindu.server.storage.memory_storage import InMemoryStorage
 from bindu.server.task_manager import TaskManager
 from bindu.server.workers.manifest_worker import ManifestWorker
 from bindu.settings import app_settings
+from bindu.utils.logging import get_logger
 
 
 pytestmark = [
@@ -51,6 +52,8 @@ pytestmark = [
     pytest.mark.slow,
     pytest.mark.x402,
 ]
+
+logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -416,8 +419,10 @@ async def test_scenario_3_parallel_nonce_double_spend():
 @pytest.mark.asyncio
 async def test_full_http_paid_message_send_settles_and_completes():
     describe("Full HTTP paid message/send lifecycle")
-    print("  Real ASGI request enters X402Middleware and agent_run_endpoint.")
-    print("  Payment context must reach ManifestWorker, settle, and complete the task.")
+    logger.info("Real ASGI request enters X402Middleware and agent_run_endpoint.")
+    logger.info(
+        "Payment context must reach ManifestWorker, settle, and complete the task."
+    )
 
     storage = InMemoryStorage()
     scheduler = InMemoryScheduler()

--- a/tests/integration/x402/test_e2e_scenarios.py
+++ b/tests/integration/x402/test_e2e_scenarios.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -32,10 +34,15 @@ from starlette.testclient import TestClient
 from x402 import PaymentPayload, PaymentRequirements
 from x402.schemas.responses import VerifyResponse
 
+from bindu.common.models import AgentManifest
+from bindu.server.endpoints.a2a_protocol import agent_run_endpoint
 from bindu.server.middleware.x402.nonce_store import InMemoryNonceStore
 from bindu.server.middleware.x402.x402_middleware import X402Middleware
+from bindu.server.scheduler.memory_scheduler import InMemoryScheduler
 from bindu.server.storage.memory_storage import InMemoryStorage
+from bindu.server.task_manager import TaskManager
 from bindu.server.workers.manifest_worker import ManifestWorker
+from bindu.settings import app_settings
 
 
 pytestmark = [
@@ -221,6 +228,30 @@ def report_task(task: Any, manifest_call_count: int) -> None:
     print(f"  → artifacts delivered:  {len(artifacts)}")
 
 
+async def wait_for_terminal_task(
+    storage: InMemoryStorage,
+    task_id: UUID,
+    *,
+    timeout_seconds: float = 2.0,
+) -> Any:
+    """Poll in-memory storage until the background worker reaches a terminal state."""
+    terminal_states = set(app_settings.agent.terminal_states)
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    last_state = "(not created)"
+
+    while asyncio.get_running_loop().time() < deadline:
+        task = await storage.load_task(task_id)
+        if task is not None:
+            last_state = task["status"]["state"]
+            if last_state in terminal_states:
+                return task
+        await asyncio.sleep(0.01)
+
+    pytest.fail(
+        f"Task {task_id} did not reach a terminal state; last state={last_state}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Scenario 1: Front-run drain (Mallory empties wallet between verify and settle)
 # ---------------------------------------------------------------------------
@@ -375,6 +406,149 @@ async def test_scenario_3_parallel_nonce_double_spend():
     assert len(manifest_b.calls) == 0
     assert not task_b.get("artifacts")
     print("  → net: 1 LLM call (paid), 0 LLM calls wasted, 1 artifact delivered.")
+
+
+# ---------------------------------------------------------------------------
+# Full paid HTTP lifecycle: middleware -> A2A endpoint -> scheduler -> worker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_http_paid_message_send_settles_and_completes():
+    describe("Full HTTP paid message/send lifecycle")
+    print("  Real ASGI request enters X402Middleware and agent_run_endpoint.")
+    print("  Payment context must reach ManifestWorker, settle, and complete the task.")
+
+    storage = InMemoryStorage()
+    scheduler = InMemoryScheduler()
+    manifest = ManifestRunRecorder(name="paid-agent")
+
+    resource_server = MagicMock()
+    resource_server.find_matching_requirements = MagicMock(return_value=REQUIREMENT)
+    resource_server.verify_payment = AsyncMock(
+        return_value=VerifyResponse(
+            is_valid=True,
+            invalid_reason=None,
+            payer="0xB0b00000000000000000000000000000000000b0",
+        )
+    )
+
+    settle_response = MagicMock()
+    settle_response.success = True
+    settle_response.error_reason = None
+    settle_response.model_dump = MagicMock(
+        return_value={"success": True, "transaction": "0xpaidsettled"}
+    )
+
+    original_methods = app_settings.x402.protected_methods
+    app_settings.x402.protected_methods = ["message/send"]
+    try:
+        async with TaskManager(
+            scheduler=scheduler,
+            storage=storage,
+            manifest=manifest,  # type: ignore[arg-type]
+        ) as manager:
+            endpoint_app = SimpleNamespace(task_manager=manager)
+
+            async def endpoint(request: Request):
+                return await agent_run_endpoint(cast(Any, endpoint_app), request)
+
+            asgi_app = Starlette(
+                routes=[Route("/", endpoint, methods=["POST"])],
+                middleware=[
+                    Middleware(
+                        X402Middleware,
+                        manifest=cast(AgentManifest, manifest),
+                        resource_server=resource_server,
+                        x402_ext=manifest.x402_extension,
+                        payment_requirements=[REQUIREMENT],
+                        nonce_store=InMemoryNonceStore(),
+                    )
+                ],
+            )
+
+            task_id = uuid4()
+            context_id = uuid4()
+            request_id = str(uuid4())
+            request_body = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "message/send",
+                "params": {
+                    "configuration": {
+                        "acceptedOutputModes": ["text/plain"],
+                    },
+                    "message": {
+                        "messageId": str(uuid4()),
+                        "contextId": str(context_id),
+                        "taskId": str(task_id),
+                        "kind": "message",
+                        "role": "user",
+                        "parts": [
+                            {
+                                "kind": "text",
+                                "text": "summarize this contract",
+                            }
+                        ],
+                    },
+                },
+            }
+            payload = make_payload(nonce="0x" + "fa" * 32)
+
+            with patch(
+                "bindu.server.workers.manifest_worker.HTTPFacilitatorClient"
+            ) as mock_fac_class:
+                mock_fac = AsyncMock()
+                mock_fac.settle = AsyncMock(return_value=settle_response)
+                mock_fac_class.return_value = mock_fac
+
+                transport = httpx.ASGITransport(app=asgi_app)
+                async with httpx.AsyncClient(
+                    transport=transport,
+                    base_url="http://testserver",
+                    timeout=2.0,
+                ) as client:
+                    response = await client.post(
+                        "/",
+                        json=request_body,
+                        headers={"X-PAYMENT": payment_header(payload)},
+                    )
+
+                assert response.status_code == 200, response.text
+                response_json = response.json()
+                assert response_json["id"] == request_id
+                assert response_json["result"]["id"] == str(task_id)
+
+                task = await wait_for_terminal_task(storage, task_id)
+
+    finally:
+        app_settings.x402.protected_methods = original_methods
+
+    report_task(task, len(manifest.calls))
+
+    assert task["status"]["state"] == "completed"
+    assert len(manifest.calls) == 1
+    assert task.get("artifacts")
+
+    history_metadata = task["history"][0].get("metadata") or {}
+    assert "_payment_context" not in history_metadata
+
+    meta = task.get("metadata") or {}
+    assert (
+        meta.get(app_settings.x402.meta_status_key)
+        == app_settings.x402.status_completed
+    )
+    assert meta.get(app_settings.x402.meta_receipts_key) == [
+        {"success": True, "transaction": "0xpaidsettled"}
+    ]
+
+    resource_server.verify_payment.assert_awaited_once()
+    mock_fac.settle.assert_awaited_once()
+    settle_call = mock_fac.settle.await_args
+    assert settle_call is not None
+    settled_payload, settled_requirement = settle_call.args
+    assert settled_payload.payload["authorization"]["nonce"] == "0x" + "fa" * 32
+    assert settled_requirement.network == REQUIREMENT.network
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/middleware/x402/test_x402_middleware.py
+++ b/tests/unit/server/middleware/x402/test_x402_middleware.py
@@ -69,11 +69,17 @@ def _build_app(
     verify_result: VerifyResponse,
     nonce_store: InMemoryNonceStore | None = None,
     protected_methods: list[str] | None = None,
+    state_recorder: dict[str, object] | None = None,
 ):
     """Spin up a minimal Starlette app with the middleware in front of
     an agent that simply echoes ``OK``."""
 
     async def agent(request: Request) -> JSONResponse:
+        if state_recorder is not None:
+            state_recorder["payment_payload"] = request.state.payment_payload
+            state_recorder["payment_requirements"] = request.state.payment_requirements
+            state_recorder["verify_response"] = request.state.verify_response
+            state_recorder["payer"] = request.state.payer
         return JSONResponse({"ok": True})
 
     resource_server = MagicMock()
@@ -263,19 +269,28 @@ class TestFacilitatorRejection:
 
 class TestHappyPath:
     def test_valid_payment_reaches_agent(self, _restore_protected_methods):
+        seen_state: dict[str, object] = {}
         app, restore, server, _ = _build_app(
-            verify_result=VerifyResponse(is_valid=True, payer="0xbeef")
+            verify_result=VerifyResponse(is_valid=True, payer="0xbeef"),
+            state_recorder=seen_state,
         )
         try:
             client = TestClient(app)
+            payload = _payload()
             r = client.post(
                 "/",
                 json={"jsonrpc": "2.0", "method": "message/send"},
-                headers={"X-PAYMENT": _payment_header(_payload())},
+                headers={"X-PAYMENT": _payment_header(payload)},
             )
             assert r.status_code == 200
             assert r.json() == {"ok": True}
             server.verify_payment.assert_awaited_once()
+            assert seen_state["payment_payload"] == payload
+            assert seen_state["payment_requirements"] == REQUIREMENT
+            verify_response = seen_state["verify_response"]
+            assert getattr(verify_response, "is_valid") is True
+            assert getattr(verify_response, "invalid_reason") is None
+            assert seen_state["payer"] == "0xbeef"
         finally:
             restore()
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- **Problem**: x402 had failure-mode integration coverage, but no full HTTP `message/send` success-path test proving payment context survived middleware, A2A routing, scheduling, worker execution, and settlement.
- **Why it matters**: regressions in that handoff can silently accept paid requests without settling, lose receipt metadata, or persist internal payment context.
- **What changed**: added a deterministic full HTTP paid `message/send` integration test with real `X402Middleware`, `agent_run_endpoint`, `TaskManager`, `InMemoryScheduler`, `ManifestWorker`, and `InMemoryStorage`, while mocking facilitator verification/settlement at the external boundary.
- **Additional guardrail**: strengthened the x402 middleware happy-path unit test so it asserts the verified request state actually reaches the downstream agent.
- **What did NOT change**: no production behavior, protocol schemas, network payment calls, storage schema, scheduler behavior, or docs were changed.

## Change Type (select all that apply)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [x] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Server / API endpoints
- [x] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [x] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [ ] CLI / utilities
- [x] Tests
- [ ] Documentation
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #348
- Related #583

## User-Visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/credentials handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Database schema/migration changes? (`Yes/No`): No
- Authentication/authorization changes? (`Yes/No`): No
- **If any `Yes`, explain risk + mitigation**: N/A

## Verification

### Environment

- OS: macOS
- Python version: 3.12.9 locally; GitHub Actions covers 3.12 and 3.13
- Storage backend: `InMemoryStorage`
- Scheduler backend: `InMemoryScheduler`

### Steps to Test

1. `uv run pytest tests/unit/server/middleware/x402/ -q`
2. `uv run pytest tests/integration/x402/ -q`
3. `uv run pytest tests/unit/ -q`
4. `uv run pytest tests/integration/ -q`
5. `uv run pre-commit run --files tests/integration/x402/test_e2e_scenarios.py tests/unit/server/middleware/x402/test_x402_middleware.py`
6. `git diff --check`

### Expected Behavior

- The paid HTTP `message/send` request verifies x402 payment, reaches the A2A endpoint, schedules a task, settles before manifest execution, completes the task, persists receipt metadata, and does not leak the internal `_payment_context` into task history.
- The x402 middleware happy path attaches `payment_payload`, `payment_requirements`, `verify_response`, and `payer` to request state before forwarding downstream.

### Actual Behavior

- `uv run pytest tests/unit/server/middleware/x402/ -q` -> 30 passed
- `uv run pytest tests/integration/x402/ -q` -> 5 passed, 2 skipped
- `uv run pytest tests/unit/ -q` -> 1087 passed, 3 skipped
- `uv run pytest tests/integration/ -q` -> 20 passed, 3 skipped
- `uv run pre-commit run --files tests/integration/x402/test_e2e_scenarios.py tests/unit/server/middleware/x402/test_x402_middleware.py` -> passed
- `git diff --check` -> passed

## Evidence (attach at least one)

- [ ] Failing test before + passing after
- [x] Test output / logs
- [ ] Screenshot / recording
- [ ] Performance metrics (if relevant)

## Human Verification (required)

What you personally verified (not just CI):

- **Verified scenarios**: full paid HTTP `message/send` happy path; existing x402 integration scenarios for insufficient balance/settlement failure, settlement timeout, parallel nonce double-spend, and replay rejection; middleware happy path state handoff.
- **Edge cases checked**: payment context is consumed internally, every persisted task-history entry omits `_payment_context`, receipt metadata is attached, mocked facilitator `verify_payment` and `settle` are each awaited once, settle receives the expected nonce/network, and middleware exposes verified state to downstream handlers.
- **What you did NOT verify**: live chain settlement or live facilitator behavior; those remain mocked so the test is deterministic and CI-safe.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Database migration needed? (`Yes/No`): No
- **If yes, exact upgrade steps**: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this test-only PR or skip `tests/integration/x402/test_e2e_scenarios.py::test_full_http_paid_message_send_settles_and_completes`.
- Files/config to restore: `tests/integration/x402/test_e2e_scenarios.py`, `tests/unit/server/middleware/x402/test_x402_middleware.py`
- Known bad symptoms reviewers should watch for: flaky terminal-task polling, missing task completion, missing x402 receipt metadata, unexpected live network calls, or missing request-state payment fields.

## Risks and Mitigations

- **Risk**: the new integration test is broader than a unit test and could become flaky if task scheduling semantics change.
  - **Mitigation**: it uses in-memory scheduler/storage, mocked external facilitator calls, and explicit polling for terminal task state.
- **Risk**: the mocked facilitator boundary may not catch live chain/facilitator incompatibilities.
  - **Mitigation**: the PR intentionally keeps CI deterministic; live facilitator checks are covered separately by existing live-smoke tests.

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass for touched files
- [x] Documentation updated (not needed; tests only)
- [x] Security impact assessed
- [x] Human verification completed
- [x] Backward compatibility considered

## AI assistance

This patch was prepared with AI assistance and manually reviewed/validated before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for paid HTTP message delivery.
  * Verifies payment processing, request routing, task scheduling and execution, settlement, completion, metadata, and facilitator interactions.
  * Added polling support to reliably wait for tasks to reach a terminal state.
  * Expanded middleware coverage to verify payment details are propagated throughout request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->