### PR TITLE
feat(sdk/csharp): implement Bindu C# SDK with gRPC integration, tests and polish

### DIFF
--- a/sdks/csharp/.gitignore
+++ b/sdks/csharp/.gitignore
@@ -1,0 +1,33 @@
+# Build results
+bin/
+obj/
+[Bb]uild/
+
+# Test results / coverage
+TestResults/
+coverage*.xml
+*.coverage
+
+# Visual Studio
+.vs/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+
+# IDE
+.vscode/
+.idea/
+
+# Local planning docs (not part of the SDK PR)
+bindu-csharp-sdk-stages.md
+bindu-csharp-sdk-stages (1).md
+CSharp-Sdk-Plan.md
+CODE-REVIEW-REPORT.md
+
+# NuGet
+*.nupkg
+*.snupkg
+
+# Logs
+*.log

--- a/sdks/csharp/Bindu-csharp-sdk.csproj
+++ b/sdks/csharp/Bindu-csharp-sdk.csproj
@@ -1,0 +1,46 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Bindu.Sdk</RootNamespace>
+	<AssemblyName>Bindu.Sdk</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Bindu.Sdk.Tests" />
+  </ItemGroup>
+
+  <!-- Keep the test project (colocated in tests/) out of the SDK's default globbing -->
+  <ItemGroup>
+    <Compile Remove="tests/**" />
+    <Content Remove="tests/**" />
+    <EmbeddedResource Remove="tests/**" />
+    <None Remove="tests/**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.81.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+	<ItemGroup>
+		<Protobuf Include="proto/agent_handler.proto" GrpcServices="Both" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<Target Name="CopyXmlDocToRefOutput" AfterTargets="Compile" Condition="'$(GenerateDocumentationFile)' == 'true'">
+		<Copy SourceFiles="$(IntermediateOutputPath)$(AssemblyName).xml"
+				DestinationFolder="$(IntermediateOutputPath)ref"
+				SkipUnchangedFiles="true"
+				Condition="Exists('$(IntermediateOutputPath)$(AssemblyName).xml')" />
+	</Target>
+
+</Project>

--- a/sdks/csharp/Bindu-csharp-sdk.slnx
+++ b/sdks/csharp/Bindu-csharp-sdk.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="Bindu-csharp-sdk.csproj" />
+  <Project Path="tests/Bindu.Sdk.Tests/Bindu.Sdk.Tests.csproj" />
+</Solution>

--- a/sdks/csharp/README.md
+++ b/sdks/csharp/README.md
@@ -1,0 +1,448 @@
+# Bindu.Sdk — C# SDK for Bindu
+
+![.NET](https://img.shields.io/badge/.NET-10.0-512BD4?logo=dotnet&logoColor=white)
+![gRPC](https://img.shields.io/badge/gRPC-2.80-244c5a?logo=grpc)
+![License](https://img.shields.io/badge/license-Apache%202.0-blue)
+
+Turn any .NET agent into a full A2A-compliant microservice with one function call.
+
+Write your agent in plain C# — call your own LLM, use Semantic Kernel, Microsoft.Extensions.AI, or nothing at all — then call `Bindufy()`. Bindu handles DID identity, authentication, x402 payments, task scheduling, storage, and the A2A protocol. You just write the handler.
+
+The C# SDK speaks the same gRPC protocol as the [TypeScript](https://github.com/getbindu/Bindu/tree/main/sdks/typescript) and [Kotlin](https://github.com/getbindu/Bindu/tree/main/sdks/kotlin) SDKs against the same Bindu core, so agent identity and protocol are identical across languages.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [What `Bindufy()` Does](#what-bindufy-does)
+- [API Reference](#api-reference)
+  - [`BinduAgent`](#binduagent)
+  - [`Bindufy(config, handler)`](#bindufyconfig-handler)
+  - [`AgentConfig`](#agentconfig)
+  - [The handler](#the-handler)
+  - [`BinduResponse`](#binduresponse)
+  - [`ChatMessage`](#chatmessage)
+  - [`RegistrationResult`](#registrationresult)
+  - [Shutting down](#shutting-down)
+- [Examples](#examples)
+  - [Echo agent](#echo-agent)
+  - [Multi-turn conversation](#multi-turn-conversation)
+  - [LLM-backed agent](#llm-backed-agent)
+  - [Graceful shutdown](#graceful-shutdown)
+- [How It Works Internally](#how-it-works-internally)
+- [Ports](#ports)
+- [Project Layout](#project-layout)
+- [Testing](#testing)
+- [Troubleshooting](#troubleshooting)
+- [License](#license)
+
+## Prerequisites
+
+- **.NET 10 SDK** — the SDK targets `net10.0`.
+- **The Bindu Python core** — install it on the same machine:
+
+  ```bash
+  pip install bindu
+  # or with uv:
+  uv pip install bindu
+  ```
+
+  You don't start the core yourself — the SDK locates it and launches it as a child process (see [How It Works Internally](#how-it-works-internally)).
+
+## Installation
+
+The SDK is not on NuGet yet. Reference the project directly (path relative to a consumer project at the repo root):
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="sdks\csharp\Bindu-csharp-sdk.csproj" />
+</ItemGroup>
+```
+
+or, from the CLI:
+
+```bash
+dotnet add reference sdks/csharp/Bindu-csharp-sdk.csproj
+```
+
+The gRPC dependencies (`Grpc.AspNetCore`, `Grpc.Net.Client`, `Google.Protobuf`) flow to your project transitively — no extra package references needed. Once the package is published to NuGet, `dotnet add package Bindu.Sdk` will work as well.
+
+## Quick Start
+
+Create a console app (`dotnet new console`) and replace `Program.cs`:
+
+```csharp
+using Bindu.Grpc;
+using Bindu.Sdk;
+
+var bindu = new BinduAgent();
+
+var config = new AgentConfig {
+    Author = "dev@example.com",
+    Name = "echo-agent",
+    Description = "Repeats the last message back",
+    DeploymentUrl = "http://localhost:3773",
+    ExposeDeployment = false,
+    Version = "0.1.0"
+};
+
+var result = await bindu.Bindufy(config, HandleMessages);
+
+Console.WriteLine($"AgentId:  {result.AgentId}");
+Console.WriteLine($"AgentUrl: {result.AgentUrl}");
+Console.WriteLine($"DID:      {result.Did}");
+
+// Keep the process alive — the agent is now serving requests.
+Console.WriteLine("Press any key to stop...");
+Console.ReadKey();
+
+static Task<object> HandleMessages(IReadOnlyList<ChatMessage> messages) {
+    var last = messages[^1].Content;
+    return Task.FromResult<object>($"Echo: {last}");
+}
+```
+
+Run it:
+
+```bash
+dotnet run
+```
+
+That's it. Your agent is now a microservice at `http://localhost:3773` with DID, auth, and A2A protocol support.
+
+> The SDK ships with a full xUnit test suite. Open `sdks/csharp/Bindu-csharp-sdk.slnx`, build, and run the tests from Visual Studio or the CLI (see [Testing](#testing)).
+
+## What `Bindufy()` Does
+
+When you call `Bindufy(config, handler)`, the SDK:
+
+1. **Locates the Bindu core** — tries `bindu` on `PATH`, then `uv run bindu`, then `python3 -m bindu.cli`
+2. **Launches the core** as a child process with gRPC enabled on `:3774`
+3. **Waits for the core's gRPC port** to accept connections (30s timeout)
+4. **Starts a gRPC callback server** for your handler (on `GrpcCallbackPort`, or a free port)
+5. **Registers your agent** with the core via the `RegisterAgent` gRPC call
+6. **Core runs full bindufy logic**: config validation, agent ID generation, DID key setup, auth, x402 payments, manifest creation, and the A2A HTTP server on the deployment URL (`:3773`)
+7. **Returns** `RegistrationResult` with your agent ID, DID, and A2A URL
+8. **Starts a heartbeat loop** (every 30 seconds) so the core knows the agent is alive
+
+When a message arrives via A2A HTTP, the core's worker calls your handler over gRPC. Your handler runs, returns a response, and the core sends it back to the client. You never touch gRPC, HTTP, or A2A — it's all handled internally.
+
+```
+Client ──HTTP──► Bindu Core ──gRPC──► Your Handler ──► LLM API
+                 (:3773)              (:dynamic)
+                 DID, Auth, x402
+                 Scheduler, Storage
+```
+
+## API Reference
+
+### `BinduAgent`
+
+The entry point of the SDK.
+
+```csharp
+var bindu = new BinduAgent();
+```
+
+Implements `IDisposable` and `IAsyncDisposable` — dispose it to unregister the agent and shut everything down cleanly. The SDK also hooks `Ctrl+C` and process exit automatically, so disposing is optional in most console apps.
+
+### `Bindufy(config, handler)`
+
+```csharp
+public Task<RegistrationResult> Bindufy(
+    AgentConfig config,
+    Func<IReadOnlyList<ChatMessage>, Task<object>> handler)
+```
+
+Transforms your agent into a Bindu microservice. Blocks until registration is complete.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `config` | `AgentConfig` | Agent configuration (see below) |
+| `handler` | `Func<IReadOnlyList<ChatMessage>, Task<object>>` | Your handler: receives the conversation history, returns a `string` or `BinduResponse` |
+
+**Returns:** `RegistrationResult` with `AgentId`, `Did`, and `AgentUrl`.
+
+**Throws:**
+
+- `InvalidOperationException` — when the Bindu core cannot be found or started, or the core rejects the registration
+- `TimeoutException` — when the core does not start within the allotted time
+
+### `AgentConfig`
+
+```csharp
+var config = new AgentConfig {
+    Author = "dev@example.com",        // required
+    Name = "my-agent",                 // required
+    Description = "What it does",      // required
+    DeploymentUrl = "http://localhost:3773",
+    ExposeDeployment = false,
+    GrpcCallbackPort = 0,              // 0 = auto-pick a free port
+    Skills = [],
+    Version = "0.1.0"
+};
+```
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `Author` | `string` (required) | Email address of the agent's author |
+| `Name` | `string` (required) | Agent name, returned by the capabilities endpoint |
+| `Description` | `string` (required) | Human-readable description of the agent |
+| `DeploymentUrl` | `string` | A2A server URL. Default: `http://localhost:3773` |
+| `ExposeDeployment` | `bool` | Expose the deployment publicly. Default: `false` |
+| `GrpcCallbackPort` | `int` | Port for the SDK's gRPC callback server. `0` (default) picks a free port automatically — and if a chosen port is busy, the SDK falls back to a free one |
+| `Skills` | `string[]` | Reserved for future use — not yet transmitted during registration |
+| `Version` | `string?` | Agent version. Default: `0.1.0` |
+
+### The handler
+
+```csharp
+Func<IReadOnlyList<ChatMessage>, Task<object>> handler
+```
+
+Your handler receives the full conversation history (oldest → newest) and returns either:
+
+- **A `string`** — normal response; the task completes
+- **A `BinduResponse`** — for state transitions (multi-turn conversations)
+
+The framework inside your handler doesn't matter — Bindu only cares about the messages it passes in and what you return.
+
+### `BinduResponse`
+
+```csharp
+var response = new BinduResponse {
+    Content = "The capital of France is Paris.",
+    State = "",                        // "", "input-required", or "auth-required"
+    Prompt = "",                       // follow-up prompt when State is set
+    Metadata = new Dictionary<string, string>()
+};
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Content` | `string` | The response text returned to the caller |
+| `State` | `string` | `""` for a completed task, `"input-required"` to ask a follow-up question, or `"auth-required"` to request authentication |
+| `Prompt` | `string` | Follow-up prompt shown to the user when `State` is set |
+| `Metadata` | `Dictionary<string, string>` | Optional key-value metadata included in the response |
+
+### `ChatMessage`
+
+A single conversation turn (`Bindu.Grpc` namespace, generated from the proto contract):
+
+```csharp
+messages[^1].Role      // "user", "assistant", or "system"
+messages[^1].Content   // message text
+```
+
+### `RegistrationResult`
+
+Returned by `Bindufy()`:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `AgentId` | `string` | UUID assigned to the agent by the Bindu core |
+| `Did` | `string` | W3C Decentralized Identifier (e.g. `did:bindu:...`) |
+| `AgentUrl` | `string` | A2A HTTP endpoint (e.g. `http://localhost:3773`) |
+
+### Shutting down
+
+The SDK cleans up on `Ctrl+C` or process exit automatically: it unregisters the agent, stops the callback server and heartbeat, and kills the core process. You can also trigger this explicitly:
+
+```csharp
+using var bindu = new BinduAgent();
+var result = await bindu.Bindufy(config, HandleMessages);
+// ...disposed at the end of the block
+```
+
+## Examples
+
+### Echo agent
+
+```csharp
+static Task<object> HandleMessages(IReadOnlyList<ChatMessage> messages) {
+    var last = messages[^1].Content;
+    return Task.FromResult<object>($"Echo: {last}");
+}
+```
+
+### Multi-turn conversation
+
+```csharp
+static Task<object> SurveyHandler(IReadOnlyList<ChatMessage> messages) {
+    var last = messages[^1].Content;
+
+    // First message — ask for more info and keep the task open
+    if (messages.Count == 1) {
+        return Task.FromResult<object>(new BinduResponse {
+            Content = "Got it.",
+            State = "input-required",
+            Prompt = "Which topic would you like to explore?"
+        });
+    }
+
+    // Follow-up — normal completion
+    return Task.FromResult<object>(new BinduResponse {
+        Content = $"Great question about \"{last}\". Here's what I found...",
+        State = ""
+    });
+}
+```
+
+### LLM-backed agent
+
+Any OpenAI-compatible chat-completions endpoint works — no SDK dependency required:
+
+```csharp
+using System.Net.Http.Json;
+using System.Text.Json;
+
+static async Task<object> LlmHandler(IReadOnlyList<ChatMessage> messages) {
+    using var http = new HttpClient();
+    http.DefaultRequestHeaders.Authorization =
+        new("Bearer", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
+
+    var payload = new {
+        model = "gpt-4o",
+        messages = messages.Select(m => new { role = m.Role, content = m.Content })
+    };
+
+    var response = await http.PostAsJsonAsync(
+        "https://api.openai.com/v1/chat/completions", payload);
+    response.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    return doc.RootElement
+              .GetProperty("choices")[0]
+              .GetProperty("message")
+              .GetProperty("content")
+              .GetString() ?? "";
+}
+```
+
+### Graceful shutdown
+
+```csharp
+using var bindu = new BinduAgent();
+var result = await bindu.Bindufy(config, HandleMessages);
+
+Console.WriteLine($"Agent online at {result.AgentUrl}");
+
+// When the using block exits, the agent is unregistered and the
+// core process is shut down.
+```
+
+## How It Works Internally
+
+```
+Bindufy(config, handler)
+  |
+  |  1. Find the core: bindu → uv run bindu → python3 -m bindu.cli
+  |  2. Spawn: bindu serve --grpc --grpc-port 3774
+  |  3. Wait for :3774 to accept TCP connections (30s timeout)
+  |
+  |  4. Start the AgentHandler gRPC server on the callback port
+  |     (GrpcCallbackPort, or a free port when 0 / when busy)
+  |
+  |  5. Call BinduService.RegisterAgent on :3774
+  |     (sends config JSON + callback address)
+  |
+  |  Core runs full bindufy logic:
+  |     - Config validation
+  |     - Agent ID generation
+  |     - DID setup (Ed25519 key generation)
+  |     - Auth + x402 payment setup (when configured)
+  |     - Manifest creation (manifest.run = GrpcAgentClient)
+  |     - A2A HTTP server on the deployment URL (:3773)
+  |
+  |  6. Return {AgentId, Did, AgentUrl}
+  |  7. Start heartbeat loop (every 30s)
+  |  8. Wait for HandleMessages calls
+```
+
+## Ports
+
+| Port | Protocol | Who | Purpose |
+|------|----------|-----|---------|
+| 3773 | HTTP | Bindu Core | A2A protocol server (clients connect here) |
+| 3774 | gRPC | Bindu Core | Registration server (SDK connects here) |
+| dynamic | gRPC | SDK | Handler server (core calls the SDK here) |
+
+## Project Layout
+
+```
+sdks/csharp/
+├── Bindu-csharp-sdk.slnx        # Solution — SDK + test project
+├── Bindu-csharp-sdk.csproj      # net10.0, gRPC packages, XML docs
+├── .gitignore                   # Local C#/VS/test ignores for the SDK
+├── proto/
+│   └── agent_handler.proto      # gRPC contract shared with other SDKs
+├── src/
+│   ├── BinduAgent.cs            # Public API: BinduAgent, AgentConfig, RegistrationResult
+│   ├── BinduResponse.cs         # Structured handler response
+│   ├── AgentHandler.cs          # gRPC service hosting your handler
+│   ├── CoreLauncher.cs          # Locates and spawns the Bindu core
+│   ├── GrpcClient.cs            # Talks to the core on :3774
+│   ├── GrpcServer.cs            # Hosts the callback server
+│   └── HeartbeatService.cs      # 30s heartbeat loop
+└── tests/
+    └── Bindu.Sdk.Tests/         # xUnit suite — unit + in-process integration tests
+```
+
+## Testing
+
+The SDK ships with an xUnit test suite that runs entirely in-process — it spins up a
+**fake Bindu core** on a random port, so no Python core or network access is needed.
+
+```bash
+cd sdks/csharp/tests/Bindu.Sdk.Tests
+dotnet test
+```
+
+With a coverage report (excludes generated proto/gRPC code):
+
+```bash
+dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+```
+
+## Troubleshooting
+
+### "Cannot find bindu, uv, or python3. Ensure at least one is installed."
+
+The Bindu Python core isn't on the machine or `PATH`. Install it and try again:
+
+```bash
+pip install bindu
+# or with uv:
+uv pip install bindu
+```
+
+### "Bindu core did not start within 30s"
+
+The core failed to launch. Check:
+
+```bash
+# Is Bindu installed?
+pip show bindu
+
+# Can it serve?
+bindu serve --grpc --help
+# or: uv run bindu serve --grpc --help
+# or: python3 -m bindu.cli serve --grpc --help
+```
+
+### "Bindu agent registration failed: ..."
+
+The core rejected the registration — the message after the colon explains why. Core logs are printed to your console with a `[bindu-core]` prefix; the SDK's own diagnostics use `[bindu-sdk]`.
+
+### The callback port I configured is already in use
+
+Not a problem — the SDK logs `Port X is in use, picking a free port automatically` and uses a free one. Set `GrpcCallbackPort = 0` to always auto-pick.
+
+### Heartbeat errors
+
+If you see `[bindu-sdk:err] Heartbeat failed: ...`, the core became unreachable (it exited or the network changed). Check that no other process is fighting over port 3774.
+
+## License
+
+Apache License 2.0. See the [repository LICENSE](https://github.com/getbindu/Bindu/blob/main/LICENSE.md).

--- a/sdks/csharp/proto/agent_handler.proto
+++ b/sdks/csharp/proto/agent_handler.proto
@@ -1,0 +1,197 @@
+// Bindu gRPC Protocol Definition
+//
+// This proto defines the contract between the Bindu core (Python) and
+// language-agnostic agent SDKs (TypeScript, Kotlin, Rust, etc.).
+//
+// Two services exist:
+//
+//   BinduService (runs on core, port 3774)
+//     - SDKs call RegisterAgent to register themselves with the core
+//     - Core then handles DID, auth, x402, A2A, scheduler, storage
+//
+//   AgentHandler (runs on SDK side, dynamic port)
+//     - Core calls HandleMessages when a task arrives
+//     - SDK executes the developer's handler function and returns the result
+//
+// The config is sent as a JSON string to keep this proto decoupled from
+// the Python config schema. This means adding new config fields to bindufy()
+// does NOT require proto changes (DRY principle).
+
+syntax = "proto3";
+
+package bindu.grpc;
+
+option java_package = "com.getbindu.grpc";
+option java_multiple_files = true;
+option go_package = "github.com/getbindu/bindu/proto";
+
+// =============================================================================
+// BinduService — SDK calls this on the Core to register and manage agents
+// =============================================================================
+
+service BinduService {
+  // Register an agent with the Bindu core.
+  // Core runs the full bindufy logic: DID, auth, x402, manifest, HTTP server.
+  // Returns agent identity and the A2A endpoint URL.
+  rpc RegisterAgent(RegisterAgentRequest) returns (RegisterAgentResponse);
+
+  // Periodic heartbeat to signal the SDK is still alive.
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
+
+  // Unregister an agent and shut down its A2A server.
+  rpc UnregisterAgent(UnregisterAgentRequest) returns (UnregisterAgentResponse);
+}
+
+// =============================================================================
+// AgentHandler — Core calls this on the SDK to execute tasks
+// =============================================================================
+
+service AgentHandler {
+  // Execute a handler with conversation history (unary).
+  // Core sends messages, SDK runs the developer's handler, returns response.
+  rpc HandleMessages(HandleRequest) returns (HandleResponse);
+
+  // Execute a handler with streaming response (server-side streaming).
+  // SDK yields chunks; core collects them via ResultProcessor.
+  rpc HandleMessagesStream(HandleRequest) returns (stream HandleResponse);
+
+  // Query agent capabilities (skills, supported modes).
+  rpc GetCapabilities(GetCapabilitiesRequest) returns (GetCapabilitiesResponse);
+
+  // Health check to verify the SDK process is responsive.
+  rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+}
+
+// =============================================================================
+// Registration Messages
+// =============================================================================
+
+message RegisterAgentRequest {
+  // Full agent config as JSON string. Parsed and validated by the core using
+  // the same ConfigValidator as Python bindufy(). This keeps the proto
+  // decoupled from config schema evolution.
+  string config_json = 1;
+
+  // Skills with their content pre-loaded from the SDK filesystem.
+  // The SDK reads skill.yaml/SKILL.md files and sends the content here
+  // so the core doesn't need filesystem access to the SDK's project.
+  repeated SkillDefinition skills = 2;
+
+  // The SDK's AgentHandler gRPC server address (e.g., "localhost:50052").
+  // Core will connect to this address to call HandleMessages.
+  string grpc_callback_address = 3;
+}
+
+message RegisterAgentResponse {
+  bool success = 1;
+  string agent_id = 2;       // UUID of the registered agent
+  string did = 3;            // W3C Decentralized Identifier assigned to the agent
+  string agent_url = 4;      // A2A HTTP endpoint URL (e.g., "http://localhost:3773")
+  string error = 5;          // Error message if success=false
+}
+
+message HeartbeatRequest {
+  string agent_id = 1;
+  int64 timestamp = 2;       // Unix timestamp in milliseconds
+}
+
+message HeartbeatResponse {
+  bool acknowledged = 1;
+  int64 server_timestamp = 2;
+}
+
+message UnregisterAgentRequest {
+  string agent_id = 1;
+}
+
+message UnregisterAgentResponse {
+  bool success = 1;
+  string error = 2;
+}
+
+// =============================================================================
+// Handler Messages — Used for task execution between Core and SDK
+// =============================================================================
+
+message ChatMessage {
+  // Conversation message in chat format.
+  // Maps directly to {"role": "user", "content": "..."} dicts in Python.
+  string role = 1;            // "user", "assistant", or "system"
+  string content = 2;
+}
+
+message HandleRequest {
+  // Conversation history sent by the core worker.
+  // This is the same list[dict[str, str]] that Python handlers receive.
+  repeated ChatMessage messages = 1;
+
+  // Task metadata for context (optional, informational).
+  string task_id = 2;
+  string context_id = 3;
+}
+
+message HandleResponse {
+  // Agent's response content.
+  string content = 1;
+
+  // Task state transition (empty string = completed normally).
+  // Supported values: "", "input-required", "auth-required"
+  // Maps to ResponseDetector.determine_task_state() in the core.
+  string state = 2;
+
+  // Prompt text when state is "input-required" or "auth-required".
+  string prompt = 3;
+
+  // Whether this is the final chunk in a streaming response.
+  bool is_final = 4;
+
+  // Additional key-value metadata to include in the response.
+  map<string, string> metadata = 5;
+}
+
+// =============================================================================
+// Skill Definition — Sent during registration with pre-loaded content
+// =============================================================================
+
+message SkillDefinition {
+  string name = 1;
+  string description = 2;
+  repeated string tags = 3;
+  repeated string input_modes = 4;
+  repeated string output_modes = 5;
+  string version = 6;
+  string author = 7;
+
+  // Raw content of the skill file (skill.yaml or SKILL.md).
+  // The SDK reads this from disk and sends it so the core
+  // can process skills without filesystem access to the SDK project.
+  string raw_content = 8;
+
+  // File format hint: "yaml" or "markdown"
+  string format = 9;
+}
+
+// =============================================================================
+// Capabilities Messages
+// =============================================================================
+
+message GetCapabilitiesRequest {}
+
+message GetCapabilitiesResponse {
+  string name = 1;
+  string description = 2;
+  string version = 3;
+  bool supports_streaming = 4;
+  repeated SkillDefinition skills = 5;
+}
+
+// =============================================================================
+// Health Check Messages
+// =============================================================================
+
+message HealthCheckRequest {}
+
+message HealthCheckResponse {
+  bool healthy = 1;
+  string message = 2;
+}

--- a/sdks/csharp/src/AgentHandler.cs
+++ b/sdks/csharp/src/AgentHandler.cs
@@ -1,0 +1,87 @@
+﻿using Bindu.Grpc;
+using Grpc.Core;
+using static Bindu.Grpc.AgentHandler;
+
+namespace Bindu.Sdk {
+
+    // HandleMessagesStream is intentionally not overridden.
+    // The base class returns gRPC UNIMPLEMENTED status, which is correct —
+    // streaming is not implemented in the TS or Kotlin SDKs either.
+    // See: docs/grpc/limitations.md
+
+    /// <summary>
+    /// gRPC service hosted by the SDK that the Bindu core calls to deliver tasks, query
+    /// capabilities, and check liveness.
+    /// </summary>
+    internal class AgentHandler : AgentHandlerBase {
+        private Func<IReadOnlyList<ChatMessage>, Task<object>> _handler;
+        private readonly AgentConfig _config;
+
+        /// <summary>
+        /// Creates a handler backed by the developer's delegate and the agent configuration.
+        /// </summary>
+        /// <param name="handler">Delegate that processes incoming conversation history.</param>
+        /// <param name="config">Agent configuration used for capabilities and health responses.</param>
+        public AgentHandler(Func<IReadOnlyList<ChatMessage>, Task<object>> handler, AgentConfig config) {
+            _handler = handler;
+            _config = config;
+        }
+
+        /// <summary>
+        /// Executes the developer's handler with the conversation history and maps the
+        /// result (a <see cref="string"/> or <see cref="BinduResponse"/>) onto a
+        /// <see cref="HandleResponse"/>.
+        /// </summary>
+        /// <param name="request">The conversation history sent by the Bindu core.</param>
+        /// <param name="context">The gRPC call context.</param>
+        /// <returns>A response containing the agent's content and optional state transition.</returns>
+        public override async Task<HandleResponse> HandleMessages(HandleRequest request, ServerCallContext context) {
+            try {
+                var messages = request.Messages.ToArray();
+                var resp = await _handler(messages);
+                var response = new HandleResponse { IsFinal = true };
+                if (resp is string text) {
+                    response.Content = text;
+                    response.State = "";
+                }
+                else if (resp is BinduResponse binduResp) {
+                    response.Content = binduResp.Content;
+                    response.State = binduResp.State;
+                    response.Prompt = binduResp.Prompt;
+                    foreach (var kv in binduResp.Metadata)
+                        response.Metadata[kv.Key] = kv.Value;
+                }
+
+                return response;
+            }
+            catch (Exception ex) {
+                // Stack traces contain CR/LF which are illegal in HTTP/2 header (trailer)
+                // values — Kestrel rejects the response with HTTP 500. Flatten them first.
+                var stackTrace = (ex.StackTrace ?? "no stack trace").Replace("\r", " ").Replace("\n", " ");
+                var trailers = new Metadata {
+                    { "exception-type", ex.GetType().Name },
+                    { "stack-trace", stackTrace }
+                };
+                throw new RpcException(new Status(StatusCode.Internal, ex.Message), trailers);
+            }
+        }
+
+        /// <summary>Returns the agent's name, description, version, and supported modes.</summary>
+        public override Task<GetCapabilitiesResponse> GetCapabilities(GetCapabilitiesRequest request, ServerCallContext context) {
+            return Task.FromResult(new GetCapabilitiesResponse {
+                Name = _config.Name,
+                Description = _config.Description,
+                Version = _config.Version ?? "0.1.0",
+                SupportsStreaming = false
+            });
+        }
+
+        /// <summary>Reports that the agent process is alive and responsive.</summary>
+        public override Task<HealthCheckResponse> HealthCheck(HealthCheckRequest request, ServerCallContext context) {
+            return Task.FromResult(new HealthCheckResponse {
+                Healthy = true,
+                Message = $"{_config.Name} is healthy"
+            });
+        }
+    }
+}

--- a/sdks/csharp/src/BinduAgent.cs
+++ b/sdks/csharp/src/BinduAgent.cs
@@ -1,0 +1,193 @@
+﻿using Bindu.Grpc;
+
+namespace Bindu.Sdk {
+    /// <summary>
+    /// Entry point for the Bindu .NET SDK.
+    /// </summary>
+    /// <remarks>
+    /// Call <see cref="Bindufy(AgentConfig, Func{IReadOnlyList{ChatMessage}, Task{object}})"/>
+    /// to launch the Bindu core and register an agent that can handle incoming tasks.
+    /// Dispose the instance (or let the process exit) to unregister the agent and shut
+    /// everything down cleanly.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var bindu = new BinduAgent();
+    /// var config = new AgentConfig { Author = "dev@example.com", Name = "my-agent", Description = "..." };
+    /// var result = await bindu.Bindufy(config, HandleMessages);
+    /// Console.WriteLine(result.AgentId);
+    /// </code>
+    /// </example>
+    public class BinduAgent : IDisposable, IAsyncDisposable {
+        private CoreLauncher? _launcher;
+        private RegistrationResult? _registrationResult;
+        private HeartbeatService? _heartbeatService;
+        private GrpcServer? _grpcServer;
+        private GrpcClient? _grpcClient;
+        private readonly CoreLauncher? _injectedLauncher;
+        private readonly string? _coreAddress;
+
+        /// <summary>
+        /// Creates a new Bindu SDK instance.
+        /// </summary>
+        /// <remarks>
+        /// Call <see cref="Bindufy(AgentConfig, Func{IReadOnlyList{ChatMessage}, Task{object}})"/>
+        /// to launch the Bindu core and register an agent.
+        /// </remarks>
+        public BinduAgent() { }
+
+        /// <summary>
+        /// Creates a Bindu SDK instance with an injected launcher and core address.
+        /// Used by the test suite to run against an in-process fake core.
+        /// </summary>
+        internal BinduAgent(CoreLauncher launcher, string coreAddress) {
+            _injectedLauncher = launcher;
+            _coreAddress = coreAddress;
+        }
+
+
+        /// <summary>
+        /// Launches the Bindu core, starts the agent's gRPC callback server, and registers
+        /// the agent with the core.
+        /// </summary>
+        /// <remarks>
+        /// This method blocks until registration is complete. Afterwards it starts a
+        /// heartbeat service (every 30 seconds) so the core knows the agent is alive, and
+        /// hooks up process-exit and Ctrl+C handlers that unregister the agent and shut
+        /// down cleanly.
+        /// </remarks>
+        /// <param name="config">Configuration describing the agent to register.</param>
+        /// <param name="handler">
+        /// Delegate invoked by the core whenever a task arrives. It receives the full
+        /// conversation history and must return either a <see cref="string"/> or a
+        /// <see cref="BinduResponse"/>.
+        /// </param>
+        /// <returns>A <see cref="RegistrationResult"/> with the agent's assigned ID, DID, and URL.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the Bindu core cannot be found or started, or when the core rejects
+        /// the agent registration.
+        /// </exception>
+        /// <exception cref="TimeoutException">Thrown when the core does not start within the allotted time.</exception>
+        public async Task<RegistrationResult> Bindufy(AgentConfig config, Func<IReadOnlyList<ChatMessage>, Task<object>> handler) {
+
+            //TODO: Verify the config files if needed before starting up all the server
+
+            var launcher = _injectedLauncher ?? new CoreLauncher();
+            var grpcServer = new GrpcServer(config.GrpcCallbackPort);
+            var grpcClient = new GrpcClient(_coreAddress ?? "http://localhost:3774/");
+
+            await launcher.LaunchBinduServer();
+            await grpcServer.StartServerAsync(handler, config);
+            await CoreLauncher.WaitForPortAsync(grpcServer.GetPort);
+            var binduClient = grpcClient.InitializeBinduClient(grpcServer);
+            var response = await grpcClient.RegisterAgent(config);
+            var regResult = new RegistrationResult(response?.AgentId ?? "", response?.Did ?? "", response?.AgentUrl ?? "");
+            _registrationResult = regResult;
+
+            var heartBeat = new HeartbeatService(regResult, binduClient);
+
+            AppDomain.CurrentDomain.ProcessExit += OnApplicationShutdown;
+            Console.CancelKeyPress += Console_CancelKeyPress;
+
+            //Assign all class Fields for shutdown handling
+            _launcher = launcher;
+            _heartbeatService = heartBeat;
+            _grpcServer = grpcServer;
+            _grpcClient = grpcClient;
+
+            return regResult;
+        }
+
+        private void Console_CancelKeyPress(object? sender, ConsoleCancelEventArgs e) {
+            e.Cancel = true;
+            Console.WriteLine("\n[bindu-sdk] Shutting down...");
+            CleanUp();
+            Environment.Exit(0);
+        }
+
+        private void OnApplicationShutdown(object? sender, EventArgs e) {
+            Console.WriteLine("\n[bindu-sdk] Shutting down...");
+            CleanUp();
+        }
+
+        private void CleanUp() {
+            _grpcClient?.UnRegisterAgent(_registrationResult!);
+            _launcher?.CleanUp();
+            _grpcServer?.StopServerAsync();
+            _heartbeatService?.CleanUp();
+        }
+
+        /// <summary>
+        /// Unregisters the agent from the core, stops the callback server and heartbeat
+        /// service, and terminates the Bindu core process.
+        /// </summary>
+        public void Dispose() {
+            CleanUp();
+        }
+
+        /// <inheritdoc cref="Dispose"/>
+        public ValueTask DisposeAsync() {
+            CleanUp();
+            return new ValueTask();
+        }
+
+    }
+
+    /// <summary>
+    /// Configuration describing an agent to register with the Bindu core.
+    /// </summary>
+    public class AgentConfig {
+        /// <summary>
+        /// Creates an empty agent configuration.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Author"/>, <see cref="Name"/>, and <see cref="Description"/>
+        /// properties are required and must be set before passing this to
+        /// <see cref="BinduAgent.Bindufy(AgentConfig, Func{IReadOnlyList{ChatMessage}, Task{object}})" />.
+        /// </remarks>
+        public AgentConfig() { }
+
+        /// <summary>Email address of the agent's author.</summary>
+        public required string Author { get; set; }
+        /// <summary>Name of the agent. Returned by the agent's capabilities response.</summary>
+        public required string Name { get; set; }
+        /// <summary>Human-readable description of what the agent does.</summary>
+        public required string Description { get; set; }
+        /// <summary>
+        /// Port the SDK's gRPC callback server listens on. Use <c>0</c> to let the SDK
+        /// pick a free port automatically.
+        /// </summary>
+        public int GrpcCallbackPort { get; set; } = 0;
+        /// <summary>Base URL of the Bindu deployment server.</summary>
+        public string DeploymentUrl { get; set; } = "http://localhost:3773";
+        /// <summary>Whether the agent's deployment should be exposed publicly.</summary>
+        public bool ExposeDeployment { get; set; } = false;
+        /// <summary>
+        /// Skills associated with this agent. Reserved for future use — skills are not yet
+        /// transmitted to the core during registration.
+        /// </summary>
+        public string[] Skills { get; set; } = [];
+
+        /// <summary>Optional version string for this agent. Defaults to "0.1.0".</summary>
+        public string? Version { get; set; }
+
+    }
+
+
+    /// <summary>
+    /// Describes a successfully registered agent: its assigned ID, DID, and endpoint URL.
+    /// </summary>
+    /// <param name="agentId">The unique identifier (UUID) assigned to the agent by the Bindu core.</param>
+    /// <param name="did">The W3C Decentralized Identifier (DID) assigned to the agent.</param>
+    /// <param name="agentUrl">The A2A HTTP endpoint URL where the agent can be reached.</param>
+    public class RegistrationResult(string agentId, string did, string agentUrl) {
+        /// <summary>Gets the unique identifier (UUID) assigned to the agent by the Bindu core.</summary>
+        public string AgentId { get; } = agentId;
+
+        /// <summary>Gets the W3C Decentralized Identifier (DID) assigned to the agent.</summary>
+        public string Did { get; } = did;
+
+        /// <summary>Gets the A2A HTTP endpoint URL where the agent can be reached (e.g. <c>http://localhost:3773</c>).</summary>
+        public string AgentUrl { get; } = agentUrl;
+    }
+}

--- a/sdks/csharp/src/BinduResponse.cs
+++ b/sdks/csharp/src/BinduResponse.cs
@@ -1,0 +1,32 @@
+﻿namespace Bindu.Sdk {
+    /// <summary>
+    /// Return this from your handler instead of a plain string when you need
+    /// to signal a state transition back to the caller.
+    /// </summary>
+    public class BinduResponse {
+        /// <summary>
+        /// Creates an empty response.
+        /// </summary>
+        /// <remarks>
+        /// Set <see cref="Content"/> (and optionally <see cref="State"/>, <see cref="Prompt"/>,
+        /// and <see cref="Metadata"/>) before returning it from your handler.
+        /// </remarks>
+        public BinduResponse() { }
+
+        /// <summary>The response text to return to the caller.</summary>
+        public string Content { get; set; } = "";
+
+        /// <summary>
+        /// State transition signal. Use "input-required" to ask the user a
+        /// follow-up question, or "auth-required" to request authentication.
+        /// Leave empty for a normal completed response.
+        /// </summary>
+        public string State { get; set; } = "";
+
+        /// <summary>Follow-up prompt shown to the user when State is set.</summary>
+        public string Prompt { get; set; } = "";
+
+        /// <summary>Optional key-value metadata to include in the response.</summary>
+        public Dictionary<string, string> Metadata { get; set; } = [];
+    }
+}

--- a/sdks/csharp/src/CoreLauncher.cs
+++ b/sdks/csharp/src/CoreLauncher.cs
@@ -1,0 +1,164 @@
+﻿using System.Diagnostics;
+using System.Net.Sockets;
+
+
+namespace Bindu.Sdk {
+    /// <summary>
+    /// Locates a Bindu installation (bindu, uv, or python3) and launches the core with
+    /// its gRPC server enabled on port 3774.
+    /// </summary>
+    internal class CoreLauncher {
+
+        private int _grpcPort = 3774;
+        private Process? _process;
+
+        /// <summary>
+        /// Starts the Bindu core process and waits until its gRPC port is accepting
+        /// connections.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when neither bindu, uv, nor python3 can be found, or when the process
+        /// fails to start.
+        /// </exception>
+        /// <exception cref="TimeoutException">
+        /// Thrown when the core does not open its gRPC port within the wait window.
+        /// </exception>
+        public virtual async Task LaunchBinduServer() {
+            var binduPath = FindBinduExecutable();
+            var command = "";
+            var argsList = Array.Empty<string>();
+
+            if (binduPath != null) {
+                command = binduPath;
+                argsList = [ "serve", "--grpc", "--grpc-port", _grpcPort.ToString() ];
+            }
+            else if (IsUvInstalled()) {
+                command = "uv";
+                argsList = ["run", "bindu", "serve", "--grpc", "--grpc-port", _grpcPort.ToString()];
+            }
+            else if(IsPython3Installed()) {
+                command = "python3";
+                argsList = ["-m", "bindu.cli", "serve", "--grpc", "--grpc-port", _grpcPort.ToString()];
+            }
+            else {
+                throw new InvalidOperationException("Cannot find bindu, uv, or python3. Ensure at least one is installed.");
+            }
+
+            var processInfo = new ProcessStartInfo {
+                FileName = command,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            for (int i = 0; i < argsList.Length; i++) {
+                processInfo.ArgumentList.Add(argsList[i]);
+            }
+
+            Console.WriteLine($"[bindu-sdk] Starting Bindu core: {command} {string.Join(" ", argsList)}");
+            var binduProcess = Process.Start(processInfo) ?? throw new InvalidOperationException("Failed to start Bindu core process.");
+            _process = binduProcess;
+
+            binduProcess.Exited += BinduProcess_Exited;
+
+            binduProcess.EnableRaisingEvents = true;
+
+            binduProcess.OutputDataReceived += (sender, e) => {
+                if (e.Data != null) Console.WriteLine($"[bindu-core] {e.Data}");
+            };
+            binduProcess.ErrorDataReceived += (s, e) => {
+                if (e.Data != null) Console.WriteLine($"[bindu-core:err] {e.Data}");
+            };
+            binduProcess.BeginOutputReadLine();
+            binduProcess.BeginErrorReadLine();
+
+
+            await WaitForPortAsync(_grpcPort);
+            Console.WriteLine("[bindu-sdk] Core is ready and accepting registrations.");
+        }
+
+        private void BinduProcess_Exited(object? sender, EventArgs e) {
+            Console.WriteLine($"[bindu-sdk] Bindu core exited unexpectedly with code {_process!.ExitCode}");
+            CleanUp();
+        }
+
+        /// <summary>Kills and disposes the Bindu core process if one was started.</summary>
+        public void CleanUp() {
+            _process?.Kill(entireProcessTree: true);
+            _process?.Dispose();
+            _process = null;
+        }
+
+        /// <summary>
+        /// Polls <paramref name="host"/>:<paramref name="port"/> until a TCP connection
+        /// succeeds or the timeout elapses.
+        /// </summary>
+        /// <param name="port">TCP port to probe.</param>
+        /// <param name="host">Host to probe (defaults to localhost).</param>
+        /// <param name="timeoutMs">Maximum time to wait, in milliseconds.</param>
+        /// <exception cref="TimeoutException">Thrown when the port never opens within the timeout.</exception>
+        public static async Task WaitForPortAsync(int port, string host = "localhost", int timeoutMs = 30000) {
+            using var cts = new CancellationTokenSource(timeoutMs);
+
+            while (!cts.IsCancellationRequested) {
+                try {
+                    using var client = new TcpClient();
+
+                    await client.ConnectAsync(host, port, cts.Token);
+
+                    return;
+                }
+                catch (SocketException) {
+
+                }
+                catch (OperationCanceledException) {
+                    break;
+                }
+
+                await Task.Delay(500, cts.Token);
+            }
+            throw new TimeoutException($"[bindu-sdk] Bindu core did not start within {timeoutMs / 1000}s on port {port}");
+        }
+
+        /// <summary>
+        /// Resolves the full path of an executable on the PATH using <c>where.exe</c>
+        /// (Windows) or <c>which</c> (Unix).
+        /// </summary>
+        /// <param name="executableName">Name of the executable to look up.</param>
+        /// <returns>The first matching path, or <c>null</c> if the executable is not found.</returns>
+        private static string? FindExecutable(string executableName) {
+            var fileName = OperatingSystem.IsWindows() ? "where.exe" : "which";
+            try {
+                using var process = Process.Start(new ProcessStartInfo {
+                    FileName = fileName,
+                    Arguments = executableName,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                });
+                if (process == null) {
+                    return null;
+                }
+                var path = process.StandardOutput.ReadToEnd();
+                process.WaitForExit();
+
+                if (process.ExitCode != 0) {
+                    return null;
+                }
+                else if (string.IsNullOrWhiteSpace(path)) {
+                    return null;
+                }
+                else {
+                    return path.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                }
+            }
+            catch {
+                return null;
+            }
+        }
+        private static bool IsPython3Installed() => FindExecutable("python3") is not null;
+        private static string? FindBinduExecutable() => FindExecutable("bindu");
+        private static bool IsUvInstalled() => FindExecutable("uv") is not null;
+    }
+}

--- a/sdks/csharp/src/GrpcClient.cs
+++ b/sdks/csharp/src/GrpcClient.cs
@@ -1,0 +1,95 @@
+﻿using Bindu.Grpc;
+using Grpc.Net.Client;
+using System.Text.Json;
+using static Bindu.Grpc.BinduService;
+
+namespace Bindu.Sdk {
+    /// <summary>
+    /// gRPC client used to talk to the Bindu core on port 3774 (register agents,
+    /// unregister agents, and send heartbeats).
+    /// </summary>
+    internal class GrpcClient {
+        private BinduServiceClient? _binduClient;
+        private GrpcServer? _grpcServer;
+        private readonly string _coreAddress;
+
+        /// <summary>
+        /// Creates a gRPC client for the Bindu core.
+        /// </summary>
+        /// <param name="coreAddress">
+        /// Base address of the core's gRPC server. Defaults to <c>http://localhost:3774</c>.
+        /// </param>
+        public GrpcClient(string coreAddress = "http://localhost:3774/") {
+            _coreAddress = coreAddress;
+        }
+
+        /// <summary>
+        /// Creates a channel and client connected to the Bindu core at
+        /// <c>http://localhost:3774</c>.
+        /// </summary>
+        /// <param name="grpcServer">The SDK's callback server; its actual port is reported
+        /// to the core during registration.</param>
+        /// <returns>The initialized core client.</returns>
+        public BinduServiceClient InitializeBinduClient(GrpcServer grpcServer) {
+            var channel = GrpcChannel.ForAddress(_coreAddress);
+
+            var client = new BinduServiceClient(channel);
+            _binduClient = client;
+            _grpcServer = grpcServer;
+            return _binduClient;
+        }
+
+        /// <summary>
+        /// Registers the agent described by <paramref name="regDetails"/> with the Bindu core.
+        /// </summary>
+        /// <param name="regDetails">Agent configuration to register.</param>
+        /// <returns>The core's registration response, or <c>null</c> if the client is not initialized.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the core rejects the registration (its response has
+        /// <c>Success == false</c>).
+        /// </exception>
+        public async Task<RegisterAgentResponse?> RegisterAgent(AgentConfig regDetails) {
+            if (_binduClient == null) { return null; }
+            var configJson = new {
+                author = regDetails.Author,
+                name = regDetails.Name,
+                description = regDetails.Description,
+                deployment = new {
+                    url = regDetails.DeploymentUrl,
+                    expose = regDetails.ExposeDeployment,
+                },
+                kind = "agent"
+            };
+
+
+            var json = JsonSerializer.Serialize(configJson);
+
+            var regRequest = new RegisterAgentRequest {
+                ConfigJson = json,
+                GrpcCallbackAddress = $"localhost:{_grpcServer!.GetPort}"
+            };
+            var response = await _binduClient.RegisterAgentAsync(regRequest);
+            if (!response.Success) {
+                throw new InvalidOperationException($"Bindu agent registration failed: {response.Error}");
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        /// Unregisters the agent from the core and releases the client.
+        /// </summary>
+        /// <param name="regDetails">The registration result of the agent to unregister.</param>
+        /// <returns>The core's unregister response, or <c>null</c> if the client is not initialized.</returns>
+        public UnregisterAgentResponse? UnRegisterAgent(RegistrationResult regDetails) {
+            var unRegister = new UnregisterAgentRequest {
+                AgentId = regDetails.AgentId
+            };
+            var returnValue = _binduClient?.UnregisterAgent(unRegister);
+            _binduClient = null;
+            return returnValue;
+        }
+
+    }
+
+}

--- a/sdks/csharp/src/GrpcServer.cs
+++ b/sdks/csharp/src/GrpcServer.cs
@@ -1,0 +1,99 @@
+﻿using Bindu.Grpc;
+using Grpc.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Sockets;
+
+
+namespace Bindu.Sdk {
+
+    /// <summary>
+    /// ASP.NET Core gRPC server that hosts the agent's <see cref="AgentHandler"/> so the
+    /// Bindu core can deliver tasks to the SDK.
+    /// </summary>
+    internal class GrpcServer {
+        private int _port = 0; //default value
+        private int _usedPort = 0;
+        private WebApplication? _app;
+
+        /// <summary>Gets the actual port the callback server is listening on (0 until started).</summary>
+        public int GetPort => _usedPort;
+
+        /// <summary>
+        /// Creates a server configuration for the given port.
+        /// </summary>
+        /// <param name="port">
+        /// Port to listen on, or <c>0</c> to let the OS pick a free port. If the requested
+        /// port is already in use, a free port is chosen automatically.
+        /// </param>
+        public GrpcServer(int port) {
+            if (port != 0 && IsPortInUse(port)) {
+                Console.WriteLine($"[bindu-sdk] Port {port} is in use, picking a free port automatically.");
+                _port = 0;
+                return;
+            }
+            _port = port;
+        }
+
+        /// <summary>
+        /// Starts the gRPC callback server (HTTP/2) with the given handler and agent config.
+        /// </summary>
+        /// <param name="handler">Delegate that processes incoming conversation history.</param>
+        /// <param name="config">Agent configuration used by the handler service.</param>
+        public async Task StartServerAsync(Func<IReadOnlyList<ChatMessage>, Task<object>> handler, AgentConfig config) {
+
+            var builder = WebApplication.CreateBuilder();
+
+            builder.Services.AddSingleton(handler);
+            builder.Services.AddSingleton(config);
+
+            builder.WebHost.ConfigureKestrel(options => {
+                options.Listen(IPAddress.Any, _port, listenOptions => {
+                    listenOptions.Protocols = HttpProtocols.Http2;
+                });
+            });
+
+            builder.Services.AddGrpc();
+
+            var app = builder.Build();
+
+            app.MapGrpcService<AgentHandler>();
+
+            await app.StartAsync();
+            _app = app;
+
+            var addressFeature = _app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
+            var address = addressFeature?.Addresses.FirstOrDefault();
+            _usedPort = new Uri(address!).Port;
+        }
+
+        /// <summary>Stops and disposes the underlying web application.</summary>
+        public async void StopServerAsync() {
+            if (_app is not null) {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+                _app = null;
+            }
+        }
+
+        /// <summary>Checks whether a TCP connection can be established to the given port.</summary>
+        /// <param name="port">Port to probe.</param>
+        /// <returns><c>true</c> if something is already listening on the port.</returns>
+        private static bool IsPortInUse(int port) {
+            try {
+                using var client = new TcpClient();
+                client.Connect("localhost", port);
+
+                return true; // connected = something is already there
+            }
+            catch (SocketException) {
+                return false; // connection refused = port is free
+            }
+        }
+    }
+}

--- a/sdks/csharp/src/HeartbeatService.cs
+++ b/sdks/csharp/src/HeartbeatService.cs
@@ -1,0 +1,77 @@
+﻿using Bindu.Grpc;
+using Grpc.Core;
+using static Bindu.Grpc.BinduService;
+
+namespace Bindu.Sdk {
+    /// <summary>
+    /// Sends periodic heartbeats to the Bindu core so it knows the registered agent
+    /// process is still alive.
+    /// </summary>
+    internal class HeartbeatService {
+
+        private Timer? _timer;
+        private BinduServiceClient? _binduClient;
+
+        /// <summary>
+        /// Starts sending heartbeats to the core every 30 seconds.
+        /// </summary>
+        /// <param name="regInfo">The agent's registration result (used for the agent ID).</param>
+        /// <param name="client">gRPC client connected to the Bindu core.</param>
+        public HeartbeatService(RegistrationResult regInfo, BinduServiceClient client)
+            : this(regInfo, client, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30)) { }
+
+        /// <summary>
+        /// Starts sending heartbeats with a custom schedule. Used by the test suite to
+        /// run a heartbeat without waiting 30 seconds.
+        /// </summary>
+        internal HeartbeatService(RegistrationResult regInfo, BinduServiceClient client, TimeSpan dueTime, TimeSpan period) {
+            _timer = new Timer(HeartBeat, regInfo, dueTime, period);
+            _binduClient = client;
+        }
+
+        /// <summary>
+        /// Sends a single heartbeat for the registered agent and logs the core's response.
+        /// </summary>
+        /// <param name="state">The <see cref="RegistrationResult"/> passed to the timer.</param>
+        private async void HeartBeat(object? state) {
+            try {
+                if (state == null) {
+                    throw new RpcException(new Status(StatusCode.Internal, ""));
+                }
+                RegistrationResult info = (RegistrationResult)state;
+
+                var heartbeatRequest = new HeartbeatRequest {
+                    AgentId = info.AgentId,
+                    Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                };
+
+                var response = await SendHeartBeat(heartbeatRequest);
+                Console.WriteLine($"[bindu-sdk:heartbeat]: Acknowledged: {response.Acknowledged}, TimeStamp: {response.ServerTimestamp}");
+            }
+            catch (RpcException ex) {
+                Console.WriteLine($"[bindu-sdk:err] Heartbeat failed: {ex.Status.Detail}");
+                Console.WriteLine($"[bindu-sdk:err] Heartbeat failed: {ex.Message}");
+            }
+            catch (Exception ex) {
+                Console.WriteLine($"[bindu-sdk:err] Heartbeat unexpected error: {ex.Message}");
+                Console.WriteLine($"[bindu-sdk:err] Heartbeat unexpected error: {ex.StackTrace}");
+            }
+        }
+
+        /// <summary>Sends a heartbeat request over gRPC and returns the core's response.</summary>
+        private async Task<HeartbeatResponse> SendHeartBeat(HeartbeatRequest heartbeatRequest) {
+
+            var response = await _binduClient!.HeartbeatAsync(heartbeatRequest, new CallOptions());
+            return response;
+        }
+
+        /// <summary>Stops the heartbeat timer.</summary>
+        public void CleanUp() {
+            _timer?.Dispose();
+            _timer = null;
+        }
+
+    }
+
+
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/AgentConfigTests.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/AgentConfigTests.cs
@@ -1,0 +1,43 @@
+using Bindu.Sdk;
+
+namespace Bindu.Sdk.Tests;
+
+public class AgentConfigTests {
+    [Fact]
+    public void Defaults_Are_As_Documented() {
+        var config = new AgentConfig {
+            Author = "dev@example.com",
+            Name = "test-agent",
+            Description = "A test agent"
+        };
+
+        Assert.Equal(0, config.GrpcCallbackPort);
+        Assert.Equal("http://localhost:3773", config.DeploymentUrl);
+        Assert.False(config.ExposeDeployment);
+        Assert.Empty(config.Skills);
+        Assert.Null(config.Version);
+    }
+
+    [Fact]
+    public void Properties_Are_Settable() {
+        var config = new AgentConfig {
+            Author = "author@example.com",
+            Name = "custom-agent",
+            Description = "Custom description",
+            GrpcCallbackPort = 5052,
+            DeploymentUrl = "http://localhost:9000",
+            ExposeDeployment = true,
+            Skills = ["skill-a", "skill-b"],
+            Version = "2.1.0"
+        };
+
+        Assert.Equal("author@example.com", config.Author);
+        Assert.Equal("custom-agent", config.Name);
+        Assert.Equal("Custom description", config.Description);
+        Assert.Equal(5052, config.GrpcCallbackPort);
+        Assert.Equal("http://localhost:9000", config.DeploymentUrl);
+        Assert.True(config.ExposeDeployment);
+        Assert.Equal(["skill-a", "skill-b"], config.Skills);
+        Assert.Equal("2.1.0", config.Version);
+    }
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/AssemblyInfo.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+// Several tests probe for a free port and then immediately bind it (GrpcServer port
+// selection, WaitForPortAsync timeout). Running test classes in parallel could let
+// another test steal the probed port in between, so keep execution serial.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/Bindu.Sdk.Tests.csproj
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/Bindu.Sdk.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Bindu-csharp-sdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/BinduAgentBindufyTests.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/BinduAgentBindufyTests.cs
@@ -1,0 +1,74 @@
+using Bindu.Grpc;
+using System.Text.Json;
+
+namespace Bindu.Sdk.Tests;
+
+public class BinduAgentBindufyTests {
+    private static AgentConfig TestConfig() => new() {
+        Author = "dev@example.com",
+        Name = "flow-agent",
+        Description = "Agent exercising the full Bindufy flow",
+        GrpcCallbackPort = 0,
+        Version = "3.2.1"
+    };
+
+    private static Task<object> TestHandler(IReadOnlyList<ChatMessage> messages) =>
+        Task.FromResult<object>($"Echo: {messages[^1].Content}");
+
+    [Fact]
+    public async Task Bindufy_Registers_And_Returns_Registration_Result() {
+        await using var core = await FakeBinduCore.StartAsync();
+        using var bindu = new BinduAgent(new NoOpCoreLauncher(), core.Address);
+
+        var result = await bindu.Bindufy(TestConfig(), TestHandler);
+
+        Assert.Equal("agent-0001", result.AgentId);
+        Assert.Equal("did:bindu:test", result.Did);
+        Assert.Equal("http://localhost:3773", result.AgentUrl);
+
+        // The fake core must have received a well-formed registration.
+        var request = core.LastRegisterRequest;
+        Assert.NotNull(request);
+        Assert.Matches(@"^localhost:\d+$", request!.GrpcCallbackAddress);
+
+        using var doc = JsonDocument.Parse(request.ConfigJson);
+        var root = doc.RootElement;
+        Assert.Equal("flow-agent", root.GetProperty("name").GetString());
+        Assert.Equal("agent", root.GetProperty("kind").GetString());
+    }
+
+    [Fact]
+    public async Task Bindufy_Throws_When_Core_Rejects_Registration() {
+        await using var core = await FakeBinduCore.StartAsync();
+        core.RegisterSucceeds = false;
+        core.RegisterError = "duplicate agent name";
+
+        using var bindu = new BinduAgent(new NoOpCoreLauncher(), core.Address);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bindu.Bindufy(TestConfig(), TestHandler));
+        Assert.Contains("duplicate agent name", ex.Message);
+    }
+
+    [Fact]
+    public async Task Dispose_Unregisters_Agent_With_The_Core() {
+        await using var core = await FakeBinduCore.StartAsync();
+        var bindu = new BinduAgent(new NoOpCoreLauncher(), core.Address);
+
+        var result = await bindu.Bindufy(TestConfig(), TestHandler);
+
+        bindu.Dispose();
+
+        Assert.Equal("agent-0001", core.LastUnregisterRequest?.AgentId);
+    }
+
+    [Fact]
+    public async Task Dispose_Async_Unregisters_Agent_With_The_Core() {
+        await using var core = await FakeBinduCore.StartAsync();
+        await using var bindu = new BinduAgent(new NoOpCoreLauncher(), core.Address);
+
+        var result = await bindu.Bindufy(TestConfig(), TestHandler);
+        await bindu.DisposeAsync();
+
+        Assert.Equal("agent-0001", core.LastUnregisterRequest?.AgentId);
+    }
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/BinduAgentLifecycleTests.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/BinduAgentLifecycleTests.cs
@@ -1,0 +1,24 @@
+using Bindu.Sdk;
+
+namespace Bindu.Sdk.Tests;
+
+public class BinduAgentLifecycleTests {
+    [Fact]
+    public void Dispose_Before_Bindufy_Does_Not_Throw() {
+        using var bindu = new BinduAgent();
+        bindu.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_Can_Be_Called_Twice() {
+        var bindu = new BinduAgent();
+        bindu.Dispose();
+        bindu.Dispose();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_Before_Bindufy_Does_Not_Throw() {
+        await using var bindu = new BinduAgent();
+        await bindu.DisposeAsync();
+    }
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/BinduResponseTests.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/BinduResponseTests.cs
@@ -1,0 +1,31 @@
+using Bindu.Sdk;
+
+namespace Bindu.Sdk.Tests;
+
+public class BinduResponseTests {
+    [Fact]
+    public void Defaults_Are_Empty() {
+        var response = new BinduResponse();
+
+        Assert.Equal("", response.Content);
+        Assert.Equal("", response.State);
+        Assert.Equal("", response.Prompt);
+        Assert.NotNull(response.Metadata);
+        Assert.Empty(response.Metadata);
+    }
+
+    [Fact]
+    public void Properties_Are_Settable() {
+        var response = new BinduResponse {
+            Content = "Hello!",
+            State = "input-required",
+            Prompt = "Which topic?",
+            Metadata = { ["source"] = "test" }
+        };
+
+        Assert.Equal("Hello!", response.Content);
+        Assert.Equal("input-required", response.State);
+        Assert.Equal("Which topic?", response.Prompt);
+        Assert.Equal("test", response.Metadata["source"]);
+    }
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/CoreLauncherTests.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/CoreLauncherTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Bindu.Sdk.Tests;
+
+public class CoreLauncherTests {
+    [Fact]
+    public async Task WaitForPortAsync_Completes_When_Port_Is_Open() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            // Should return promptly because something is already listening.
+            await CoreLauncher.WaitForPortAsync(port, timeoutMs: 5000);
+        }
+        finally {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task WaitForPortAsync_Throws_Timeout_When_Port_Never_Opens() {
+        // Grab a free port by binding and releasing it.
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var freePort = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+            CoreLauncher.WaitForPortAsync(freePort, timeoutMs: 1500));
+
+        Assert.Contains(freePort.ToString(), ex.Message);
+    }
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/FakeBinduCore.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/FakeBinduCore.cs
@@ -1,0 +1,151 @@
+using Bindu.Grpc;
+using Grpc.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using static Bindu.Grpc.BinduService;
+
+namespace Bindu.Sdk.Tests;
+
+/// <summary>
+/// An in-process stand-in for the Bindu Python core. Hosts the <c>BinduService</c>
+/// gRPC contract on a dynamically assigned port so tests never touch the real core.
+/// </summary>
+public sealed class FakeBinduCore : IAsyncDisposable {
+    private readonly WebApplication _app;
+
+    /// <summary>Captures the most recent registration request the SDK sent.</summary>
+    public RegisterAgentRequest? LastRegisterRequest { get; private set; }
+
+    /// <summary>Captures the most recent unregister request the SDK sent.</summary>
+    public UnregisterAgentRequest? LastUnregisterRequest { get; private set; }
+
+    /// <summary>Captures the most recent heartbeat request the SDK sent.</summary>
+    public HeartbeatRequest? LastHeartbeatRequest { get; set; }
+
+    /// <summary>Total number of heartbeat requests received.</summary>
+    public int HeartbeatCount { get; private set; }
+
+    /// <summary>
+    /// When <c>true</c>, the fake core rejects heartbeats with an <c>RpcException</c>
+    /// so the SDK's heartbeat error handling is exercised.
+    /// </summary>
+    public bool RejectHeartbeats { get; set; }
+
+    /// <summary>Whether RegisterAgent should succeed. Set to <c>false</c> to test failure paths.</summary>
+    public bool RegisterSucceeds { get; set; } = true;
+
+    /// <summary>Error text returned when <see cref="RegisterSucceeds"/> is <c>false</c>.</summary>
+    public string RegisterError { get; set; } = "registration rejected by test";
+
+    /// <summary>Agent ID the fake core assigns on successful registration.</summary>
+    public string AgentId { get; set; } = "agent-0001";
+
+    /// <summary>DID the fake core assigns on successful registration.</summary>
+    public string Did { get; set; } = "did:bindu:test";
+
+    /// <summary>A2A URL the fake core assigns on successful registration.</summary>
+    public string AgentUrl { get; set; } = "http://localhost:3773";
+
+    /// <summary>The port the fake core is listening on.</summary>
+    public int Port { get; }
+
+    /// <summary>Base address (including trailing slash) of the fake core.</summary>
+    public string Address => $"http://localhost:{Port}/";
+
+    private FakeBinduCore(WebApplication app, int port) {
+        _app = app;
+        Port = port;
+    }
+
+    /// <summary>
+    /// Starts the fake core on a dynamically assigned free port.
+    /// </summary>
+    public static async Task<FakeBinduCore> StartAsync() {
+        var core = new FakeBinduCorePlaceholder();
+        var builder = WebApplication.CreateBuilder();
+
+        builder.WebHost.ConfigureKestrel(options => {
+            options.Listen(IPAddress.Any, 0, listenOptions => {
+                listenOptions.Protocols = HttpProtocols.Http2;
+            });
+        });
+
+        builder.Services.AddSingleton(core);
+        builder.Services.AddGrpc();
+
+        var app = builder.Build();
+        app.MapGrpcService<FakeBinduCoreService>();
+
+        await app.StartAsync();
+
+        var addressFeature = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
+        var address = addressFeature?.Addresses.FirstOrDefault() ?? throw new InvalidOperationException("No server address");
+        var port = new Uri(address).Port;
+
+        var instance = new FakeBinduCore(app, port);
+        core.Instance = instance;
+        return instance;
+    }
+
+    public async ValueTask DisposeAsync() {
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+    }
+
+    /// <summary>Wiring helper so the gRPC service can reach the owning core instance.</summary>
+    private sealed class FakeBinduCorePlaceholder {
+        public FakeBinduCore? Instance { get; set; }
+    }
+
+    private sealed class FakeBinduCoreService : BinduServiceBase {
+        private readonly FakeBinduCorePlaceholder _core;
+
+        public FakeBinduCoreService(FakeBinduCorePlaceholder core) {
+            _core = core;
+        }
+
+        public override Task<RegisterAgentResponse> RegisterAgent(RegisterAgentRequest request, ServerCallContext context) {
+            var core = _core.Instance!;
+            core.LastRegisterRequest = request;
+            return Task.FromResult(new RegisterAgentResponse {
+                Success = core.RegisterSucceeds,
+                Error = core.RegisterSucceeds ? "" : core.RegisterError,
+                AgentId = core.AgentId,
+                Did = core.Did,
+                AgentUrl = core.AgentUrl
+            });
+        }
+
+        public override Task<HeartbeatResponse> Heartbeat(HeartbeatRequest request, ServerCallContext context) {
+            var core = _core.Instance!;
+            core.LastHeartbeatRequest = request;
+            core.HeartbeatCount++;
+            if (core.RejectHeartbeats) {
+                throw new RpcException(new Status(StatusCode.Unavailable, "core not accepting heartbeats"));
+            }
+            return Task.FromResult(new HeartbeatResponse {
+                Acknowledged = true,
+                ServerTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            });
+        }
+
+        public override Task<UnregisterAgentResponse> UnregisterAgent(UnregisterAgentRequest request, ServerCallContext context) {
+            var core = _core.Instance!;
+            core.LastUnregisterRequest = request;
+            return Task.FromResult(new UnregisterAgentResponse { Success = true });
+        }
+    }
+}
+
+/// <summary>
+/// A <see cref="CoreLauncher"/> stub that never spawns a real core process.
+/// Used to run <see cref="BinduAgent.Bindufy"/> against <see cref="FakeBinduCore"/>.
+/// </summary>
+internal sealed class NoOpCoreLauncher : CoreLauncher {
+    public override Task LaunchBinduServer() => Task.CompletedTask;
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/GrpcClientTests.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/GrpcClientTests.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+
+namespace Bindu.Sdk.Tests;
+
+public class GrpcClientTests {
+    private static AgentConfig TestConfig() => new() {
+        Author = "dev@example.com",
+        Name = "json-agent",
+        Description = "Agent that tests JSON",
+        DeploymentUrl = "http://localhost:9000",
+        ExposeDeployment = true
+    };
+
+    private static async Task<(GrpcServer server, GrpcClient client)> CreateClientAsync(FakeBinduCore core) {
+        // A real callback server so the registration carries a real callback address.
+        var server = new GrpcServer(0);
+        await server.StartServerAsync(_ => Task.FromResult<object>("ok"), TestConfig());
+        var client = new GrpcClient(core.Address);
+        client.InitializeBinduClient(server);
+        return (server, client);
+    }
+
+    [Fact]
+    public async Task RegisterAgent_Sends_Correct_Json_And_Callback_Address() {
+        await using var core = await FakeBinduCore.StartAsync();
+        var (server, client) = await CreateClientAsync(core);
+        try {
+            var response = await client.RegisterAgent(TestConfig());
+
+            Assert.NotNull(response);
+            Assert.True(response!.Success);
+            Assert.Equal("agent-0001", response.AgentId);
+
+            var request = core.LastRegisterRequest;
+            Assert.NotNull(request);
+            Assert.Equal($"localhost:{server.GetPort}", request!.GrpcCallbackAddress);
+
+            using var doc = JsonDocument.Parse(request.ConfigJson);
+            var root = doc.RootElement;
+
+            Assert.Equal("dev@example.com", root.GetProperty("author").GetString());
+            Assert.Equal("json-agent", root.GetProperty("name").GetString());
+            Assert.Equal("Agent that tests JSON", root.GetProperty("description").GetString());
+            Assert.Equal("http://localhost:9000", root.GetProperty("deployment").GetProperty("url").GetString());
+            Assert.True(root.GetProperty("deployment").GetProperty("expose").GetBoolean());
+            Assert.Equal("agent", root.GetProperty("kind").GetString());
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+
+    [Fact]
+    public async Task RegisterAgent_Throws_When_Core_Rejects() {
+        await using var core = await FakeBinduCore.StartAsync();
+        core.RegisterSucceeds = false;
+        core.RegisterError = "config validation failed";
+
+        var (server, client) = await CreateClientAsync(core);
+        try {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.RegisterAgent(TestConfig()));
+            Assert.Contains("config validation failed", ex.Message);
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+
+    [Fact]
+    public async Task RegisterAgent_Returns_Null_Before_Initialize() {
+        var client = new GrpcClient("http://localhost:1/");
+        var response = await client.RegisterAgent(TestConfig());
+        Assert.Null(response);
+    }
+
+    [Fact]
+    public async Task UnRegisterAgent_Sends_AgentId_To_Core() {
+        await using var core = await FakeBinduCore.StartAsync();
+        var (server, client) = await CreateClientAsync(core);
+        try {
+            var regResult = new RegistrationResult("agent-0001", "did:bindu:test", "http://localhost:3773");
+
+            var response = client.UnRegisterAgent(regResult);
+
+            Assert.NotNull(response);
+            Assert.True(response!.Success);
+            Assert.Equal("agent-0001", core.LastUnregisterRequest?.AgentId);
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/GrpcServerTests.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/GrpcServerTests.cs
@@ -1,0 +1,207 @@
+using Bindu.Grpc;
+using Grpc.Core;
+using Grpc.Net.Client;
+using System.Net;
+using System.Net.Sockets;
+using static Bindu.Grpc.AgentHandler;
+
+namespace Bindu.Sdk.Tests;
+
+public class GrpcServerTests {
+    private static AgentConfig TestConfig() => new() {
+        Author = "dev@example.com",
+        Name = "test-agent",
+        Description = "Test agent",
+        Version = "1.2.3"
+    };
+
+    private static int FreePort() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    [Fact]
+    public void GetPort_Is_Zero_Before_Start() {
+        var server = new GrpcServer(0);
+        Assert.Equal(0, server.GetPort);
+    }
+
+    [Fact]
+    public async Task Port_Zero_Picks_A_Free_Port() {
+        var server = new GrpcServer(0);
+        await server.StartServerAsync(_ => Task.FromResult<object>("ok"), TestConfig());
+        try {
+            Assert.True(server.GetPort > 0, "Server should have been assigned an ephemeral port");
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Busy_Port_Falls_Back_To_A_Free_Port() {
+        var blocker = new TcpListener(IPAddress.Loopback, 0);
+        blocker.Start();
+        try {
+            var busyPort = ((IPEndPoint)blocker.LocalEndpoint).Port;
+
+            var server = new GrpcServer(busyPort);
+            await server.StartServerAsync(_ => Task.FromResult<object>("ok"), TestConfig());
+            try {
+                Assert.NotEqual(busyPort, server.GetPort);
+                Assert.True(server.GetPort > 0);
+            }
+            finally {
+                server.StopServerAsync();
+            }
+        }
+        finally {
+            blocker.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Free_Port_Is_Used_As_Requested() {
+        var port = FreePort();
+
+        var server = new GrpcServer(port);
+        await server.StartServerAsync(_ => Task.FromResult<object>("ok"), TestConfig());
+        try {
+            Assert.Equal(port, server.GetPort);
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+
+    [Fact]
+    public async Task HandleMessages_Round_Trips_Handler_Result() {
+        var server = new GrpcServer(0);
+        await server.StartServerAsync(
+            messages => Task.FromResult<object>($"Echo: {messages[^1].Content}"),
+            TestConfig());
+        using var channel = GrpcChannel.ForAddress($"http://localhost:{server.GetPort}");
+        var client = new AgentHandlerClient(channel);
+        try {
+            var response = await client.HandleMessagesAsync(new HandleRequest {
+                Messages = { new ChatMessage { Role = "user", Content = "hi there" } }
+            });
+
+            Assert.Equal("Echo: hi there", response.Content);
+            Assert.Equal("", response.State);
+            Assert.True(response.IsFinal);
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+
+    [Fact]
+    public async Task HandleMessages_Maps_BinduResponse_State_Prompt_And_Metadata() {
+        var server = new GrpcServer(0);
+        await server.StartServerAsync(
+            _ => Task.FromResult<object>(new BinduResponse {
+                Content = "Need more info",
+                State = "input-required",
+                Prompt = "Which topic?",
+                Metadata = { ["intent"] = "survey" }
+            }),
+            TestConfig());
+        using var channel = GrpcChannel.ForAddress($"http://localhost:{server.GetPort}");
+        var client = new AgentHandlerClient(channel);
+        try {
+            var response = await client.HandleMessagesAsync(new HandleRequest {
+                Messages = { new ChatMessage { Role = "user", Content = "start" } }
+            });
+
+            Assert.Equal("Need more info", response.Content);
+            Assert.Equal("input-required", response.State);
+            Assert.Equal("Which topic?", response.Prompt);
+            Assert.Equal("survey", response.Metadata["intent"]);
+            Assert.True(response.IsFinal);
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+
+    [Fact]
+    public async Task HandleMessages_Exception_Becomes_RpcException_With_Trailers() {
+        var server = new GrpcServer(0);
+        await server.StartServerAsync(
+            _ => throw new InvalidOperationException("handler exploded"),
+            TestConfig());
+        using var channel = GrpcChannel.ForAddress($"http://localhost:{server.GetPort}");
+        var client = new AgentHandlerClient(channel);
+        try {
+            var ex = await Assert.ThrowsAsync<RpcException>(() =>
+                client.HandleMessagesAsync(new HandleRequest {
+                    Messages = { new ChatMessage { Role = "user", Content = "boom" } }
+                }).ResponseAsync);
+
+            Assert.Equal(StatusCode.Internal, ex.StatusCode);
+            Assert.Equal("handler exploded", ex.Status.Detail);
+            Assert.Equal("InvalidOperationException", ex.Trailers.GetValue("exception-type"));
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+
+    [Fact]
+    public async Task GetCapabilities_Returns_Config_Values() {
+        var server = new GrpcServer(0);
+        await server.StartServerAsync(_ => Task.FromResult<object>("ok"), TestConfig());
+        using var channel = GrpcChannel.ForAddress($"http://localhost:{server.GetPort}");
+        var client = new AgentHandlerClient(channel);
+        try {
+            var caps = await client.GetCapabilitiesAsync(new GetCapabilitiesRequest());
+
+            Assert.Equal("test-agent", caps.Name);
+            Assert.Equal("Test agent", caps.Description);
+            Assert.Equal("1.2.3", caps.Version);
+            Assert.False(caps.SupportsStreaming);
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+
+    [Fact]
+    public async Task GetCapabilities_Defaults_Version_To_0_1_0() {
+        var config = TestConfig();
+        config.Version = null;
+
+        var server = new GrpcServer(0);
+        await server.StartServerAsync(_ => Task.FromResult<object>("ok"), config);
+        using var channel = GrpcChannel.ForAddress($"http://localhost:{server.GetPort}");
+        var client = new AgentHandlerClient(channel);
+        try {
+            var caps = await client.GetCapabilitiesAsync(new GetCapabilitiesRequest());
+            Assert.Equal("0.1.0", caps.Version);
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+
+    [Fact]
+    public async Task HealthCheck_Reports_Healthy() {
+        var server = new GrpcServer(0);
+        await server.StartServerAsync(_ => Task.FromResult<object>("ok"), TestConfig());
+        using var channel = GrpcChannel.ForAddress($"http://localhost:{server.GetPort}");
+        var client = new AgentHandlerClient(channel);
+        try {
+            var health = await client.HealthCheckAsync(new HealthCheckRequest());
+
+            Assert.True(health.Healthy);
+            Assert.Equal("test-agent is healthy", health.Message);
+        }
+        finally {
+            server.StopServerAsync();
+        }
+    }
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/HeartbeatServiceTests.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/HeartbeatServiceTests.cs
@@ -1,0 +1,95 @@
+using Bindu.Grpc;
+using Grpc.Net.Client;
+using static Bindu.Grpc.BinduService;
+
+namespace Bindu.Sdk.Tests;
+
+public class HeartbeatServiceTests {
+    [Fact]
+    public async Task Heartbeat_Is_Sent_To_Core_With_AgentId() {
+        await using var core = await FakeBinduCore.StartAsync();
+        var channel = GrpcChannel.ForAddress(core.Address);
+        var client = new BinduServiceClient(channel);
+
+        var regInfo = new RegistrationResult("agent-0001", "did:bindu:test", "http://localhost:3773");
+        // Fire the first heartbeat almost immediately so the test doesn't wait 30s.
+        var heartbeat = new HeartbeatService(regInfo, client, dueTime: TimeSpan.FromMilliseconds(200), period: TimeSpan.FromSeconds(30));
+        try {
+            await WaitForHeartbeatAsync(core, TimeSpan.FromSeconds(5));
+
+            Assert.NotNull(core.LastHeartbeatRequest);
+            Assert.Equal("agent-0001", core.LastHeartbeatRequest!.AgentId);
+            Assert.True(core.LastHeartbeatRequest.Timestamp > 0);
+        }
+        finally {
+            heartbeat.CleanUp();
+            channel.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task CleanUp_Stops_Heartbeats() {
+        await using var core = await FakeBinduCore.StartAsync();
+        var channel = GrpcChannel.ForAddress(core.Address);
+        var client = new BinduServiceClient(channel);
+
+        var regInfo = new RegistrationResult("agent-0002", "did:bindu:test", "http://localhost:3773");
+        var heartbeat = new HeartbeatService(regInfo, client, dueTime: TimeSpan.FromMilliseconds(100), period: TimeSpan.FromMilliseconds(100));
+        try {
+            // Let at least one heartbeat through, then stop the timer.
+            await WaitForHeartbeatAsync(core, TimeSpan.FromSeconds(5));
+            heartbeat.CleanUp();
+
+            // Absorb any in-flight callback, then verify no further heartbeats arrive.
+            await Task.Delay(300);
+            var countAfterFirstDrain = core.HeartbeatCount;
+            await Task.Delay(400);
+
+            Assert.Equal(countAfterFirstDrain, core.HeartbeatCount);
+        }
+        finally {
+            heartbeat.CleanUp();
+            channel.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Rejected_Heartbeat_Is_Handled_Without_Throwing() {
+        await using var core = await FakeBinduCore.StartAsync();
+        core.RejectHeartbeats = true;
+        var channel = GrpcChannel.ForAddress(core.Address);
+        var client = new BinduServiceClient(channel);
+
+        var regInfo = new RegistrationResult("agent-0003", "did:bindu:test", "http://localhost:3773");
+        var heartbeat = new HeartbeatService(regInfo, client, dueTime: TimeSpan.FromMilliseconds(200), period: TimeSpan.FromSeconds(30));
+        try {
+            // A rejected heartbeat must be caught and logged by the SDK, never surfaced.
+            await WaitForAttemptedHeartbeatAsync(core, TimeSpan.FromSeconds(5));
+            Assert.True(core.HeartbeatCount > 0);
+        }
+        finally {
+            heartbeat.CleanUp();
+            channel.Dispose();
+        }
+    }
+
+    private static async Task WaitForHeartbeatAsync(FakeBinduCore core, TimeSpan timeout) {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline) {
+            if (core.LastHeartbeatRequest is not null) {
+                return;
+            }
+            await Task.Delay(50);
+        }
+    }
+
+    private static async Task WaitForAttemptedHeartbeatAsync(FakeBinduCore core, TimeSpan timeout) {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline) {
+            if (core.HeartbeatCount > 0) {
+                return;
+            }
+            await Task.Delay(50);
+        }
+    }
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/RegistrationResultTests.cs
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/RegistrationResultTests.cs
@@ -1,0 +1,14 @@
+using Bindu.Sdk;
+
+namespace Bindu.Sdk.Tests;
+
+public class RegistrationResultTests {
+    [Fact]
+    public void Constructor_Assigns_Values() {
+        var result = new RegistrationResult("agent-123", "did:bindu:abc", "http://localhost:3773");
+
+        Assert.Equal("agent-123", result.AgentId);
+        Assert.Equal("did:bindu:abc", result.Did);
+        Assert.Equal("http://localhost:3773", result.AgentUrl);
+    }
+}

--- a/sdks/csharp/tests/Bindu.Sdk.Tests/coverlet.runsettings
+++ b/sdks/csharp/tests/Bindu.Sdk.Tests/coverlet.runsettings
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <!-- Measure only the SDK; exclude the generated proto/gRPC code in Bindu.Grpc -->
+          <Include>[Bindu.Sdk]*</Include>
+          <Exclude>[Bindu.Sdk]Bindu.Grpc.*</Exclude>
+          <ExcludeByAttribute>System.CodeDom.Compiler.GeneratedCodeAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary

- **Problem**: Bindu could turn agents written in TypeScript and Kotlin into A2A-compliant
  microservices, but .NET/C# developers had no supported SDK, so a large ecosystem
  (Semantic Kernel, Microsoft.Extensions.AI, plain C# agents) had no path to Bindu.
- **Why it matters**: A C# SDK gives .NET agents identical DID identity, auth, x402
  payments, and A2A protocol support against the same Bindu core as the TS/Kotlin SDKs,
  keeping agent identity and protocol consistent across languages.
- **What changed**: Added `sdks/csharp/` — `Bindu.Sdk` with a one-call `Bindufy()` API
  (core discovery/launch, gRPC registration, callback server, 30s heartbeat, clean
  shutdown), the shared `agent_handler.proto` gRPC contract, full XML docs, a README, and
  a 31-test xUnit suite that runs in-process against a fake core (no Python/network needed).
- **What did NOT change** (scope boundary): The Python Bindu core, the TypeScript/Kotlin
  SDKs, and all existing code were untouched (25 new files, all under `sdks/csharp/`).
  Streaming (`HandleMessagesStream`) is intentionally not implemented — matches the TS/Kotlin
  SDKs. The `Skills` config field is not yet transmitted during registration.

## Change Type (select all that apply)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [x] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Server / API endpoints
- [ ] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [ ] CLI / utilities
- [x] Tests
- [x] Documentation
- [ ] CI/CD / infra

> Note: this PR adds a new area not listed above — `sdks/csharp/` (new language SDK).

## Linked Issue/PR

- Closes #
- Related #

## User-Visible / Behavior Changes
New SDK only — no changes to existing users (for them: `None`).

- .NET developers can now write an agent in plain C# and call `Bindufy(config, handler)`
  to get DID, auth, x402, and A2A protocol support.
- SDK defaults: callback port auto-picked (`GrpcCallbackPort = 0`, falls back to a free
  port if busy), `DeploymentUrl = http://localhost:3773`, `ExposeDeployment = false`,
  `Version = 0.1.0`.


## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/credentials handling changed? (`No`)
- New/changed network calls? (`Yes`) — the SDK launches the Bindu core as a local child
  process and talks to it over localhost gRPC (register/heartbeat/unregister on :3774),
  hosts a local gRPC callback server (dynamic port) for the core to deliver tasks, and the
  core exposes the A2A server on :3773. All on the local machine by default.
- Database schema/migration changes? (`No`)
- Authentication/authorization changes? (`No`)
- **If any `Yes`, explain risk + mitigation**: The SDK's callback gRPC server binds
  `IPAddress.Any` (all interfaces), not just loopback. The port is dynamic/ephemeral and
  the address is only shared with the locally launched core. Mitigation: consider
  restricting the bind to loopback in a follow-up before broader release.

## Verification

### Environment

- OS: Windows
- .NET SDK: 10.0.302
- Storage backend: N/A (tests use an in-process fake core)
- Scheduler backend: N/A

### Steps to Test

1. `cd sdks/csharp`
2. `dotnet test`
3. Observe all tests pass
4. Alternatively, there is another test process described in the readme which involves creating a new console test app that echos back the users prompt.

### Expected Behavior
- All 31 xUnit tests pass (registration, heartbeat, gRPC client/server, core launcher,
  agent lifecycle, response mapping, fake-core integration).

>For the alternate test process
- End-to-end: the echo test app returns the user's prompt with an echo message appended,
  and the A2A port responds to `messages/send` / `messages/get`.

### Actual Behavior

- `Passed! - Failed: 0, Passed: 31, Skipped: 0, Total: 31, Duration: 54 s`

## Evidence (attach at least one)

- [x] Test output / logs (`dotnet test` — 31/31 passed on the squashed branch)
<img width="807" height="374" alt="Screenshot 2026-08-13 022738" src="https://github.com/user-attachments/assets/52457ba7-d836-4e38-8437-58ecd3948c88" />

- [ ] Failing test before + passing after (N/A — new code, no prior tests existed)
- [x] Screenrecording (Postman `messages/send` + `task/get` exchanges from the echo test app are available)
https://github.com/user-attachments/assets/f0f95708-0285-48be-8a2a-ac2251bf037f



## Human Verification (required)

What you personally verified (not just CI):
- **Verified scenarios**: Full unit + in-process integration suite runs green on the
  squashed commit (`dotnet test`: 31 passed, 0 failed); clean build of `Bindu.Sdk` and the
  test project on .NET 10. Full end-to-end loop verified with a small ConsoleApp echo test
  app (launches the real Bindu core, registers the agent, returns the user's prompt with an
  echo message appended).
- **Edge cases checked**: callback port in use → automatic fallback to a free port; core
  startup timeout handling; heartbeat failure logging; graceful shutdown paths.
- **What you did NOT verify**: NuGet packaging/publishing.

## Compatibility / Migration

- Backward compatible? (`Yes`) — additive only; no existing files modified.
- Config/env changes? (`No`) — new SDK requires the .NET 10 SDK and (at runtime) the
  Bindu Python core, as documented in the SDK README.
- Database migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single commit or delete
  `sdks/csharp/` — nothing else depends on it.
- Files/config to restore: none (no existing files were touched).
- Known bad symptoms reviewers should watch for: none expected — isolated new code.

## Risks and Mitigations
- **Risk**: The callback gRPC server binds `IPAddress.Any` instead of loopback.
  - **Mitigation**: Dynamic ephemeral port; address only shared with the locally launched
    core; plan to restrict to loopback in a follow-up.
- **Risk**: `CoreLauncher` uses a fixed gRPC port (3774), so two SDK agents on one machine
  would contend for it.
  - **Mitigation**: Port map documented in the README; making the port configurable is
    follow-up work.


## Checklist

- [x] Tests pass — `dotnet test` (31/31). Note: `uv run pytest` is N/A — this PR changes no Python code.
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`) — run before opening; not executed in this session. 
>Note: `uv run pre-commit run --files $(git ls-files sdks/csharp/)` ran and passed
<img width="872" height="223" alt="Screenshot 2026-08-13 021106" src="https://github.com/user-attachments/assets/c8611910-d675-405c-98f5-353ed7caead9" />

- [x] Documentation updated — SDK README ships with the PR.
- [x] Security impact assessed
- [x] Human verification completed
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a C# SDK for creating, configuring, registering, and managing Bindu agents.
  * Supports synchronous and asynchronous cleanup, automatic core startup, health reporting, capabilities, and heartbeat monitoring.
  * Added structured responses with content, state transitions, prompts, and metadata.
  * Added gRPC communication for agent registration, task handling, and unregistration.
* **Documentation**
  * Added comprehensive C# SDK setup, usage, API, lifecycle, troubleshooting, and testing guidance.
* **Tests**
  * Added broad coverage for registration, messaging, lifecycle management, heartbeats, responses, networking, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->