### PR TITLE
feat(runtime): migrate boxd provider to SDK 0.2.x

### DIFF
--- a/bindu/cli/__init__.py
+++ b/bindu/cli/__init__.py
@@ -94,12 +94,62 @@ async def _handle_logs(agent_name: str, follow: bool = True) -> None:
 
 
 async def _handle_shell(agent_name: str) -> None:
-    """Open an interactive bash on the agent's VM."""
-    from bindu.runtime.boxd_provider import _make_compute
+    """Open an interactive bash on the agent's VM.
 
-    async with _make_compute() as compute:
-        box = await compute.box.get(agent_name)
-        await box.exec("bash", interactive=True)
+    boxd 0.2.x has no interactive-exec convenience, so bridge the local
+    terminal to a tty ``stream_exec`` session by hand: raw mode locally,
+    stdin pumped into the stream, merged output pumped to stdout.
+    """
+    import shutil
+
+    from bindu.runtime.boxd_provider import _get_machine, _make_client
+
+    loop = asyncio.get_event_loop()
+    cols, rows = shutil.get_terminal_size()
+
+    async with _make_client() as client:
+        machine = await _get_machine(client, agent_name)
+        if machine is None:
+            sys.exit(f"Error: no boxd machine named {agent_name}")
+        stream = client.machines.stream_exec(
+            machine.id, command="bash", tty=True, cols=cols, rows=rows
+        )
+        async with stream:
+            if not sys.stdin.isatty():
+                # No local tty (piped input, tests): just drain output.
+                async for chunk in stream:
+                    sys.stdout.buffer.write(chunk)
+                    sys.stdout.buffer.flush()
+                return
+
+            import termios
+            import tty as _tty
+
+            fd = sys.stdin.fileno()
+            old_attrs = termios.tcgetattr(fd)
+
+            def _pump_stdin() -> None:
+                data = os.read(fd, 4096)
+                if data:
+                    asyncio.ensure_future(stream.write(data))
+                else:
+                    asyncio.ensure_future(stream.write_eof())
+
+            def _on_winch() -> None:
+                size = shutil.get_terminal_size()
+                asyncio.ensure_future(stream.resize(size.columns, size.lines))
+
+            _tty.setraw(fd)
+            loop.add_reader(fd, _pump_stdin)
+            loop.add_signal_handler(signal.SIGWINCH, _on_winch)
+            try:
+                async for chunk in stream:
+                    sys.stdout.buffer.write(chunk)
+                    sys.stdout.buffer.flush()
+            finally:
+                loop.remove_signal_handler(signal.SIGWINCH)
+                loop.remove_reader(fd)
+                termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
 
 
 def _capture_agent_metadata(script_path: str) -> dict[str, Any]:
@@ -228,8 +278,11 @@ def _print_dry_run(
     if runtime_config.image:
         print(f"  image (A1):    {runtime_config.image}")
     else:
-        print(f"  vcpu / memory: {runtime_config.vcpu} / {runtime_config.memory}")
-        print(f"  disk:          {runtime_config.disk}")
+        vcpu = runtime_config.vcpu if runtime_config.vcpu is not None else "org default"
+        memory = runtime_config.memory or "org default"
+        print(f"  vcpu / memory: {vcpu} / {memory}")
+        if runtime_config.disk:
+            print(f"  disk:          {runtime_config.disk}")
         print(f"  auto_suspend:  {runtime_config.auto_suspend}s")
         print(f"  on_exit:       {runtime_config.on_exit}")
         if runtime_config.bindu_version:

--- a/bindu/runtime/boxd_provider.py
+++ b/bindu/runtime/boxd_provider.py
@@ -9,6 +9,9 @@ Two modes:
 
 The host's role ends after the agent is healthy. A2A clients then talk
 directly to the VM's public URL.
+
+Targets the boxd 0.2.x SDK: a flat ``AsyncBoxd`` client with
+``machines.<verb>(id, ...)`` namespaces; ``Machine`` records are plain data.
 """
 
 from __future__ import annotations
@@ -27,8 +30,8 @@ from bindu.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-# Bindu's default HTTP port. The boxd proxy is configured to forward to
-# this port at VM creation time, so the agent's public URL routes correctly.
+# Bindu's default HTTP port. The machine's default proxy route is pointed at
+# this port after create/reuse, so the agent's public URL routes correctly.
 BINDU_DEFAULT_PORT = 3773
 
 # Where we stage the user's source inside the VM. Must be writable by the
@@ -39,8 +42,9 @@ APP_DIR = "/home/boxd/app"
 BINDU_SRC_DIR = "/home/boxd/bindu_source"
 
 # Where the in-VM agent's stdout/stderr go. Streamed back to the host on
-# demand via ``stream_logs`` (using ``tail -F`` over ``box.exec(stream=True)``
-# until boxd ships server-side ``StreamLogs``).
+# demand via ``stream_logs`` (using ``tail -F`` over ``machines.stream_exec``;
+# ``machines.logs`` is the VM console, which a detached nohup'd agent
+# never writes to).
 AGENT_LOG_PATH = "/tmp/bindu-agent.log"  # nosec B108 — single-tenant VM
 AGENT_PID_PATH = "/tmp/bindu-agent.pid"  # nosec B108 — single-tenant VM
 
@@ -70,11 +74,11 @@ _HEALTH_TIMEOUT = 60.0
 _POLL_INTERVAL = 1.0
 
 
-def _make_compute(**kwargs: Any):
-    """Construct a boxd Compute client. Indirection so tests can patch."""
-    from boxd.aio import Compute
+def _make_client(**kwargs: Any):
+    """Construct an AsyncBoxd client. Indirection so tests can patch."""
+    from boxd import AsyncBoxd
 
-    return Compute(**kwargs)
+    return AsyncBoxd(**kwargs)
 
 
 async def _poll_until(
@@ -98,111 +102,111 @@ async def _poll_until(
 
 
 async def _exec_or_raise(
-    box: Any, *cmd: str, env: dict[str, str] | None = None, error: str
+    client: Any,
+    machine_id: str,
+    *cmd: str,
+    env: dict[str, str] | None = None,
+    error: str,
 ) -> Any:
     """Run a command in the VM and raise if it exits non-zero."""
-    result = await box.exec(*cmd, env=env) if env is not None else await box.exec(*cmd)
+    result = await client.machines.exec(machine_id, list(cmd), env=env)
     if getattr(result, "exit_code", 0) != 0:
         stderr = getattr(result, "stderr", "")
         raise RuntimeError(f"{error}: {stderr}")
     return result
 
 
-_WRITE_FILE_RETRIES = 3
+async def _get_machine(client: Any, name: str) -> Any | None:
+    """Look up a machine by name; ``None`` when it doesn't exist.
 
-
-async def _safe_write_file(box: Any, blob: bytes, dest: str) -> None:
-    """``box.write_file`` + sha256 verification, with retry on mismatch.
-
-    boxd 0.1.1's ``Box.write_file`` intermittently silently truncates
-    uploads (https://github.com/azin-tech/boxd/issues/45). The corruption
-    is rare and has 4 KB-aligned deltas — almost certainly a streaming-
-    writer race. We hash on both ends and retry on mismatch so the deploy
-    never proceeds with a corrupt artifact in the VM.
+    ``machines.get`` resolves a name in the account's default org context
+    only, which misses machines living in another organization (observed
+    with org-fenced API keys: ``get(name)`` raises NotFound while ``list``
+    shows the machine). Fall back to an exact-name scan of ``list()``
+    before concluding the machine is gone — creating over a name that
+    actually exists fails with ConflictError, and a skipped teardown
+    leaves the VM running (and billing) forever.
     """
-    import hashlib
+    from boxd import NotFoundError
 
-    expected = hashlib.sha256(blob).hexdigest()
-    last_seen = "unknown"
-    for attempt in range(_WRITE_FILE_RETRIES):
-        await box.write_file(blob, dest)
-        result = await box.exec("sha256sum", dest)
-        stdout = getattr(result, "stdout", "") or ""
-        last_seen = stdout.split()[0] if stdout else "<no output>"
-        if last_seen == expected:
-            return
-        if attempt < _WRITE_FILE_RETRIES - 1:
-            await asyncio.sleep(1.0)
-    raise RuntimeError(
-        f"upload to {dest} corrupted after {_WRITE_FILE_RETRIES} attempts "
-        f"(expected sha256 {expected[:12]}..., got {last_seen[:12]}...). "
-        "Likely boxd write_file truncation; see "
-        "https://github.com/azin-tech/boxd/issues/45"
-    )
+    try:
+        return await client.machines.get(name)
+    except NotFoundError:
+        for machine in await client.machines.list():
+            if machine.name == name:
+                return machine
+        return None
+
+
+async def _upload_file(client: Any, machine_id: str, blob: bytes, dest: str) -> None:
+    """Upload ``blob`` to ``dest`` and verify the confirmed byte count.
+
+    boxd 0.2.x's ``files.upload`` streams in chunks and returns the number
+    of bytes the machine confirmed it wrote — a mismatch means the artifact
+    in the VM is corrupt, so fail the deploy rather than proceed.
+    """
+    written = await client.machines.files.upload(machine_id, dest, blob)
+    if written != len(blob):
+        raise RuntimeError(
+            f"upload to {dest} incomplete: machine confirmed {written} of "
+            f"{len(blob)} bytes"
+        )
 
 
 class BoxdRuntimeProvider(RuntimeProvider):
     """RuntimeProvider that runs the agent inside a boxd microVM."""
 
-    async def _resolve_vm(self, compute: Any, name: str, config: RuntimeConfig) -> Any:
-        """Get or create the VM for this agent (idempotent by name)."""
-        from boxd import BoxConfig, LifecycleConfig, NetworkConfig, ProxyEntry
-        from boxd.errors import NotFoundError
+    async def _resolve_vm(self, client: Any, name: str, config: RuntimeConfig) -> Any:
+        """Get or create the machine for this agent (idempotent by name).
 
-        try:
-            return await compute.box.get(name)
-        except NotFoundError:
-            pass
-
-        box_config = BoxConfig(
-            vcpu=config.vcpu,
-            memory=config.memory,
-            disk=config.disk,
-            lifecycle=LifecycleConfig(auto_suspend_timeout=config.auto_suspend),
-            network=NetworkConfig(
-                proxies=[ProxyEntry(name="", port=BINDU_DEFAULT_PORT)],
-            ),
-        )
-        create_kwargs: dict[str, Any] = {"name": name, "config": box_config}
-        if config.image:
-            create_kwargs["image"] = config.image
-        return await compute.box.create(**create_kwargs)
-
-    async def _wait_vm_ready(
-        self, box: Any, timeout: float = _VM_READY_TIMEOUT
-    ) -> None:
-        """Wait until the VM's in-VM exec server is responsive.
-
-        ``box.create()`` returns at "running", but the takeoff agent serving
-        exec/write_file takes a few more seconds to come up.
+        A reused machine may have been paused/hibernated/stopped since the
+        last deploy (``on_exit='suspend'`` is the default); the 0.2.x SDK
+        never resumes implicitly, so bring it back explicitly here.
         """
+        machine = await _get_machine(client, name)
+        if machine is None:
+            # Sizing keys are passed only when explicitly configured: boxd
+            # 0.2.x machines come in fixed vCPU/memory pairs with an org
+            # default, and the server refuses per-machine disk sizing.
+            create_kwargs: dict[str, Any] = {
+                "auto_suspend_timeout": config.auto_suspend,
+            }
+            if config.vcpu is not None:
+                create_kwargs["vcpu"] = config.vcpu
+            if config.memory is not None:
+                create_kwargs["memory"] = config.memory
+            if config.disk is not None:
+                create_kwargs["disk"] = config.disk
+            if config.image:
+                create_kwargs["image"] = config.image
+            return await client.machines.create(name, **create_kwargs)
 
-        async def probe() -> bool:
-            result = await box.exec("true")
-            return getattr(result, "exit_code", 0) == 0
+        if machine.status == "suspended":
+            await client.machines.resume(machine.id)
+        elif machine.status == "hibernated":
+            await client.machines.wake(machine.id)
+        elif machine.status == "stopped":
+            await client.machines.start(machine.id)
+        return machine
 
-        await _poll_until(
-            probe,
-            timeout=timeout,
-            interval=2.0,
-            error_msg=f"VM {box.name} did not become exec-ready within {timeout}s",
-        )
-
-    async def _ship_source(self, box: Any, source_dir: Path) -> None:
+    async def _ship_source(
+        self, client: Any, machine_id: str, source_dir: Path
+    ) -> None:
         """Tar+gzip ``source_dir``, upload, extract to ``APP_DIR``."""
         blob = build_tarball(source_dir)
         # /tmp inside the VM is fine: the VM is single-tenant, the host is the
         # only writer, and the file is consumed immediately by the next exec.
-        await _safe_write_file(box, blob, "/tmp/source.tar.gz")  # nosec B108
+        await _upload_file(client, machine_id, blob, "/tmp/source.tar.gz")  # nosec B108
         await _exec_or_raise(
-            box,
+            client,
+            machine_id,
             "sh",
             "-c",
             f"mkdir -p {APP_DIR} && tar xzf /tmp/source.tar.gz -C {APP_DIR}",
             error=f"failed to extract source to {APP_DIR}",
         )
 
-    async def _ship_bindu_source(self, box: Any) -> None:
+    async def _ship_bindu_source(self, client: Any, machine_id: str) -> None:
         """Tar the host's bindu source tree, ship to ``BINDU_SRC_DIR``.
 
         Used by ``bindu_version == "local"``: lets the VM run the same bindu
@@ -222,9 +226,15 @@ class BoxdRuntimeProvider(RuntimeProvider):
                 f"checkout; no pyproject.toml found at or above {host_root}"
             )
         blob = build_tarball(host_root, extra_ignores=_BINDU_SHIP_EXCLUDES)
-        await _safe_write_file(box, blob, "/tmp/bindu-source.tar.gz")  # nosec B108
+        await _upload_file(
+            client,
+            machine_id,
+            blob,
+            "/tmp/bindu-source.tar.gz",  # nosec B108
+        )
         await _exec_or_raise(
-            box,
+            client,
+            machine_id,
             "sh",
             "-c",
             f"mkdir -p {BINDU_SRC_DIR} && "
@@ -234,7 +244,8 @@ class BoxdRuntimeProvider(RuntimeProvider):
 
     async def _install_deps(
         self,
-        box: Any,
+        client: Any,
+        machine_id: str,
         has_pyproject: bool,
         has_requirements: bool,
         bindu_version: str | None = None,
@@ -268,7 +279,8 @@ class BoxdRuntimeProvider(RuntimeProvider):
             steps.append(f"cd {APP_DIR} && pip install --break-system-packages -e .")
         # One round-trip with `&&` chaining so the first failure short-circuits.
         await _exec_or_raise(
-            box,
+            client,
+            machine_id,
             "sh",
             "-c",
             " && ".join(steps),
@@ -277,7 +289,8 @@ class BoxdRuntimeProvider(RuntimeProvider):
 
     async def _start_agent(
         self,
-        box: Any,
+        client: Any,
+        machine_id: str,
         script: str,
         env: dict[str, str] | None = None,
         public_url: str | None = None,
@@ -314,7 +327,12 @@ class BoxdRuntimeProvider(RuntimeProvider):
             f"fi"
         )
         await _exec_or_raise(
-            box, "sh", "-c", kill_old, error="failed to stop previous agent"
+            client,
+            machine_id,
+            "sh",
+            "-c",
+            kill_old,
+            error="failed to stop previous agent",
         )
 
         # Step 2: start the new agent detached. ``setsid`` puts it in its own
@@ -328,7 +346,8 @@ class BoxdRuntimeProvider(RuntimeProvider):
             f"echo $! > {AGENT_PID_PATH}"
         )
         await _exec_or_raise(
-            box,
+            client,
+            machine_id,
             "sh",
             "-c",
             start,
@@ -383,37 +402,34 @@ class BoxdRuntimeProvider(RuntimeProvider):
                 "BOXD_API_KEY or BOXD_TOKEN must be set in the host environment"
             )
 
-        async with _make_compute() as compute:
-            box = await self._resolve_vm(compute, agent_name, config)
-            # box.url is returned with scheme on CreateVm but bare on GetVm.
-            raw_url = box.url or f"{agent_name}.boxd.sh"
-            if not raw_url.startswith(("http://", "https://")):
-                raw_url = f"https://{raw_url}"
-            public_url = raw_url
+        async with _make_client() as client:
+            machine = await self._resolve_vm(client, agent_name, config)
+            # Blocks until the machine is "running" AND exec round-trips —
+            # covers fresh creates and the resume/wake path alike.
+            machine = await client.machines.wait_until_ready(
+                machine.id, timeout=_VM_READY_TIMEOUT
+            )
+            public_url = machine.access.url or f"https://{agent_name}.boxd.sh"
 
-            await self._wait_vm_ready(box, timeout=_VM_READY_TIMEOUT)
-
-            # Reapply on every deploy: boxd 0.1.1 doesn't always honor
-            # NetworkConfig.proxies on create, and warm reuse keeps the
-            # original config. Idempotent.
-            try:
-                await box.set_proxy_port(port=BINDU_DEFAULT_PORT)
-            except AttributeError:
-                pass
+            # Point the machine's default proxy route at bindu's port on
+            # every deploy (boxd's own default is a different port).
+            # Idempotent.
+            await client.machines.proxies.set_port(machine.id, BINDU_DEFAULT_PORT)
 
             if config.image is None:
                 if source_dir is None:
                     raise RuntimeError(
                         "source_dir is required when config.image is not set"
                     )
-                ship_tasks = [self._ship_source(box, source_dir)]
+                ship_tasks = [self._ship_source(client, machine.id, source_dir)]
                 if config.bindu_version == "local":
-                    ship_tasks.append(self._ship_bindu_source(box))
+                    ship_tasks.append(self._ship_bindu_source(client, machine.id))
                 await asyncio.gather(*ship_tasks)
                 has_pyproject = (source_dir / "pyproject.toml").exists()
                 has_requirements = (source_dir / "requirements.txt").exists()
                 await self._install_deps(
-                    box,
+                    client,
+                    machine.id,
                     has_pyproject=has_pyproject,
                     has_requirements=has_requirements,
                     bindu_version=config.bindu_version,
@@ -421,7 +437,8 @@ class BoxdRuntimeProvider(RuntimeProvider):
                 script_to_run = script or self._detect_script_name(source_dir)
                 merged_env = {**config.env, **(env or {})}
                 await self._start_agent(
-                    box,
+                    client,
+                    machine.id,
                     script=script_to_run,
                     env=merged_env,
                     public_url=public_url,
@@ -433,7 +450,7 @@ class BoxdRuntimeProvider(RuntimeProvider):
                 name=agent_name,
                 url=public_url,
                 provider="boxd",
-                metadata={"vm_id": box.id, "public_ip": box.public_ip},
+                metadata={"vm_id": machine.id},
             )
 
     async def health(self, handle: RuntimeHandle) -> bool:
@@ -450,28 +467,27 @@ class BoxdRuntimeProvider(RuntimeProvider):
     ) -> AsyncIterator[bytes]:
         """Yield chunks of the in-VM agent's stdout/stderr.
 
-        boxd 0.1.x's server-side ``StreamLogs`` is unimplemented, so we tail
-        ``AGENT_LOG_PATH`` over a streaming exec instead. ``tail -F`` is
-        deliberate: it keeps polling when the file is missing or rotates,
-        which matches the agent's startup window (the file appears as soon
-        as the python3 process opens it for redirect).
+        ``machines.logs`` is the VM console — a detached nohup'd agent never
+        writes there — so we tail ``AGENT_LOG_PATH`` over a streaming exec
+        instead. ``tail -F`` is deliberate: it keeps polling when the file
+        is missing or rotates, which matches the agent's startup window (the
+        file appears as soon as the python3 process opens it for redirect).
         """
-        async with _make_compute() as compute:
-            box = await compute.box.get(handle.name)
-            args = (
-                ("tail", "-n", "+1", "-F", AGENT_LOG_PATH)
+        async with _make_client() as client:
+            machine = await _get_machine(client, handle.name)
+            if machine is None:
+                raise RuntimeError(f"no boxd machine named {handle.name}")
+            command = (
+                ["tail", "-n", "+1", "-F", AGENT_LOG_PATH]
                 if follow
-                else ("sh", "-c", f"cat {AGENT_LOG_PATH} 2>/dev/null || true")
+                else ["sh", "-c", f"cat {AGENT_LOG_PATH} 2>/dev/null || true"]
             )
-            proc = await box.exec(*args, stream=True)
-            try:
-                async for chunk in proc.stdout:
+            stream = client.machines.stream_exec(
+                machine.id, command=command, close_stdin=True
+            )
+            async with stream:
+                async for chunk in stream:
                     yield chunk
-            finally:
-                # Async-iterator GC + exec-stream close should kill the
-                # remote ``tail`` when the consumer stops iterating; nothing
-                # else to do on the host.
-                pass
 
     async def on_exit(
         self,
@@ -480,24 +496,28 @@ class BoxdRuntimeProvider(RuntimeProvider):
     ) -> None:
         """Apply the on-exit policy (``suspend`` / ``destroy`` / ``detach``).
 
-        ``suspend`` actively calls ``box.suspend()`` rather than waiting for
-        the auto-suspend timer. The timer is disabled by default (so background
-        tasks aren't frozen mid-flight while the agent is running), so relying
-        on it would silently turn ``--on-exit=suspend`` into a no-op.
+        ``suspend`` actively calls ``machines.pause()`` (suspend to RAM)
+        rather than waiting for the auto-suspend timer. The timer is disabled
+        by default (so background tasks aren't frozen mid-flight while the
+        agent is running), so relying on it would silently turn
+        ``--on-exit=suspend`` into a no-op.
         """
         if mode == "detach":
             return
-        async with _make_compute() as compute:
+        async with _make_client() as client:
             try:
-                box = await compute.box.get(handle.name)
+                machine = await _get_machine(client, handle.name)
             except Exception as e:
                 logger.warning("on_exit could not look up VM %s: %s", handle.name, e)
                 return
+            if machine is None:
+                logger.warning("on_exit: no boxd machine named %s", handle.name)
+                return
             if mode == "destroy":
-                await box.destroy()
+                await client.machines.delete(machine.id)
             elif mode == "suspend":
                 try:
-                    await box.suspend()
+                    await client.machines.pause(machine.id)
                 except Exception as e:
                     # The agent's still up; user can retry or destroy manually.
                     logger.warning("on_exit suspend failed for %s: %s", handle.name, e)

--- a/bindu/runtime/config.py
+++ b/bindu/runtime/config.py
@@ -32,9 +32,13 @@ class RuntimeConfig:
 
     provider: Literal["in-process", "boxd"] = "in-process"
     image: str | None = None
-    vcpu: int = 2
-    memory: str = "4G"
-    disk: str = "20G"
+    # Sizing is optional: boxd 0.2.x machines come in fixed vCPU/memory
+    # pairs with an org-level default, and per-machine disk sizing is not
+    # supported server-side. ``None`` means "don't ask, take the default";
+    # only explicitly-set values are passed to the create call.
+    vcpu: int | None = None
+    memory: str | None = None
+    disk: str | None = None
     # ``0`` is boxd's "disabled" sentinel for auto-suspend. Default to off
     # because bindu agents commonly run background tasks (scheduler ticks,
     # streaming LLM calls, websocket sessions) that would be frozen mid-flight
@@ -76,16 +80,18 @@ class RuntimeConfig:
                 f"on_exit must be one of {KNOWN_ON_EXIT}, got {on_exit!r}"
             )
 
-        vcpu = int(raw.get("vcpu", 2))
-        if vcpu <= 0:
-            raise RuntimeConfigError(f"vcpu must be positive, got {vcpu}")
+        vcpu = raw.get("vcpu")
+        if vcpu is not None:
+            vcpu = int(vcpu)
+            if vcpu <= 0:
+                raise RuntimeConfigError(f"vcpu must be positive, got {vcpu}")
 
         return cls(
             provider="boxd",
             image=raw.get("image"),
             vcpu=vcpu,
-            memory=raw.get("memory", "4G"),
-            disk=raw.get("disk", "20G"),
+            memory=raw.get("memory"),
+            disk=raw.get("disk"),
             auto_suspend=int(raw.get("auto_suspend", 0)),
             on_exit=on_exit,
             bindu_version=raw.get("bindu_version"),

--- a/docs/runtime/boxd.md
+++ b/docs/runtime/boxd.md
@@ -18,11 +18,11 @@ the agent serves traffic from its own VM with a public HTTPS URL.
 | `--runtime` | str | `boxd` | Runtime provider. |
 | `--name` | str | from script `config["name"]` | Override the agent name (e.g., for preview envs). |
 | `--image` | str | unset | If set, **A1 mode**: VM is created from this image; no source ship. See [custom-image.md](custom-image.md). |
-| `--vcpu` | int | `2` | vCPUs for the VM. |
-| `--memory` | str | `4G` | RAM. Accepts boxd size strings (`512M`, `4G`, ...). |
-| `--disk` | str | `20G` | Disk size. |
+| `--vcpu` | int | org default | vCPUs. boxd machines come in fixed sizes (1 vCPU/4G, 2/8G, 4/16G) — set either `--vcpu` or `--memory` and the other follows. Unset uses your org's default size. |
+| `--memory` | str | org default | RAM (`4G`, `8G`, `16G`). See `--vcpu`. |
+| `--disk` | str | unset | Not supported by boxd yet — every machine gets 100 GiB, and the server refuses a per-machine disk size. Kept for when it lands. |
 | `--auto-suspend` | int | `0` (disabled) | Seconds of *idle* (no HTTP request) before boxd auto-suspends the VM. **Default off** because bindu agents commonly run background work (scheduler ticks, streaming LLM calls, websockets) that would be frozen mid-flight by an idle timeout. Pass an explicit value like `--auto-suspend=60` only if your agent is pure request/response. |
-| `--on-exit` | str | `suspend` | Behavior on Ctrl-C: `suspend` (actively call `box.suspend()`), `destroy` (tear down VM), `detach` (leave running). `suspend` works regardless of `--auto-suspend` — it suspends the VM directly when the host detaches. |
+| `--on-exit` | str | `suspend` | Behavior on Ctrl-C: `suspend` (actively call `machines.pause()`), `destroy` (tear down VM), `detach` (leave running). `suspend` works regardless of `--auto-suspend` — it suspends the VM directly when the host detaches. |
 | `--bindu-version` | str | unset | Pin the bindu version installed in the VM. Special value `local` ships the host's bindu source instead of pulling from PyPI (useful for testing patched bindu). |
 | `--env` | KEY=VALUE | — | Extra env var for the agent inside the VM (repeatable). |
 
@@ -37,7 +37,7 @@ the agent serves traffic from its own VM with a public HTTPS URL.
 2. **Subsequent runs (same agent name):** the CLI reuses the existing VM,
    updates source, restarts the agent. ~1–3 seconds.
 3. **Ctrl-C with `--on-exit=suspend` (default):** the CLI explicitly calls
-   `box.suspend()`, freezing the VM's memory and pausing all in-flight
+   `machines.pause()`, freezing the VM's memory and pausing all in-flight
    work. The VM is preserved on disk; re-running `bindu deploy` resumes
    in 1–3s with state intact (DID keys, vector store, conversation
    history, etc. all survive).
@@ -90,8 +90,9 @@ to `.binduignore`.
 ## Dev DX
 
 - `bindu logs <agent>` — stream the agent's stdout/stderr to your terminal.
-  Implemented as a ``tail -F`` of the in-VM agent log over a streaming exec,
-  because boxd 0.1.x's server-side ``StreamLogs`` RPC is not yet implemented.
+  Implemented as a ``tail -F`` of the in-VM agent log over a streaming exec —
+  boxd's ``machines.logs`` is the VM console, which the detached agent
+  process never writes to.
   The upside: you only see the agent's own output, not kernel/boot noise.
   Pass ``--no-follow`` to print what's there now and exit.
 - `bindu shell <agent>` — open an interactive shell on the agent's VM
@@ -107,5 +108,5 @@ to `.binduignore`.
 | `pip install` failure | Dep not on PyPI, native build fails | Switch to A1 (custom image) and install the dep at image-build time |
 | Source >50 MB | Large data files included | Add to `.binduignore` |
 | Old bindu in VM rejects new features | Published bindu lags the host's | Pass `--bindu-version=local` to ship the host's source instead |
-| `upload to /tmp/... corrupted after 3 attempts` | boxd write_file truncation ([azin-tech/boxd#45](https://github.com/azin-tech/boxd/issues/45)) | Re-run `bindu deploy`; the corruption is intermittent and almost always clears on retry |
-| Looks like the wrong code is running after redeploy | boxd 0.1.x sometimes ships truncated tarballs | The deploy now sha256-verifies every upload and retries on mismatch. If you see this anyway, run `bindu shell <agent>` and check `cat /tmp/bindu-agent.pid` against `pgrep python3` |
+| `upload to /tmp/... incomplete` | The machine confirmed fewer bytes than the host sent | Re-run `bindu deploy`; if it persists, check boxd status — the deploy refuses to proceed on a corrupt artifact |
+| Looks like the wrong code is running after redeploy | Old agent process kept port 3773 | The deploy kills the previous agent via its pidfile before starting the new one. If you see this anyway, run `bindu shell <agent>` and check `cat /tmp/bindu-agent.pid` against `pgrep python3` |

--- a/docs/runtime/quickstart.md
+++ b/docs/runtime/quickstart.md
@@ -388,13 +388,13 @@ agents that don't get traffic 24/7.
 > dashboard. To force-suspend from Python:
 >
 > ```python
-> from boxd.aio import Compute
-> import asyncio, os
+> from boxd import AsyncBoxd
+> import asyncio
 >
 > async def main():
->     async with Compute(api_key=os.environ["BOXD_API_KEY"]) as c:
->         box = await c.box.get("runtime-boxd-example")
->         await box.stop()  # or .destroy() to delete it entirely
+>     async with AsyncBoxd() as boxd:  # reads BOXD_API_KEY from the env
+>         machine = await boxd.machines.get("runtime-boxd-example")
+>         await boxd.machines.pause(machine.id)  # or .delete(machine.id)
 >
 > asyncio.run(main())
 > ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,9 @@ grpc = [
 
 # Boxd runtime provider — agents-in-microVM (use: pip install bindu[runtime-boxd])
 runtime-boxd = [
-    "boxd>=0.1.1",
+    # 0.2 reshaped the client (Boxd/AsyncBoxd + machines.* namespaces);
+    # bindu/runtime/boxd_provider.py targets that surface.
+    "boxd>=0.2.7,<0.3",
     # boxd's generated gRPC stubs require grpcio>=1.80.0; bindu's main pin is
     # lower, so uv would otherwise pick a too-old grpcio for the boxd wheel.
     "grpcio>=1.80.0",

--- a/tests/unit/runtime/conftest.py
+++ b/tests/unit/runtime/conftest.py
@@ -2,54 +2,72 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 
-class _FakeBox:
-    """Stand-in for boxd.aio.Box used by tests."""
+def _ok_exec_result():
+    """Stub ExecResult with exit_code=0."""
+    r = MagicMock()
+    r.exit_code = 0
+    r.success = True
+    r.stdout = ""
+    r.stderr = ""
+    return r
+
+
+class _FakeMachine:
+    """Stand-in for the boxd 0.2.x ``Machine`` record (plain data)."""
 
     def __init__(self, name: str = "agent", vm_id: str = "vm-1"):
         self.id = vm_id
         self.name = name
-        self.image = "ubuntu:latest"
-        self.public_ip = "1.2.3.4"
         self.status = "running"
-        self.url = f"https://{name}.boxd.sh"
+        self.image_ref = "ubuntu:latest"
         self.boot_time_ms = 2000
-        # All async methods that the provider may call:
-        self.exec = AsyncMock()
-        self.write_file = AsyncMock()
-        self.read_file = AsyncMock(return_value=b"")
-        self.destroy = AsyncMock()
-        self.suspend = AsyncMock()
-        self.resume = AsyncMock()
-        # `stream_logs` is set by tests that exercise log streaming.
-        self.stream_logs = MagicMock()
+        self.access = SimpleNamespace(
+            url=f"https://{name}.boxd.sh",
+            domain=f"{name}.boxd.sh",
+            ssh_port=None,
+        )
 
 
-class _FakeBoxService:
+class _FakeMachines:
+    """Stand-in for ``AsyncBoxd().machines`` (verbs + sub-namespaces)."""
+
     def __init__(self):
         self.create = AsyncMock()
         self.get = AsyncMock()
         self.list = AsyncMock(return_value=[])
-        self.fork = AsyncMock()
+        self.delete = AsyncMock()
+        self.pause = AsyncMock()
+        self.resume = AsyncMock()
+        self.wake = AsyncMock()
+        self.start = AsyncMock()
+        self.wait_until_ready = AsyncMock()
+        self.exec = AsyncMock(return_value=_ok_exec_result())
+        # ``stream_exec`` is sync — it returns the stream session directly.
+        self.stream_exec = MagicMock()
+        self.logs = MagicMock()
+        self.files = SimpleNamespace(upload=AsyncMock(), download=AsyncMock())
+        self.proxies = SimpleNamespace(
+            create=AsyncMock(),
+            list=AsyncMock(return_value=[]),
+            set_port=AsyncMock(),
+            delete=AsyncMock(),
+        )
 
 
-class _FakeCompute:
-    """Stand-in for boxd.aio.Compute used as an async context manager."""
+class _FakeBoxdClient:
+    """Stand-in for ``boxd.AsyncBoxd`` used as an async context manager."""
 
     def __init__(self):
-        self.box = _FakeBoxService()
-        self.template = MagicMock()
-        self.disk = MagicMock()
-        self.domain = MagicMock()
-        self.network = MagicMock()
-        self.token = MagicMock()
+        self.machines = _FakeMachines()
+        self.snapshots = MagicMock()
+        self.disks = MagicMock()
         self.close = AsyncMock()
-        self.whoami = AsyncMock()
-        self.config = AsyncMock()
 
     async def __aenter__(self):
         return self
@@ -59,24 +77,34 @@ class _FakeCompute:
 
 
 @pytest.fixture
-def fake_box():
-    """Return a fresh _FakeBox per test."""
-    return _FakeBox()
+def fake_machine():
+    """Return a fresh _FakeMachine per test."""
+    return _FakeMachine()
 
 
 @pytest.fixture
-def fake_compute(fake_box):
-    """Return a fresh _FakeCompute per test, wired so .box.create returns fake_box."""
-    c = _FakeCompute()
-    c.box.create.return_value = fake_box
-    c.box.get.return_value = fake_box
+def fake_client(fake_machine):
+    """Return a fresh _FakeBoxdClient wired so machine lookups resolve.
+
+    ``files.upload`` confirms the full byte count by default, matching a
+    clean upload.
+    """
+    c = _FakeBoxdClient()
+    c.machines.create.return_value = fake_machine
+    c.machines.get.return_value = fake_machine
+    c.machines.wait_until_ready.return_value = fake_machine
+
+    async def _upload_ok(machine_id, path, data):
+        return len(data)
+
+    c.machines.files.upload.side_effect = _upload_ok
     return c
 
 
 @pytest.fixture
-def mock_boxd(monkeypatch, fake_compute):
-    """Patch boxd_provider._make_compute to return `fake_compute`."""
+def mock_boxd(monkeypatch, fake_client):
+    """Patch boxd_provider._make_client to return `fake_client`."""
     import bindu.runtime.boxd_provider as bp
 
-    monkeypatch.setattr(bp, "_make_compute", lambda **kw: fake_compute)
-    return fake_compute
+    monkeypatch.setattr(bp, "_make_client", lambda **kw: fake_client)
+    return fake_client

--- a/tests/unit/runtime/test_boxd_provider.py
+++ b/tests/unit/runtime/test_boxd_provider.py
@@ -22,76 +22,105 @@ def _ok_exec_result():
     return r
 
 
-def _wire_safe_write_file(fake_box):
-    """Make fake_box echo back the correct sha256 from sha256sum invocations.
+def _bad_exec_result(stderr: str = "boom"):
+    r = MagicMock()
+    r.exit_code = 1
+    r.success = False
+    r.stdout = ""
+    r.stderr = stderr
+    return r
 
-    The real ``_safe_write_file`` writes a blob, then runs ``sha256sum`` on
-    the destination and compares to the host's hash. To test the *callers*
-    (ship_source, _ship_bindu_source, deploy()) we need the box to look like
-    the bytes landed intact — so wire write_file to remember what was sent
-    and exec to return the matching hash for sha256sum.
+
+def _sh_calls(fake_client):
+    """Extract the shell script strings from ``sh -c`` exec invocations.
+
+    The provider calls ``machines.exec(machine_id, ["sh", "-c", script])``.
     """
-    import hashlib
-
-    last_blob: dict[str, bytes] = {}
-
-    async def fake_write_file(blob, dest):
-        last_blob[dest] = blob
-
-    fake_box.write_file.side_effect = fake_write_file
-
-    async def fake_exec(*args, **kwargs):
-        if args and args[0] == "sha256sum" and len(args) >= 2:
-            dest = args[1]
-            blob = last_blob.get(dest, b"")
-            r = MagicMock()
-            r.exit_code = 0
-            r.success = True
-            r.stdout = f"{hashlib.sha256(blob).hexdigest()}  {dest}\n"
-            r.stderr = ""
-            return r
-        return _ok_exec_result()
-
-    fake_box.exec.side_effect = fake_exec
+    out = []
+    for c in fake_client.machines.exec.await_args_list:
+        cmd = c.args[1]
+        if isinstance(cmd, list) and cmd[:2] == ["sh", "-c"]:
+            out.append(cmd[2])
+    return out
 
 
 # ── _resolve_vm ────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_resolve_vm_creates_when_not_found(mock_boxd, fake_box):
-    """If no VM with this name exists, create one."""
-    from boxd.errors import NotFoundError
+async def test_resolve_vm_creates_when_not_found(mock_boxd, fake_machine):
+    """If no machine with this name exists, create one."""
+    from boxd import NotFoundError
 
-    mock_boxd.box.get.side_effect = NotFoundError("not found")
+    mock_boxd.machines.get.side_effect = NotFoundError("not found")
     p = BoxdRuntimeProvider()
 
     cfg = RuntimeConfig.from_dict({"provider": "boxd"})
-    box = await p._resolve_vm(mock_boxd, "my-agent", cfg)
+    machine = await p._resolve_vm(mock_boxd, "my-agent", cfg)
 
-    mock_boxd.box.get.assert_awaited_once_with("my-agent")
-    mock_boxd.box.create.assert_awaited_once()
-    assert box is fake_box
+    mock_boxd.machines.get.assert_awaited_once_with("my-agent")
+    mock_boxd.machines.create.assert_awaited_once()
+    assert machine is fake_machine
 
 
 @pytest.mark.asyncio
-async def test_resolve_vm_reuses_when_found(mock_boxd, fake_box):
-    """If a VM already exists, reuse it without creating."""
+async def test_resolve_vm_reuses_when_found(mock_boxd, fake_machine):
+    """If a machine already exists and is running, reuse it as-is."""
     p = BoxdRuntimeProvider()
     cfg = RuntimeConfig.from_dict({"provider": "boxd"})
-    box = await p._resolve_vm(mock_boxd, "my-agent", cfg)
+    machine = await p._resolve_vm(mock_boxd, "my-agent", cfg)
 
-    mock_boxd.box.get.assert_awaited_once_with("my-agent")
-    mock_boxd.box.create.assert_not_awaited()
-    assert box is fake_box
+    mock_boxd.machines.get.assert_awaited_once_with("my-agent")
+    mock_boxd.machines.create.assert_not_awaited()
+    mock_boxd.machines.resume.assert_not_awaited()
+    assert machine is fake_machine
 
 
 @pytest.mark.asyncio
-async def test_resolve_vm_passes_config(mock_boxd, fake_box):
+@pytest.mark.parametrize(
+    ("status", "verb"),
+    [("suspended", "resume"), ("hibernated", "wake"), ("stopped", "start")],
+)
+async def test_resolve_vm_revives_saved_machine(mock_boxd, fake_machine, status, verb):
+    """A reused machine left paused/hibernated/stopped by a previous
+    ``on_exit`` must be brought back explicitly — boxd 0.2.x never resumes
+    implicitly, and ``wait_until_ready`` raises on 'stopped'."""
+    fake_machine.status = status
+    p = BoxdRuntimeProvider()
+    cfg = RuntimeConfig.from_dict({"provider": "boxd"})
+
+    await p._resolve_vm(mock_boxd, "my-agent", cfg)
+
+    getattr(mock_boxd.machines, verb).assert_awaited_once_with(fake_machine.id)
+    mock_boxd.machines.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_vm_falls_back_to_list_on_name_miss(mock_boxd, fake_machine):
+    """``machines.get(name)`` resolves names only in the default org
+    context; a machine living in another org raises NotFound while
+    ``list()`` still shows it. The provider must find it via the list scan
+    and reuse it — creating over the name fails with ConflictError."""
+    from boxd import NotFoundError
+
+    mock_boxd.machines.get.side_effect = NotFoundError("not found")
+    fake_machine.name = "my-agent"
+    mock_boxd.machines.list.return_value = [fake_machine]
+    p = BoxdRuntimeProvider()
+    cfg = RuntimeConfig.from_dict({"provider": "boxd"})
+
+    machine = await p._resolve_vm(mock_boxd, "my-agent", cfg)
+
+    assert machine is fake_machine
+    mock_boxd.machines.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_vm_passes_config(mock_boxd, fake_machine):
     """vcpu / memory / disk / image / auto_suspend land in the create call."""
-    from boxd.errors import NotFoundError
+    from boxd import NotFoundError
 
-    mock_boxd.box.get.side_effect = NotFoundError("nope")
+    mock_boxd.machines.get.side_effect = NotFoundError("nope")
     p = BoxdRuntimeProvider()
 
     cfg = RuntimeConfig.from_dict(
@@ -106,233 +135,148 @@ async def test_resolve_vm_passes_config(mock_boxd, fake_box):
     )
     await p._resolve_vm(mock_boxd, "my-agent", cfg)
 
-    call = mock_boxd.box.create.await_args
-    assert call.kwargs.get("name") == "my-agent"
+    call = mock_boxd.machines.create.await_args
+    assert call.args[0] == "my-agent"
     assert call.kwargs.get("image") == "ghcr.io/me/agent:v1"
-    box_config = call.kwargs.get("config")
-    assert box_config is not None
-    assert box_config.vcpu == 4
-    assert box_config.memory == "8G"
-    assert box_config.disk == "40G"
-    # auto_suspend goes through LifecycleConfig
-    assert box_config.lifecycle is not None
-    assert box_config.lifecycle.auto_suspend_timeout == 30
-    # default proxy must forward to bindu's default port (3773), not boxd's
-    # default (8000), or the public URL is unreachable.
-    assert box_config.network is not None
-    assert box_config.network.proxies is not None
-    assert any(p.port == 3773 for p in box_config.network.proxies)
+    assert call.kwargs.get("vcpu") == 4
+    assert call.kwargs.get("memory") == "8G"
+    assert call.kwargs.get("disk") == "40G"
+    assert call.kwargs.get("auto_suspend_timeout") == 30
 
 
 # ── _ship_source ───────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_ship_source_writes_and_extracts(mock_boxd, fake_box, tmp_path):
+async def test_ship_source_uploads_and_extracts(mock_boxd, fake_machine, tmp_path):
     (tmp_path / "agent.py").write_text("# hi\n")
-    _wire_safe_write_file(fake_box)
     p = BoxdRuntimeProvider()
 
-    await p._ship_source(fake_box, tmp_path)
+    await p._ship_source(mock_boxd, fake_machine.id, tmp_path)
 
-    fake_box.write_file.assert_awaited_once()
-    args = fake_box.write_file.await_args
-    payload, dest = args.args[0], args.args[1]
-    assert isinstance(payload, bytes)
+    mock_boxd.machines.files.upload.assert_awaited_once()
+    args = mock_boxd.machines.files.upload.await_args
+    machine_id, dest, payload = args.args[0], args.args[1], args.args[2]
+    assert machine_id == fake_machine.id
     assert dest == "/tmp/source.tar.gz"
+    assert isinstance(payload, bytes)
 
     # mkdir + tar extract are issued as a single shell exec to save a round-trip
-    exec_calls = fake_box.exec.await_args_list
     assert any(
-        c.args[0] == "sh"
-        and c.args[1] == "-c"
-        and "mkdir -p /home/boxd/app" in c.args[2]
-        and "tar xzf /tmp/source.tar.gz -C /home/boxd/app" in c.args[2]
-        for c in exec_calls
+        "mkdir -p /home/boxd/app" in s
+        and "tar xzf /tmp/source.tar.gz -C /home/boxd/app" in s
+        for s in _sh_calls(mock_boxd)
     )
 
 
-# ── _safe_write_file (verify-and-retry workaround for boxd issue #45) ─
+# ── _upload_file (verify the confirmed byte count) ─────────────────
 
 
 @pytest.mark.asyncio
-async def test_safe_write_file_succeeds_on_clean_upload(fake_box):
-    """When the sha256 on the VM matches the host, no retry."""
-    from bindu.runtime.boxd_provider import _safe_write_file
+async def test_upload_file_accepts_confirmed_full_write(mock_boxd, fake_machine):
+    """When the machine confirms all bytes, no error."""
+    from bindu.runtime.boxd_provider import _upload_file
 
-    _wire_safe_write_file(fake_box)
-    await _safe_write_file(fake_box, b"hello world", "/tmp/x.bin")
+    await _upload_file(mock_boxd, fake_machine.id, b"hello world", "/tmp/x.bin")
 
-    assert fake_box.write_file.await_count == 1
-
-
-@pytest.mark.asyncio
-async def test_safe_write_file_retries_on_corrupted_upload(monkeypatch, fake_box):
-    """If the first upload's hash mismatches, retry until it succeeds."""
-    import hashlib
-
-    from bindu.runtime.boxd_provider import _safe_write_file
-
-    monkeypatch.setattr(
-        "bindu.runtime.boxd_provider.asyncio.sleep", AsyncMock(return_value=None)
+    mock_boxd.machines.files.upload.assert_awaited_once_with(
+        fake_machine.id, "/tmp/x.bin", b"hello world"
     )
 
-    blob = b"some data"
-    expected = hashlib.sha256(blob).hexdigest()
-    state = {"call": 0}
-
-    async def fake_write(b, d):
-        pass
-
-    async def fake_exec(*args, **kwargs):
-        if args and args[0] == "sha256sum":
-            state["call"] += 1
-            r = MagicMock()
-            r.exit_code = 0
-            # First call returns a wrong hash (truncation simulated); second matches.
-            hash_str = "0" * 64 if state["call"] == 1 else expected
-            r.stdout = f"{hash_str}  {args[1]}\n"
-            r.stderr = ""
-            return r
-        return _ok_exec_result()
-
-    fake_box.write_file.side_effect = fake_write
-    fake_box.exec.side_effect = fake_exec
-
-    await _safe_write_file(fake_box, blob, "/tmp/x.bin")
-    # Wrote twice (once corrupted, once clean)
-    assert fake_box.write_file.await_count == 2
-
 
 @pytest.mark.asyncio
-async def test_safe_write_file_raises_after_max_retries(monkeypatch, fake_box):
-    """If every attempt produces a corrupt upload, raise with a useful message."""
-    from bindu.runtime.boxd_provider import _safe_write_file
+async def test_upload_file_raises_on_short_write(mock_boxd, fake_machine):
+    """If the machine confirms fewer bytes than sent, fail the deploy."""
+    from bindu.runtime.boxd_provider import _upload_file
 
-    monkeypatch.setattr(
-        "bindu.runtime.boxd_provider.asyncio.sleep", AsyncMock(return_value=None)
-    )
+    mock_boxd.machines.files.upload.side_effect = None
+    mock_boxd.machines.files.upload.return_value = 3
 
-    async def fake_write(b, d):
-        pass
-
-    async def fake_exec_always_wrong(*args, **kwargs):
-        if args and args[0] == "sha256sum":
-            r = MagicMock()
-            r.exit_code = 0
-            r.stdout = f"{'f' * 64}  {args[1]}\n"
-            r.stderr = ""
-            return r
-        return _ok_exec_result()
-
-    fake_box.write_file.side_effect = fake_write
-    fake_box.exec.side_effect = fake_exec_always_wrong
-
-    with pytest.raises(RuntimeError) as ei:
-        await _safe_write_file(fake_box, b"data", "/tmp/x.bin")
-    msg = str(ei.value)
-    assert "corrupted" in msg
-    assert "issues/45" in msg  # points at the upstream bug
+    with pytest.raises(RuntimeError, match="incomplete"):
+        await _upload_file(mock_boxd, fake_machine.id, b"some data", "/tmp/x.bin")
 
 
 # ── _install_deps ──────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_install_deps_with_pyproject(mock_boxd, fake_box):
-    fake_box.exec.return_value = _ok_exec_result()
+async def test_install_deps_with_pyproject(mock_boxd, fake_machine):
     p = BoxdRuntimeProvider()
 
-    await p._install_deps(fake_box, has_pyproject=True, has_requirements=False)
+    await p._install_deps(
+        mock_boxd, fake_machine.id, has_pyproject=True, has_requirements=False
+    )
 
     # All pip steps are chained into a single sh -c invocation to save round-trips.
-    install_calls = [
-        c
-        for c in fake_box.exec.await_args_list
-        if c.args and c.args[0] == "sh" and "pip install" in c.args[2]
-    ]
+    install_calls = [s for s in _sh_calls(mock_boxd) if "pip install" in s]
     assert len(install_calls) == 1
-    cmd = install_calls[0].args[2]
+    cmd = install_calls[0]
     assert "pip install --break-system-packages bindu" in cmd
     assert "pip install --break-system-packages -e ." in cmd
 
 
 @pytest.mark.asyncio
-async def test_install_deps_with_requirements(mock_boxd, fake_box):
-    fake_box.exec.return_value = _ok_exec_result()
+async def test_install_deps_with_requirements(mock_boxd, fake_machine):
     p = BoxdRuntimeProvider()
 
-    await p._install_deps(fake_box, has_pyproject=False, has_requirements=True)
+    await p._install_deps(
+        mock_boxd, fake_machine.id, has_pyproject=False, has_requirements=True
+    )
 
-    install_calls = [
-        c
-        for c in fake_box.exec.await_args_list
-        if c.args and c.args[0] == "sh" and "pip install" in c.args[2]
-    ]
+    install_calls = [s for s in _sh_calls(mock_boxd) if "pip install" in s]
     assert len(install_calls) == 1
-    cmd = install_calls[0].args[2]
     assert (
-        "pip install --break-system-packages -r /home/boxd/app/requirements.txt" in cmd
+        "pip install --break-system-packages -r /home/boxd/app/requirements.txt"
+        in install_calls[0]
     )
 
 
 @pytest.mark.asyncio
-async def test_install_deps_pinned_bindu_version(mock_boxd, fake_box):
-    fake_box.exec.return_value = _ok_exec_result()
+async def test_install_deps_pinned_bindu_version(mock_boxd, fake_machine):
     p = BoxdRuntimeProvider()
 
     await p._install_deps(
-        fake_box,
+        mock_boxd,
+        fake_machine.id,
         has_pyproject=False,
         has_requirements=False,
         bindu_version="0.2.5",
     )
 
-    install_calls = [
-        c
-        for c in fake_box.exec.await_args_list
-        if c.args and c.args[0] == "sh" and "pip install" in c.args[2]
-    ]
+    install_calls = [s for s in _sh_calls(mock_boxd) if "pip install" in s]
     assert len(install_calls) == 1
-    assert (
-        "pip install --break-system-packages bindu==0.2.5" in install_calls[0].args[2]
-    )
+    assert "pip install --break-system-packages bindu==0.2.5" in install_calls[0]
 
 
 @pytest.mark.asyncio
-async def test_install_deps_raises_on_failure(mock_boxd, fake_box):
+async def test_install_deps_raises_on_failure(mock_boxd, fake_machine):
     """Non-zero exit code from pip install should raise."""
-    bad = MagicMock()
-    bad.exit_code = 1
-    bad.stderr = "boom"
-    fake_box.exec.return_value = bad
+    mock_boxd.machines.exec.return_value = _bad_exec_result()
     p = BoxdRuntimeProvider()
 
     with pytest.raises(RuntimeError, match="failed"):
-        await p._install_deps(fake_box, has_pyproject=False, has_requirements=False)
+        await p._install_deps(
+            mock_boxd, fake_machine.id, has_pyproject=False, has_requirements=False
+        )
 
 
 @pytest.mark.asyncio
-async def test_install_deps_bindu_version_local(mock_boxd, fake_box):
+async def test_install_deps_bindu_version_local(mock_boxd, fake_machine):
     """bindu_version='local' installs bindu editable from BINDU_SRC_DIR."""
     from bindu.runtime.boxd_provider import BINDU_SRC_DIR
 
-    fake_box.exec.return_value = _ok_exec_result()
     p = BoxdRuntimeProvider()
 
     await p._install_deps(
-        fake_box,
+        mock_boxd,
+        fake_machine.id,
         has_pyproject=False,
         has_requirements=False,
         bindu_version="local",
     )
-    install_calls = [
-        c
-        for c in fake_box.exec.await_args_list
-        if c.args and c.args[0] == "sh" and "pip install" in c.args[2]
-    ]
+    install_calls = [s for s in _sh_calls(mock_boxd) if "pip install" in s]
     assert len(install_calls) == 1
-    cmd = install_calls[0].args[2]
+    cmd = install_calls[0]
     assert f"pip install --break-system-packages -e {BINDU_SRC_DIR}" in cmd
     # Must NOT pull from PyPI when local mode is requested.
     assert "bindu==" not in cmd
@@ -343,24 +287,22 @@ async def test_install_deps_bindu_version_local(mock_boxd, fake_box):
 
 
 @pytest.mark.asyncio
-async def test_start_agent_execs_bindu_serve(mock_boxd, fake_box):
+async def test_start_agent_execs_bindu_serve(mock_boxd, fake_machine):
     p = BoxdRuntimeProvider()
-    fake_box.exec.return_value = _ok_exec_result()
 
     await p._start_agent(
-        fake_box,
+        mock_boxd,
+        fake_machine.id,
         script="my_agent.py",
         env={"FOO": "bar"},
         public_url="https://my-agent.boxd.sh",
     )
 
-    fake_box.exec.assert_awaited()
-    cmd_call = fake_box.exec.await_args
-    assert cmd_call.args[0] == "sh"
-    assert cmd_call.args[1] == "-c"
-    cmd_str = cmd_call.args[2]
-    assert "python3" in cmd_str
-    assert "/home/boxd/app/my_agent.py" in cmd_str
+    cmd_call = mock_boxd.machines.exec.await_args
+    cmd = cmd_call.args[1]
+    assert cmd[:2] == ["sh", "-c"]
+    assert "python3" in cmd[2]
+    assert "/home/boxd/app/my_agent.py" in cmd[2]
     # env from caller plus the auto-injected BINDU_PUBLIC_URL
     env = cmd_call.kwargs.get("env")
     assert env is not None
@@ -369,7 +311,7 @@ async def test_start_agent_execs_bindu_serve(mock_boxd, fake_box):
 
 
 @pytest.mark.asyncio
-async def test_start_agent_kills_old_pid_and_writes_new(mock_boxd, fake_box):
+async def test_start_agent_kills_old_pid_and_writes_new(mock_boxd, fake_machine):
     """Redeploy must SIGTERM the previous python3 (tracked via pidfile),
     wait for it to die, then start the new one and record its PID.
 
@@ -378,10 +320,9 @@ async def test_start_agent_kills_old_pid_and_writes_new(mock_boxd, fake_box):
     backgrounds the wrong subshell — easy to miss without splitting.
     """
     p = BoxdRuntimeProvider()
-    fake_box.exec.return_value = _ok_exec_result()
 
-    await p._start_agent(fake_box, script="agent.py")
-    sh_calls = [c.args[2] for c in fake_box.exec.await_args_list if c.args[0] == "sh"]
+    await p._start_agent(mock_boxd, fake_machine.id, script="agent.py")
+    sh_calls = _sh_calls(mock_boxd)
     assert len(sh_calls) == 2, "expected two execs: kill-old then start"
     kill_cmd, start_cmd = sh_calls
     # First exec: pidfile check + TERM + poll + SIGKILL fallback.
@@ -395,17 +336,14 @@ async def test_start_agent_kills_old_pid_and_writes_new(mock_boxd, fake_box):
 
 
 @pytest.mark.asyncio
-async def test_start_agent_raises_on_nonzero_exit(mock_boxd, fake_box):
-    bad = MagicMock()
-    bad.exit_code = 1
-    bad.stderr = "boom"
-    fake_box.exec.return_value = bad
+async def test_start_agent_raises_on_nonzero_exit(mock_boxd, fake_machine):
+    mock_boxd.machines.exec.return_value = _bad_exec_result()
 
     p = BoxdRuntimeProvider()
     # First exec (kill-old) raises with this message; we accept either
     # since both phases are "starting" from the user's POV.
     with pytest.raises(RuntimeError, match="(failed to start|failed to stop)"):
-        await p._start_agent(fake_box, script="agent.py")
+        await p._start_agent(mock_boxd, fake_machine.id, script="agent.py")
 
 
 # ── _wait_healthy ──────────────────────────────────────────────────
@@ -499,16 +437,15 @@ def boxd_api_key(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_deploy_a2_full_flow(
-    mock_boxd, fake_box, tmp_path, fake_health, boxd_api_key
+    mock_boxd, fake_machine, tmp_path, fake_health, boxd_api_key
 ):
     """A2 deploy: source ship + install + start + healthy."""
     (tmp_path / "agent.py").write_text(
         "from bindu.penguin.bindufy import bindufy\nbindufy({}, lambda m: 'hi')\n"
     )
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n")
-    _wire_safe_write_file(fake_box)
-    fake_box.name = "my-agent"
-    fake_box.url = "https://my-agent.boxd.sh"
+    fake_machine.name = "my-agent"
+    fake_machine.access.url = "https://my-agent.boxd.sh"
 
     p = BoxdRuntimeProvider()
     cfg = RuntimeConfig.from_dict({"provider": "boxd"})
@@ -525,30 +462,26 @@ async def test_deploy_a2_full_flow(
     assert handle.provider == "boxd"
     assert handle.metadata.get("vm_id") == "vm-1"
 
-    fake_box.write_file.assert_awaited_once()
-    pip_calls = [
-        c
-        for c in fake_box.exec.await_args_list
-        if c.args and c.args[0] == "sh" and "pip install" in c.args[2]
-    ]
-    assert pip_calls, "pip install should have been called"
-    serve_calls = [
-        c
-        for c in fake_box.exec.await_args_list
-        if c.args and c.args[0] == "sh" and "python3" in c.args[2]
-    ]
-    assert serve_calls, "agent script should have been started"
+    mock_boxd.machines.wait_until_ready.assert_awaited_once()
+    mock_boxd.machines.files.upload.assert_awaited_once()
+    # The default proxy route must forward to bindu's port (3773), not
+    # boxd's default, or the public URL is unreachable.
+    mock_boxd.machines.proxies.set_port.assert_awaited_once_with(fake_machine.id, 3773)
+    sh_calls = _sh_calls(mock_boxd)
+    assert any("pip install" in s for s in sh_calls), "pip install expected"
+    assert any("python3" in s for s in sh_calls), "agent start expected"
 
 
 @pytest.mark.asyncio
-async def test_deploy_a1_skips_source(mock_boxd, fake_box, fake_health, boxd_api_key):
+async def test_deploy_a1_skips_source(
+    mock_boxd, fake_machine, fake_health, boxd_api_key
+):
     """A1 deploy: image-based; no source ship, no pip install."""
-    from boxd.errors import NotFoundError
+    from boxd import NotFoundError
 
-    mock_boxd.box.get.side_effect = NotFoundError("nope")
-    fake_box.exec.return_value = _ok_exec_result()
-    fake_box.name = "my-agent"
-    fake_box.url = "https://my-agent.boxd.sh"
+    mock_boxd.machines.get.side_effect = NotFoundError("nope")
+    fake_machine.name = "my-agent"
+    fake_machine.access.url = "https://my-agent.boxd.sh"
 
     p = BoxdRuntimeProvider()
     cfg = RuntimeConfig.from_dict({"provider": "boxd", "image": "ghcr.io/me/agent:v1"})
@@ -561,13 +494,8 @@ async def test_deploy_a1_skips_source(mock_boxd, fake_box, fake_health, boxd_api
     )
 
     assert handle.url == "https://my-agent.boxd.sh"
-    fake_box.write_file.assert_not_awaited()
-    pip_calls = [
-        c
-        for c in fake_box.exec.await_args_list
-        if c.args and c.args[0] == "sh" and "pip install" in c.args[2]
-    ]
-    assert not pip_calls
+    mock_boxd.machines.files.upload.assert_not_awaited()
+    assert not [s for s in _sh_calls(mock_boxd) if "pip install" in s]
 
 
 @pytest.mark.asyncio
@@ -584,7 +512,7 @@ async def test_deploy_requires_credentials(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_deploy_uses_explicit_script_over_detection(
-    mock_boxd, fake_box, tmp_path, fake_health, boxd_api_key
+    mock_boxd, fake_machine, tmp_path, fake_health, boxd_api_key
 ):
     """When ``script=`` is passed, the VM runs that exact path — even if
     multiple .py files at the source root call bindufy()."""
@@ -597,9 +525,6 @@ async def test_deploy_uses_explicit_script_over_detection(
         "from bindu.penguin.bindufy import bindufy\nbindufy({}, lambda m: 'old')\n"
     )
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n")
-    _wire_safe_write_file(fake_box)
-    fake_box.name = "agent"
-    fake_box.url = "https://agent.boxd.sh"
 
     p = BoxdRuntimeProvider()
     cfg = RuntimeConfig.from_dict({"provider": "boxd"})
@@ -612,16 +537,11 @@ async def test_deploy_uses_explicit_script_over_detection(
         script="real_agent.py",
     )
 
-    serve_calls = [
-        c
-        for c in fake_box.exec.await_args_list
-        if c.args and c.args[0] == "sh" and "python3" in c.args[2]
-    ]
+    serve_calls = [s for s in _sh_calls(mock_boxd) if "python3" in s]
     assert serve_calls, "agent script should have been started"
-    cmd_str = serve_calls[0].args[2]
-    assert "real_agent.py" in cmd_str
+    assert "real_agent.py" in serve_calls[0]
     # Detection fallback would have picked stale_agent.py (sorts first).
-    assert "stale_agent.py" not in cmd_str
+    assert "stale_agent.py" not in serve_calls[0]
 
 
 # ── health / stream_logs / on_exit ────────────────────────────────
@@ -675,16 +595,16 @@ async def test_health_returns_false_when_unreachable(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_on_exit_destroy(mock_boxd, fake_box, boxd_api_key):
+async def test_on_exit_destroy(mock_boxd, fake_machine, boxd_api_key):
     p = BoxdRuntimeProvider()
     h = RuntimeHandle("my-agent", "https://my-agent.boxd.sh", "boxd", {"vm_id": "vm-1"})
     await p.on_exit(h, "destroy")
-    fake_box.destroy.assert_awaited_once()
+    mock_boxd.machines.delete.assert_awaited_once_with(fake_machine.id)
 
 
 @pytest.mark.asyncio
-async def test_on_exit_suspend_actively_suspends(mock_boxd, fake_box, boxd_api_key):
-    """suspend mode calls box.suspend() — not a no-op.
+async def test_on_exit_suspend_actively_pauses(mock_boxd, fake_machine, boxd_api_key):
+    """suspend mode calls machines.pause() — not a no-op.
 
     The auto-suspend timer is disabled by default (so background tasks
     aren't frozen mid-flight while the agent is running), so relying on the
@@ -693,62 +613,64 @@ async def test_on_exit_suspend_actively_suspends(mock_boxd, fake_box, boxd_api_k
     p = BoxdRuntimeProvider()
     h = RuntimeHandle("my-agent", "https://my-agent.boxd.sh", "boxd", {})
     await p.on_exit(h, "suspend")
-    fake_box.suspend.assert_awaited_once()
-    fake_box.destroy.assert_not_awaited()
+    mock_boxd.machines.pause.assert_awaited_once_with(fake_machine.id)
+    mock_boxd.machines.delete.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_on_exit_suspend_swallows_errors(mock_boxd, fake_box, boxd_api_key):
-    """If box.suspend() raises, on_exit returns cleanly — host shutdown
+async def test_on_exit_suspend_swallows_errors(mock_boxd, fake_machine, boxd_api_key):
+    """If machines.pause() raises, on_exit returns cleanly — host shutdown
     shouldn't bubble VM-side errors to the user's terminal."""
-    fake_box.suspend.side_effect = RuntimeError("boxd had a moment")
+    mock_boxd.machines.pause.side_effect = RuntimeError("boxd had a moment")
     p = BoxdRuntimeProvider()
     h = RuntimeHandle("my-agent", "https://my-agent.boxd.sh", "boxd", {})
     # Must not raise.
     await p.on_exit(h, "suspend")
-    fake_box.suspend.assert_awaited_once()
+    mock_boxd.machines.pause.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_on_exit_detach_is_pure_noop(mock_boxd, fake_box, boxd_api_key):
+async def test_on_exit_detach_is_pure_noop(mock_boxd, fake_machine, boxd_api_key):
     """detach mode does not even open a connection."""
     p = BoxdRuntimeProvider()
     h = RuntimeHandle("my-agent", "https://my-agent.boxd.sh", "boxd", {})
     await p.on_exit(h, "detach")
-    fake_box.destroy.assert_not_awaited()
-    fake_box.suspend.assert_not_awaited()
-    mock_boxd.box.get.assert_not_awaited()
+    mock_boxd.machines.delete.assert_not_awaited()
+    mock_boxd.machines.pause.assert_not_awaited()
+    mock_boxd.machines.get.assert_not_awaited()
 
 
-def _exec_proc_with_chunks(chunks):
-    """Build a fake ``ExecProcess`` whose .stdout yields the given chunks."""
+class _FakeStream:
+    """Stand-in for boxd's AsyncExecStream (async CM + async iterator)."""
 
-    class _Stdout:
-        def __init__(self, cs):
-            self._cs = list(cs)
+    def __init__(self, chunks):
+        self._cs = list(chunks)
+        self.closed = False
 
-        def __aiter__(self):
-            return self
+    async def __aenter__(self):
+        return self
 
-        async def __anext__(self):
-            if not self._cs:
-                raise StopAsyncIteration
-            return self._cs.pop(0)
+    async def __aexit__(self, *a):
+        self.closed = True
 
-    proc = MagicMock()
-    proc.stdout = _Stdout(chunks)
-    return proc
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._cs:
+            raise StopAsyncIteration
+        return self._cs.pop(0)
 
 
 @pytest.mark.asyncio
-async def test_stream_logs_tails_agent_log(mock_boxd, fake_box, boxd_api_key):
+async def test_stream_logs_tails_agent_log(mock_boxd, fake_machine, boxd_api_key):
     """stream_logs(follow=True) issues ``tail -F AGENT_LOG_PATH`` over a
     streaming exec, and passes the chunks through unchanged."""
     from bindu.runtime.boxd_provider import AGENT_LOG_PATH
 
     chunks = [b"agent up\n", b"served /\n"]
-    fake_box.exec = AsyncMock(return_value=_exec_proc_with_chunks(chunks))
-    mock_boxd.box.get.return_value = fake_box
+    fake_stream = _FakeStream(chunks)
+    mock_boxd.machines.stream_exec.return_value = fake_stream
 
     p = BoxdRuntimeProvider()
     h = RuntimeHandle("my-agent", "https://my-agent.boxd.sh", "boxd", {})
@@ -757,31 +679,28 @@ async def test_stream_logs_tails_agent_log(mock_boxd, fake_box, boxd_api_key):
         out.append(chunk)
 
     assert out == chunks
-    call = fake_box.exec.await_args
-    assert call is not None
-    assert call.args[0] == "tail"
-    assert "-F" in call.args
-    assert AGENT_LOG_PATH in call.args
-    assert call.kwargs.get("stream") is True
+    assert fake_stream.closed
+    call = mock_boxd.machines.stream_exec.call_args
+    assert call.args[0] == fake_machine.id
+    command = call.kwargs.get("command")
+    assert command[0] == "tail"
+    assert "-F" in command
+    assert AGENT_LOG_PATH in command
 
 
 @pytest.mark.asyncio
-async def test_stream_logs_no_follow_uses_cat(mock_boxd, fake_box, boxd_api_key):
+async def test_stream_logs_no_follow_uses_cat(mock_boxd, fake_machine, boxd_api_key):
     """stream_logs(follow=False) prints current contents and ends.
 
     Implementation uses ``sh -c "cat ... 2>/dev/null || true"`` so a missing
     log file doesn't surface a confusing exec error.
     """
-    fake_box.exec = AsyncMock(return_value=_exec_proc_with_chunks([b"static\n"]))
-    mock_boxd.box.get.return_value = fake_box
+    mock_boxd.machines.stream_exec.return_value = _FakeStream([b"static\n"])
 
     p = BoxdRuntimeProvider()
     h = RuntimeHandle("my-agent", "https://my-agent.boxd.sh", "boxd", {})
     out = [chunk async for chunk in p.stream_logs(h, follow=False)]
     assert out == [b"static\n"]
-    call = fake_box.exec.await_args
-    assert call is not None
-    # Either tail-without-F or cat with a no-error wrapper is fine; check that
-    # the streamed command does NOT contain ``-F`` (which would tail forever).
-    assert "-F" not in call.args
-    assert call.kwargs.get("stream") is True
+    command = mock_boxd.machines.stream_exec.call_args.kwargs.get("command")
+    # Must NOT contain ``-F`` (which would tail forever).
+    assert "-F" not in command

--- a/tests/unit/runtime/test_cli_shell_logs.py
+++ b/tests/unit/runtime/test_cli_shell_logs.py
@@ -5,71 +5,81 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+class _FakeStream:
+    """Stand-in for boxd's AsyncExecStream (async CM + async iterator)."""
+
+    def __init__(self, chunks):
+        self._cs = list(chunks)
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        self.closed = True
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._cs:
+            raise StopAsyncIteration
+        return self._cs.pop(0)
+
+
+def _fake_client(machine, stream):
+    client = MagicMock()
+    client.machines.get = AsyncMock(return_value=machine)
+    client.machines.stream_exec = MagicMock(return_value=stream)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock()
+    return client
+
+
 @pytest.mark.asyncio
 async def test_logs_streams_to_stdout(capsys):
     """`bindu logs my-agent` tails the in-VM agent log and pipes to stdout.
 
-    Server-side ``StreamLogs`` is unimplemented in boxd 0.1.x; the CLI
-    works around it by ``tail -F``-ing the known agent log path inside
-    the VM via a streaming exec.
+    ``machines.logs`` is the VM console, which a detached nohup'd agent
+    never writes to — the CLI ``tail -F``s the known agent log path inside
+    the VM via a streaming exec instead.
     """
     from bindu.cli import _handle_logs
 
-    chunks = [b"hello\n", b"world\n"]
+    machine = MagicMock(id="vm-1")
+    stream = _FakeStream([b"hello\n", b"world\n"])
+    client = _fake_client(machine, stream)
 
-    class _Stdout:
-        def __init__(self, cs):
-            self._cs = list(cs)
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if not self._cs:
-                raise StopAsyncIteration
-            return self._cs.pop(0)
-
-    fake_proc = MagicMock()
-    fake_proc.stdout = _Stdout(chunks)
-
-    fake_box = MagicMock()
-    fake_box.exec = AsyncMock(return_value=fake_proc)
-
-    fake_compute = MagicMock()
-    fake_compute.box.get = AsyncMock(return_value=fake_box)
-    fake_compute.__aenter__ = AsyncMock(return_value=fake_compute)
-    fake_compute.__aexit__ = AsyncMock()
-
-    with patch("bindu.runtime.boxd_provider._make_compute", return_value=fake_compute):
+    with patch("bindu.runtime.boxd_provider._make_client", return_value=client):
         await _handle_logs("my-agent", follow=True)
 
     out = capsys.readouterr().out
     assert "hello" in out
     assert "world" in out
-    call = fake_box.exec.await_args
+    call = client.machines.stream_exec.call_args
     assert call is not None
-    assert call.kwargs.get("stream") is True
-    assert "-F" in call.args  # follow=True → tail -F
+    assert call.args[0] == "vm-1"
+    command = call.kwargs.get("command")
+    assert command[0] == "tail"
+    assert "-F" in command  # follow=True → tail -F
 
 
 @pytest.mark.asyncio
-async def test_shell_calls_exec_bash():
-    """`bindu shell my-agent` should exec `bash` interactively on the VM."""
+async def test_shell_opens_tty_bash_session():
+    """`bindu shell my-agent` opens a tty ``stream_exec`` bash session."""
     from bindu.cli import _handle_shell
 
-    fake_box = MagicMock()
-    fake_box.exec = AsyncMock()
+    machine = MagicMock(id="vm-1")
+    stream = _FakeStream([b"$ \n"])
+    client = _fake_client(machine, stream)
 
-    fake_compute = MagicMock()
-    fake_compute.box.get = AsyncMock(return_value=fake_box)
-    fake_compute.__aenter__ = AsyncMock(return_value=fake_compute)
-    fake_compute.__aexit__ = AsyncMock()
-
-    with patch("bindu.runtime.boxd_provider._make_compute", return_value=fake_compute):
+    with patch("bindu.runtime.boxd_provider._make_client", return_value=client):
         await _handle_shell("my-agent")
 
-    fake_box.exec.assert_awaited_once()
-    args = fake_box.exec.await_args
-    assert args is not None
-    assert "bash" in args.args
-    assert args.kwargs.get("interactive") is True
+    client.machines.get.assert_awaited_once_with("my-agent")
+    call = client.machines.stream_exec.call_args
+    assert call is not None
+    assert call.args[0] == "vm-1"
+    assert call.kwargs.get("command") == "bash"
+    assert call.kwargs.get("tty") is True
+    assert stream.closed

--- a/tests/unit/runtime/test_config.py
+++ b/tests/unit/runtime/test_config.py
@@ -19,9 +19,11 @@ def test_boxd_minimal():
     cfg = RuntimeConfig.from_dict({"provider": "boxd"})
     assert cfg.provider == "boxd"
     assert cfg.image is None
-    assert cfg.vcpu == 2
-    assert cfg.memory == "4G"
-    assert cfg.disk == "20G"
+    # Sizing defaults to None: boxd 0.2.x sizes machines from the org
+    # default unless explicitly asked, and refuses per-machine disk sizing.
+    assert cfg.vcpu is None
+    assert cfg.memory is None
+    assert cfg.disk is None
     # auto_suspend defaults OFF (0 is boxd's "disabled" sentinel) so the VM
     # never freezes mid-task. on_exit=suspend still saves cost between sessions.
     assert cfg.auto_suspend == 0

--- a/uv.lock
+++ b/uv.lock
@@ -501,7 +501,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0,<1" },
     { name = "base58", specifier = ">=2.1.1,<3" },
     { name = "base58", marker = "extra == 'core'", specifier = ">=2.1.1,<3" },
-    { name = "boxd", marker = "extra == 'runtime-boxd'", specifier = ">=0.1.1" },
+    { name = "boxd", marker = "extra == 'runtime-boxd'", specifier = ">=0.2.7,<0.3" },
     { name = "cdp-sdk", specifier = ">=1.45.0,<2" },
     { name = "cookiecutter", specifier = ">=2.6.0,<3" },
     { name = "cryptography", specifier = ">=50.0.0,<51" },
@@ -668,16 +668,17 @@ css = [
 
 [[package]]
 name = "boxd"
-version = "0.1.2"
+version = "0.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "httpx" },
     { name = "protobuf" },
+    { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/d6/6b1130b42a97724583b239df3943aa306874d52666c1266809c6861f9c97/boxd-0.1.2.tar.gz", hash = "sha256:6d257ec5a494d0ea7fa9b30d3e40976db36fe7a1b0b2853be1ff8b9c9c967de1", size = 45729, upload-time = "2026-05-04T21:50:03.334Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/d8/f983e42ca822072d1a389c2a78a055e2e623c92b2288e577e49abef6b64e/boxd-0.2.7.tar.gz", hash = "sha256:769090da8e74f9bd90098c9a21c40a99742fe3938daaeb342325667e56a0a68d", size = 101593, upload-time = "2026-08-31T16:46:59.058Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/f7/3edb799184b2fbd0b80f95b7e29867000bd09a4b4bf83bdfed129807f356/boxd-0.1.2-py3-none-any.whl", hash = "sha256:343f62f4afa8e5085895a16d24781ec17ba76b45f26fc0a88d332a5f90cd4f1b", size = 40962, upload-time = "2026-05-04T21:50:02.194Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ee/3bd911f577fc461f5cfe32c361e9aa63dbf74d82a3ac5b2dd6671215dba9/boxd-0.2.7-py3-none-any.whl", hash = "sha256:6095ab60bf626ec2bab379f77d5518a63a373038dc75e45028256e2c9cfdf029", size = 77302, upload-time = "2026-08-31T16:46:57.917Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

boxd 0.2 reshaped its Python SDK: the `Compute`/`Box` objects with methods became a flat `AsyncBoxd` client with `machines.<verb>(id, ...)` namespaces, where `Machine` records are plain data. This PR migrates the runtime provider, CLI, and tests to that surface and pins `boxd>=0.2.7,<0.3` (we were on 0.1.2).

## API mapping

| boxd 0.1.x | boxd 0.2.x |
|---|---|
| `Compute()` / `compute.box.get/create` | `AsyncBoxd()` / `client.machines.get/create` |
| `box.exec(...)` | `machines.exec(id, [...])` |
| `box.write_file(blob, dest)` | `machines.files.upload(id, dest, blob)` (returns confirmed byte count) |
| `box.set_proxy_port(port=...)` | `machines.proxies.set_port(id, port)` |
| `box.suspend()` / `box.destroy()` | `machines.pause(id)` / `machines.delete(id)` |
| hand-rolled exec-readiness poll | `machines.wait_until_ready(id)` |
| `box.exec(..., stream=True)` | `machines.stream_exec(id, command=...)` |

## Behavior changes (all found by testing against real VMs)

- **Explicit resume on warm reuse.** The 0.2.x SDK never resumes a suspended/hibernated/stopped machine implicitly, and `wait_until_ready` raises on `"stopped"` — so `_resolve_vm` now revives saved machines before redeploying. Without this, `on_exit=suspend` (the default) would break every subsequent deploy.
- **Name-lookup fallback.** `machines.get(name)` resolves names only in the account's default org context; a machine living in another org raises NotFound while `list()` still shows it. This made deploys die with `ConflictError` and — worse — made `on_exit("destroy")` silently skip teardown, leaving a VM running and billing. `_get_machine` now falls back to an exact-name scan of `machines.list()`.
- **Sizing is optional.** boxd machines now come in fixed vCPU/memory pairs (1/4G, 2/8G, 4/16G) with an org-level default, and the server refuses per-machine disk sizing (`per-machine disk sizing is not supported yet: every machine gets 100 GiB; omit disk`). `RuntimeConfig` defaults for vcpu/memory/disk are now `None`; only explicitly-set values reach the create call. `--disk` stays wired for when boxd ships disk sizing.
- **Upload verification simplified.** The sha256-verify-and-retry workaround for boxd 0.1.1's silent upload truncation (azin-tech/boxd#45) is gone: 0.2.x uploads stream in chunks and return the byte count the machine confirmed, which the provider checks instead.
- **`bindu shell` reimplemented.** The old `exec(interactive=True)` convenience no longer exists; the CLI now bridges the local terminal to a `stream_exec(tty=True)` session (raw mode, stdin pump, SIGWINCH resize).
- **`stream_logs` still tails the agent log file** — `machines.logs` is the VM console, which a detached nohup'd agent never writes to.

Docs (`docs/runtime/boxd.md`, `quickstart.md`) updated where they referenced the old API, sizing defaults, and the obsolete truncation workaround.

## Testing

- 1098 unit tests pass; runtime fixtures/tests rewritten for the new client shape, with new coverage for the resume-on-reuse path and the name-lookup fallback.
- Real-VM e2e (`BOXD_E2E=1`) passes: create → ship source → pip install → start → `/health` 200 → agent card verified → destroy (~40s).
- Separately validated the full warm-reuse lifecycle against real VMs: deploy → pause (status `suspended`) → redeploy resumes and goes healthy → destroy confirmed via machine listing. No orphaned VMs left behind.
- Pre-commit clean (ruff, ruff-format, ty, bandit, secrets baseline, pydocstyle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct interactive shell access with terminal input forwarding and resize support.
  * Added live log streaming and improved non-interactive command output handling.
  * Machines can now be resumed, awakened, or started automatically when needed.
  * VM sizing can use organization defaults when values are omitted.

* **Bug Fixes**
  * Added upload verification to detect incomplete source transfers.
  * Improved cleanup of terminal settings, processes, and runtime resources.

* **Documentation**
  * Updated runtime and quickstart guidance for current machine management, pausing, logs, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->