### PR TITLE
feat: add OrcaRouter as a second planner LLM provider

### DIFF
--- a/docs/GATEWAY.md
+++ b/docs/GATEWAY.md
@@ -119,6 +119,13 @@ decide.
   planner LLM. Sign up at [openrouter.ai](https://openrouter.ai), add a
   few dollars of credit, and copy the key from the *API* section. It
   looks like `sk-or-v1-<long random string>`.
+- **…or an OrcaRouter API key.** [OrcaRouter](https://www.orcarouter.ai)
+  is an alternative OpenAI-compatible gateway the gateway can use for
+  the planner instead of OpenRouter. Sign up and grab a key from the
+  console; it looks like `sk-orca-<long random string>`. Throughout
+  this guide, set either `OPENROUTER_API_KEY` or `ORCAROUTER_API_KEY` —
+  whichever gateway you configure — and reference models as
+  `openrouter/<model-id>` or `orcarouter/<model-id>`.
 - **A Supabase project**. Supabase is a hosted Postgres service with a
   free tier. The gateway uses it to store conversation history between
   turns. Create a project at [supabase.com](https://supabase.com), then
@@ -184,6 +191,8 @@ GATEWAY_API_KEY=<paste generated token>
 
 # The planner AI
 OPENROUTER_API_KEY=sk-or-v1-<your key>
+# …or use OrcaRouter instead (whichever gateway you pick):
+# ORCAROUTER_API_KEY=sk-orca-<your key>
 
 # Gateway listens here
 GATEWAY_PORT=3774
@@ -343,7 +352,7 @@ You now have three things talking to each other:
 ┌─────────────┐   bearer-auth POST /plan   ┌────────────────────┐
 │   curl      │ ─────────────────────────▶ │  Bindu Gateway     │
 │             │ ◀───  SSE event stream ─── │  port 3774         │
-└─────────────┘                             │  (planner LLM ───▶ OpenRouter)
+└─────────────┘                             │  (planner LLM ───▶ OpenRouter / OrcaRouter)
                                             │  (sessions ─────▶ Supabase)
                                             └──┬─────────────────┘
                                                │ A2A (JSON-RPC)
@@ -516,18 +525,23 @@ permission:
 # System prompt body — the planner's own instructions.
 ```
 
+(The `model` value can be any supported provider/model pair — e.g.
+`openrouter/anthropic/claude-sonnet-4.6` or
+`orcarouter/anthropic/claude-opus-4.7`.)
+
 The body is the system prompt. On each `/plan` request, the gateway:
 
 1. Reads the planner's system prompt.
 2. Adds the user's question as a new "user" message.
 3. Builds the tool list from your `agents[]` catalog.
-4. Hands all of that to the OpenRouter API with `streamText()`.
+4. Hands all of that to the configured gateway (OpenRouter or OrcaRouter)
+   with `streamText()`.
 5. Streams the output back to you as SSE.
 
-Inside OpenRouter, Claude (or whichever model you configured) runs its
-agentic loop — text → tool call → tool result → more text → another tool
-call → final text. The gateway's job is just to execute the tool calls
-against your real agents and plumb the results back.
+Inside OpenRouter or OrcaRouter, Claude (or whichever model you configured)
+runs its agentic loop — text → tool call → tool result → more text →
+another tool call → final text. The gateway's job is just to execute the
+tool calls against your real agents and plumb the results back.
 
 Open `gateway/agents/planner.md` and read the body. That's the instructions
 the coordinator AI follows. You can edit it and the next plan will see the
@@ -978,7 +992,8 @@ If you're moving this past localhost:
    secret. Distribute via your usual secret-management tool, not
    `.env.local`.
 3. **Pin the planner model.** Add `model:
-   openrouter/anthropic/claude-sonnet-4.6` (or whichever you want) to
+   openrouter/anthropic/claude-sonnet-4.6` (or whichever you want,
+   e.g. `orcarouter/anthropic/claude-opus-4.7`) to
    `gateway/agents/planner.md` frontmatter so upgrades are explicit.
 4. **Set `max_steps`** on your `/plan` requests so a runaway planner
    can't loop 100 times at your expense.
@@ -995,7 +1010,8 @@ If you're moving this past localhost:
   Anthropic's docs say tool descriptions are "by far the most important
   factor in tool performance" — 3-4 sentences on intent, inputs,
   outputs, and when to use it.
-- Agent returns "User not found": your `OPENROUTER_API_KEY` is invalid
+- Agent returns "User not found": your `OPENROUTER_API_KEY` (or
+  `ORCAROUTER_API_KEY`, whichever gateway you configured) is invalid
   or out of credit.
 - `event: error` with "Invalid Responses API request": you're on an
   older gateway commit. `git pull`.

--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -16,7 +16,7 @@ SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOi...
 # must then also update their Authorization header.
 GATEWAY_API_KEY=dev-key-change-me
 
-# Planner LLM — OpenRouter (single supported provider)
+# Planner LLM — OpenRouter (default provider)
 #
 # The gateway talks to every model through OpenRouter's OpenAI-compat
 # API. Model IDs take the form "openrouter/<openrouter-model-id>",
@@ -29,6 +29,17 @@ GATEWAY_API_KEY=dev-key-change-me
 # request (see src/provider/index.ts). OpenAI/Grok/DeepSeek cache
 # automatically; Anthropic/Gemini caching is enabled by the marker.
 OPENROUTER_API_KEY=sk-or-v1-...
+
+# Planner LLM — OrcaRouter (alternative provider)
+#
+# OrcaRouter (https://www.orcarouter.ai) is a second OpenAI-compatible
+# gateway. Set ORCAROUTER_API_KEY instead of (or in addition to)
+# OPENROUTER_API_KEY and reference models as "orcarouter/<model-id>",
+# e.g. "orcarouter/anthropic/claude-opus-4.7" or
+# "orcarouter/orcarouter/fusion-flash". Default base URL is filled in
+# by the provider layer; override via gateway.config.json under
+# provider.orcarouter.baseURL.
+ORCAROUTER_API_KEY=sk-orca-...
 
 # Optional: comma-separated fallback models for OpenRouter routing.
 # When the primary model errors (rate limit, upstream down, etc.)

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -21,7 +21,7 @@ This README is the **operator's reference** — configuration, troubleshooting, 
 ```bash
 cd gateway
 npm install
-cp .env.example .env.local    # fill in GATEWAY_API_KEY, OPENROUTER_API_KEY
+cp .env.example .env.local    # fill in GATEWAY_API_KEY and OPENROUTER_API_KEY (or ORCAROUTER_API_KEY)
 npm run dev
 ```
 
@@ -84,7 +84,10 @@ For a runnable multi-agent walkthrough, see [`docs/GATEWAY.md`](../docs/GATEWAY.
 | Variable | Purpose |
 |---|---|
 | `GATEWAY_API_KEY` | Bearer token that callers must send |
-| `OPENROUTER_API_KEY` | Planner LLM provider |
+| `OPENROUTER_API_KEY` | Planner LLM provider (default) |
+| `ORCAROUTER_API_KEY` | Planner LLM provider (alternative — use either, see below) |
+
+The gateway's planner LLM runs on an OpenAI-compatible gateway. By default that's OpenRouter — reference models as `openrouter/<model-id>` (e.g. `openrouter/anthropic/claude-sonnet-4.6`). Set `ORCAROUTER_API_KEY` instead to route the planner through OrcaRouter — reference models as `orcarouter/<model-id>` (e.g. `orcarouter/anthropic/claude-opus-4.7`). Both are OpenAI-compatible, so the same `@ai-sdk/openai` client with a baseURL override covers either; OpenRouter additionally gets the gateway's `cache_control` + fallback-model injection, OrcaRouter gets a plain chat-completions body.
 
 The gateway used to require `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` for session storage. Those are no longer used — sessions live in-memory, the calling client owns durable history.
 
@@ -255,7 +258,7 @@ gateway/
 │   ├── config/               # hierarchical config loader
 │   ├── auth/                 # credential keystore
 │   ├── permission/           # wildcard ruleset evaluator
-│   ├── provider/             # AI SDK handle lookup (OpenRouter)
+│   ├── provider/             # AI SDK handle lookup (OpenRouter, OrcaRouter)
 │   ├── recipe/               # markdown recipe loader
 │   ├── agent/                # agent.md loader
 │   ├── tool/                 # Tool.define + registry + load_recipe

--- a/gateway/src/api/health-route.ts
+++ b/gateway/src/api/health-route.ts
@@ -45,8 +45,8 @@ export interface PlannerInfo {
    *  agent is configured or the agent has no model set. */
   readonly model: string | null
   /** Provider segment (the bit before the first ``/``). Today that's
-   *  always ``openrouter`` — the gateway uses OpenRouter exclusively
-   *  for LLM access. */
+   *  ``openrouter`` or ``orcarouter`` — the gateway uses OpenAI-
+   *  compatible gateways exclusively for LLM access. */
   readonly provider: string | null
   /** Upstream model id the provider understands (everything after the
    *  provider segment). For OpenRouter-proxied Anthropic models this

--- a/gateway/src/config/loader.ts
+++ b/gateway/src/config/loader.ts
@@ -112,7 +112,7 @@ function envOverrides(base: Record<string, any>): Record<string, any> {
   // .env.local is harmless (they're ignored), but they no longer wire
   // anything. Stateless gateway, see config/schema.ts §SessionConfig.
 
-  // OpenRouter is the single supported LLM provider — see
+  // OpenRouter is the default LLM provider — see
   // src/provider/index.ts for the rationale. The env hook wires
   // OpenRouter's OpenAI-compatible API (baseURL filled in by the
   // provider layer if not explicitly set in a config file).
@@ -121,6 +121,17 @@ function envOverrides(base: Record<string, any>): Record<string, any> {
     out.provider.openrouter = {
       ...out.provider.openrouter,
       apiKey: process.env.OPENROUTER_API_KEY,
+    }
+  }
+
+  // OrcaRouter is a second OpenAI-compatible gateway — see
+  // src/provider/index.ts. Same shape: apiKey goes into
+  // provider.orcarouter, baseURL defaults to OrcaRouter's API.
+  if (process.env.ORCAROUTER_API_KEY) {
+    out.provider = out.provider ?? {}
+    out.provider.orcarouter = {
+      ...out.provider.orcarouter,
+      apiKey: process.env.ORCAROUTER_API_KEY,
     }
   }
 

--- a/gateway/src/provider/index.ts
+++ b/gateway/src/provider/index.ts
@@ -5,22 +5,28 @@ import { Service as ConfigService, type Config } from "../config"
 import type { z } from "zod"
 
 /**
- * Provider service — OpenRouter-only.
+ * Provider service — OpenAI-compatible gateways (OpenRouter, OrcaRouter).
  *
- * Looks up an AI-SDK LanguageModel handle by ``"openrouter/<modelId>"``
- * where ``modelId`` is whatever OpenRouter publishes for that model
- * (for example ``openai/gpt-4o-mini`` or
- * ``anthropic/claude-sonnet-4.6``).
+ * Looks up an AI-SDK LanguageModel handle by ``"<provider>/<modelId>"``:
  *
- * Why a single provider: we ship every agent (gateway planner + the
- * fleet) on OpenRouter. Supporting the Anthropic or OpenAI SDKs
+ *   - ``openrouter/<modelId>`` — ``modelId`` is whatever OpenRouter
+ *     publishes for that model (for example ``openai/gpt-4o-mini`` or
+ *     ``anthropic/claude-sonnet-4.6``).
+ *   - ``orcarouter/<modelId>`` — ``modelId`` is whatever OrcaRouter
+ *     publishes for that model (for example ``anthropic/claude-opus-4.7``
+ *     or ``orcarouter/fusion-flash``).
+ *
+ * Why two OpenAI-compatible gateways instead of the full SDK matrix:
+ * we ship every agent (gateway planner + the fleet) on an
+ * OpenAI-compatible gateway. Supporting the Anthropic or OpenAI SDKs
  * directly was optionality nobody used and added two env vars and a
- * dependency we could drop. OpenRouter exposes an OpenAI-compatible
- * API, so a single ``@ai-sdk/openai`` client with a baseURL override
- * covers every model on the platform.
+ * dependency we could drop. Both OpenRouter and OrcaRouter expose an
+ * OpenAI-compatible API, so a single ``@ai-sdk/openai`` client with a
+ * baseURL override covers every model on either platform.
  *
- * On every outbound request the gateway's fetch wrapper injects two
- * OpenRouter-specific request-body fields:
+ * On every outbound request to OpenRouter the gateway's fetch wrapper
+ * injects two OpenRouter-specific request-body fields (OrcaRouter gets
+ * a clean chat-completions body — those fields are OpenRouter-only):
  *
  *   - ``cache_control: { type: "ephemeral" }`` — enables OpenRouter's
  *     automatic-breakpoint prompt caching. Ignored by providers that
@@ -36,10 +42,11 @@ import type { z } from "zod"
  * a model string, give me a model handle the AI SDK can stream.
  */
 
-const SUPPORTED_PROVIDERS = ["openrouter"] as const
+const SUPPORTED_PROVIDERS = ["openrouter", "orcarouter"] as const
 export type ProviderId = (typeof SUPPORTED_PROVIDERS)[number]
 
 const OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+export const ORCAROUTER_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1"
 
 export function parseModelId(s: string): { providerId: ProviderId; modelId: string } {
   const slash = s.indexOf("/")
@@ -159,8 +166,8 @@ export const layer = Layer.effect(
       const providerCfg = providers[providerId] as
         | { apiKey?: string; baseURL?: string; fallbackModels?: readonly string[] }
         | undefined
-      // OpenRouter's API is OpenAI-compatible — one @ai-sdk/openai
-      // client pointed at OpenRouter's baseURL handles every model.
+      // Both providers are OpenAI-compatible — one @ai-sdk/openai
+      // client pointed at the provider's baseURL handles every model.
       //
       // IMPORTANT: use ``.chat()`` explicitly, not the default callable.
       // ``@ai-sdk/openai`` v3 defaults to OpenAI's newer Responses API
@@ -169,12 +176,18 @@ export const layer = Layer.effect(
       // callable produces "Invalid Responses API request" from
       // OpenRouter at the first LLM call.
       //
-      // The ``fetch`` wrapper injects cache_control + fallback models.
-      // See ``injectCacheControl`` + ``injectFallbackModels`` above.
+      // The OpenRouter fetch wrapper injects cache_control + fallback
+      // models — both OpenRouter-specific fields. OrcaRouter gets a
+      // plain client so we don't send OpenRouter-only body fields to a
+      // different gateway.
+      const defaultBaseURL =
+        providerId === "orcarouter" ? ORCAROUTER_DEFAULT_BASE_URL : OPENROUTER_DEFAULT_BASE_URL
       const p = createOpenAI({
         apiKey: providerCfg?.apiKey,
-        baseURL: providerCfg?.baseURL ?? OPENROUTER_DEFAULT_BASE_URL,
-        fetch: openrouterFetch({ fallbackModels: providerCfg?.fallbackModels }),
+        baseURL: providerCfg?.baseURL ?? defaultBaseURL,
+        ...(providerId === "openrouter"
+          ? { fetch: openrouterFetch({ fallbackModels: providerCfg?.fallbackModels }) }
+          : {}),
       })
       return p.chat(modelId)
     }

--- a/gateway/tests/provider/openrouter-body-injection.test.ts
+++ b/gateway/tests/provider/openrouter-body-injection.test.ts
@@ -15,7 +15,12 @@
  */
 
 import { describe, it, expect } from "vitest"
-import { injectCacheControl, injectFallbackModels } from "../../src/provider"
+import {
+  ORCAROUTER_DEFAULT_BASE_URL,
+  injectCacheControl,
+  injectFallbackModels,
+  parseModelId,
+} from "../../src/provider"
 
 describe("injectCacheControl — OpenRouter prompt-caching marker", () => {
   it("adds cache_control at the top level of a chat-completions body", () => {
@@ -123,5 +128,36 @@ describe("injectFallbackModels — OpenRouter fail-over routing", () => {
     const body = JSON.stringify({ model: "primary/x", messages: [] })
     const out = JSON.parse(injectFallbackModels(body, ["fallback/y"]))
     expect(out.model).toBe("primary/x")
+  })
+})
+
+describe("parseModelId — supported providers", () => {
+  it("accepts openrouter model ids", () => {
+    expect(parseModelId("openrouter/anthropic/claude-sonnet-4.6")).toEqual({
+      providerId: "openrouter",
+      modelId: "anthropic/claude-sonnet-4.6",
+    })
+  })
+
+  it("accepts orcarouter model ids (multi-segment model id preserved)", () => {
+    expect(parseModelId("orcarouter/anthropic/claude-opus-4.7")).toEqual({
+      providerId: "orcarouter",
+      modelId: "anthropic/claude-opus-4.7",
+    })
+  })
+
+  it("accepts orcarouter's own model family", () => {
+    expect(parseModelId("orcarouter/orcarouter/fusion-flash")).toEqual({
+      providerId: "orcarouter",
+      modelId: "orcarouter/fusion-flash",
+    })
+  })
+
+  it("rejects an unsupported provider", () => {
+    expect(() => parseModelId("unknown/model")).toThrow(/unsupported provider "unknown"/)
+  })
+
+  it("defaults orcarouter to the OrcaRouter API base URL", () => {
+    expect(ORCAROUTER_DEFAULT_BASE_URL).toBe("https://api.orcarouter.ai/v1")
   })
 })


### PR DESCRIPTION
## Summary

- **Problem**: The gateway's planner LLM is OpenRouter-only — `SUPPORTED_PROVIDERS = ["openrouter"]`. Operators who want to route the planner through a different OpenAI-compatible gateway have to override `provider.openrouter.baseURL`, which mislabels the provider in `/health` and in model ids.
- **Why it matters**: [OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model gateway exposing 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Wiring it in as a first-class provider lets operators run the planner on OrcaRouter the same way they run it on OpenRouter today.
- **What changed**: Added `orcarouter` as a second supported provider in the gateway provider layer, mirroring the existing OpenRouter wiring:
  - `gateway/src/provider/index.ts`: `SUPPORTED_PROVIDERS` now includes `orcarouter`; `parseModelId` accepts `orcarouter/<model-id>`; the provider client defaults to OrcaRouter's base URL (`https://api.orcarouter.ai/v1`) and sends a plain chat-completions body — the OpenRouter-specific `cache_control`/fallback-model injection stays OpenRouter-only.
  - `gateway/src/config/loader.ts`: `ORCAROUTER_API_KEY` env var wires into `provider.orcarouter.apiKey`.
  - `gateway/.env.example`, `gateway/README.md`, `docs/GATEWAY.md`: documented the alternative provider and model-id format.
  - `gateway/src/api/health-route.ts`: provider-segment doc comment updated.
  - `gateway/tests/provider/openrouter-body-injection.test.ts`: 5 new tests covering `parseModelId` (both providers) and the OrcaRouter default base URL.
- **What did NOT change**: The OpenRouter path is untouched — OpenRouter stays the default planner provider, and its `cache_control` + fallback-model injection applies only to OpenRouter requests. No Python/core changes.

I'm an engineer on the OrcaRouter team.

## Change Type (select all that apply)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [x] Tests
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Server / API endpoints
- [ ] Extensions (DID, x402, etc.)
- [ ] Storage backends
- [ ] Scheduler backends
- [ ] Observability / monitoring
- [ ] Authentication / authorization
- [ ] CLI / utilities
- [x] Tests
- [x] Documentation
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-Visible / Behavior Changes

Setting `ORCAROUTER_API_KEY` (instead of, or in addition to, `OPENROUTER_API_KEY`) and referencing planner models as `orcarouter/<model-id>` now routes the planner LLM through OrcaRouter. OpenRouter remains the default; existing configs are unaffected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/credentials handling changed? No — optional new env var `ORCAROUTER_API_KEY`, handled exactly like `OPENROUTER_API_KEY`.
- New/changed network calls? Yes — when configured, the gateway calls `https://api.orcarouter.ai/v1/chat/completions`, the same request shape as the existing OpenRouter call.
- Database schema/migration changes? No
- Authentication/authorization changes? No
- **If any `Yes`, explain risk + mitigation**: OrcaRouter requests are plain OpenAI-compatible chat-completions calls with bearer auth — identical transport to the existing OpenRouter path; verified live.

## Verification

### Environment

- OS: Windows 11 (Git Bash), Node v24.19.0, npm 11.17.0

### Steps to Test

1. Set `ORCAROUTER_API_KEY` and reference a planner model as `orcarouter/anthropic/claude-sonnet-5`.
2. `/health` reports provider `orcarouter` for the planner.
3. The gateway streams completions through OrcaRouter.

### Expected Behavior

Planner LLM runs through OrcaRouter; OpenRouter behavior unchanged.

### Actual Behavior

Verified live — see Evidence.

## Evidence (attach at least one)

- [x] Test output / logs
  - `npx vitest run tests/provider/openrouter-body-injection.test.ts` → **17 passed** (incl. 5 new tests).
  - Full gateway suite: **245 passed / 12 failed** — the 12 failures are identical on clean `main` (Windows-only fixture/path issues in `tests/bindu/identity`, `tests/bindu/protocol`, `tests/recipe/loader`, `tests/recipe/tool`); zero new failures.
  - `npx tsc --noEmit`: same single pre-existing error on clean `main` (`src/planner/index.ts:328`) — no new type errors.
  - Live L3 against OrcaRouter (real key): `loadConfig()` wired `ORCAROUTER_API_KEY` → `provider.orcarouter.apiKey` (`sk-orca-` prefix); `parseModelId("orcarouter/anthropic/claude-sonnet-5")` → `{ providerId: "orcarouter", modelId: "anthropic/claude-sonnet-5" }`; the exact provider transport returned `ORCA-OK` for `orcarouter/anthropic/claude-sonnet-5` and `ORCA-FUSION` for `orcarouter/fusion-flash`; default base URL resolves to `https://api.orcarouter.ai/v1`.

## Human Verification (required)

- **Verified scenarios**: config env wiring, model-id parsing, live completion through OrcaRouter (both an Anthropic-proxied model and OrcaRouter's own `orcarouter/*` family), default base URL.
- **Edge cases checked**: unsupported provider ids still rejected; OpenRouter path unchanged (its fetch wrapper still applies only to OpenRouter).
- **What you did NOT verify**: full `/plan` orchestration end-to-end (requires a running gateway + agent fleet).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Optional new `ORCAROUTER_API_KEY` env var; no existing config changes.
- Database migration needed? No
- **If yes, exact upgrade steps**: n/a

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: unset `ORCAROUTER_API_KEY` / remove the `provider.orcarouter` block; the OpenRouter path is untouched.
- Files/config to restore: n/a.
- Known bad symptoms reviewers should watch for: none expected — the new provider only activates when an `orcarouter` model id or `ORCAROUTER_API_KEY` is configured.

## Risks and Mitigations

- **Risk**: New outbound endpoint when an operator configures OrcaRouter.
  - **Mitigation**: Same OpenAI-compatible transport as OpenRouter, bearer auth, plain chat-completions body; verified live against the real endpoint.

## Checklist

- [x] Tests pass (gateway `npm test` — no new failures vs clean `main`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`) — not applicable to the gateway TypeScript changes
- [x] Documentation updated (if needed)
- [x] Security impact assessed
- [x] Human verification completed
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as an alternative OpenAI-compatible planner provider.
  * Added configuration support for OrcaRouter API keys, models, and base URLs.
  * Added provider-specific routing and model configuration guidance.
  * OpenRouter remains the default provider.

* **Documentation**
  * Updated gateway setup, architecture, troubleshooting, health status, and production configuration guidance for both providers.

* **Tests**
  * Added coverage for provider selection, model parsing, default URLs, and unsupported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->