### PR TITLE
fix(worker): preserve A2A parts in handler message history

### DIFF
--- a/bindu/grpc/client.py
+++ b/bindu/grpc/client.py
@@ -13,10 +13,11 @@ Supports both unary and streaming responses:
 
 Key contract:
     - Input:  list[dict] — A2A protocol messages with "parts" (as passed
-      through by ManifestWorker.build_message_history), plus optionally a
-      chat-format {"role": "system", "content": ...} system prompt. The
-      proto ChatMessage only carries {role, content}, so this client
-      flattens parts to text at the wire boundary (_build_request).
+      through by ManifestWorker.build_message_history, including the
+      A2A-shaped injected system prompt). The proto ChatMessage only
+      carries {role, content}, so this client flattens parts to text at
+      the wire boundary (_build_request); chat-shaped {role, content}
+      dicts from direct callers are passed through for compatibility.
     - Output: str (normal completion), dict with "state" key (state transition),
       or generator of str/dict (streaming — collected by ResultProcessor).
 
@@ -115,10 +116,10 @@ class GrpcAgentClient:
         """Convert message history to a proto HandleRequest.
 
         ManifestWorker passes A2A protocol messages through with ``parts``
-        intact (plus an optional chat-format system message). The proto
-        ChatMessage only carries {role, content}, so flattening happens here
-        at the wire boundary: parts collapse to text (file parts extracted
-        by FileInterceptor) and A2A roles map to chat roles.
+        intact (system prompt included). The proto ChatMessage only carries
+        {role, content}, so flattening happens here at the wire boundary:
+        parts collapse to text (file parts extracted by FileInterceptor)
+        and A2A roles map to chat roles ("system" maps through unchanged).
 
         Args:
             messages: Conversation history — A2A messages with "parts",
@@ -127,25 +128,38 @@ class GrpcAgentClient:
         Returns:
             HandleRequest proto message ready for gRPC call.
         """
-        chat_messages: list[dict[str, str]] = []
+        proto_messages: list[agent_handler_pb2.ChatMessage] = []
         for m in messages:
             if m.get("parts"):
                 # A2A message → flatten to {role, content} for the proto.
-                chat_messages.extend(
-                    MessageConverter.to_chat_format(cast("list[Message]", [m]))
+                flattened = MessageConverter.to_chat_format(cast("list[Message]", [m]))
+                proto_messages.extend(
+                    agent_handler_pb2.ChatMessage(
+                        role=cm["role"], content=cm["content"]
+                    )
+                    for cm in flattened
                 )
+                if not flattened:
+                    # Data-only / empty parts carry no proto-representable
+                    # text — the turn is invisible to the SDK agent. Local
+                    # handlers still receive it; see docs/grpc/limitations.md.
+                    logger.debug(
+                        f"Message with no extractable text dropped from gRPC "
+                        f"request (role={m.get('role')})"
+                    )
             elif "content" in m:
-                # Already chat-shaped (e.g. the injected system prompt).
-                chat_messages.append(
-                    {"role": m.get("role", "user"), "content": m.get("content", "")}
+                # Chat-shaped compatibility for direct callers still passing
+                # the pre-parts flattened format.
+                proto_messages.append(
+                    agent_handler_pb2.ChatMessage(
+                        role=m.get("role", "user"), content=m.get("content", "")
+                    )
                 )
-        proto_messages = [
-            agent_handler_pb2.ChatMessage(
-                role=m["role"],
-                content=m["content"],
-            )
-            for m in chat_messages
-        ]
+            else:
+                logger.debug(
+                    f"Message with neither parts nor content dropped from "
+                    f"gRPC request (role={m.get('role')})"
+                )
         return agent_handler_pb2.HandleRequest(messages=proto_messages)
 
     def __call__(self, messages: list[dict[str, Any]], **kwargs: Any) -> Any:

--- a/bindu/grpc/client.py
+++ b/bindu/grpc/client.py
@@ -12,7 +12,11 @@ Supports both unary and streaming responses:
       chunks. ResultProcessor.collect_results() drains it automatically.
 
 Key contract:
-    - Input:  list[dict[str, str]] — chat messages [{"role": "user", "content": "..."}]
+    - Input:  list[dict] — A2A protocol messages with "parts" (as passed
+      through by ManifestWorker.build_message_history), plus optionally a
+      chat-format {"role": "system", "content": ...} system prompt. The
+      proto ChatMessage only carries {role, content}, so this client
+      flattens parts to text at the wire boundary (_build_request).
     - Output: str (normal completion), dict with "state" key (state transition),
       or generator of str/dict (streaming — collected by ResultProcessor).
 
@@ -23,12 +27,14 @@ and a remote gRPC handler.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import grpc
 
+from bindu.common.protocol.types import Message
 from bindu.grpc.generated import agent_handler_pb2, agent_handler_pb2_grpc
 from bindu.utils.logging import get_logger
+from bindu.utils.worker import MessageConverter
 
 logger = get_logger("bindu.grpc.client")
 
@@ -104,27 +110,45 @@ class GrpcAgentClient:
             logger.debug(f"Connected to agent handler at {scheme}://{self._address}")
 
     def _build_request(
-        self, messages: list[dict[str, str]]
+        self, messages: list[dict[str, Any]]
     ) -> agent_handler_pb2.HandleRequest:
-        """Convert chat-format messages to a proto HandleRequest.
+        """Convert message history to a proto HandleRequest.
+
+        ManifestWorker passes A2A protocol messages through with ``parts``
+        intact (plus an optional chat-format system message). The proto
+        ChatMessage only carries {role, content}, so flattening happens here
+        at the wire boundary: parts collapse to text (file parts extracted
+        by FileInterceptor) and A2A roles map to chat roles.
 
         Args:
-            messages: Conversation history as list of dicts.
-                Each dict has "role" (str) and "content" (str) keys.
+            messages: Conversation history — A2A messages with "parts",
+                and/or chat-format dicts with "role"/"content" keys.
 
         Returns:
             HandleRequest proto message ready for gRPC call.
         """
+        chat_messages: list[dict[str, str]] = []
+        for m in messages:
+            if m.get("parts"):
+                # A2A message → flatten to {role, content} for the proto.
+                chat_messages.extend(
+                    MessageConverter.to_chat_format(cast("list[Message]", [m]))
+                )
+            elif "content" in m:
+                # Already chat-shaped (e.g. the injected system prompt).
+                chat_messages.append(
+                    {"role": m.get("role", "user"), "content": m.get("content", "")}
+                )
         proto_messages = [
             agent_handler_pb2.ChatMessage(
-                role=m.get("role", "user"),
-                content=m.get("content", ""),
+                role=m["role"],
+                content=m["content"],
             )
-            for m in messages
+            for m in chat_messages
         ]
         return agent_handler_pb2.HandleRequest(messages=proto_messages)
 
-    def __call__(self, messages: list[dict[str, str]], **kwargs: Any) -> Any:
+    def __call__(self, messages: list[dict[str, Any]], **kwargs: Any) -> Any:
         """Execute the remote handler with conversation history.
 
         Called by ManifestWorker at line 171:
@@ -136,8 +160,8 @@ class GrpcAgentClient:
               ResultProcessor.collect_results() drains generators via __next__.
 
         Args:
-            messages: Conversation history as list of dicts.
-                Each dict has "role" (str) and "content" (str) keys.
+            messages: Conversation history — A2A protocol messages with
+                "parts" and/or chat-format dicts (see _build_request).
             **kwargs: Additional keyword arguments (ignored, for compatibility).
 
         Returns:

--- a/bindu/penguin/bindufy.py
+++ b/bindu/penguin/bindufy.py
@@ -684,7 +684,7 @@ def _bindufy_core(
 
 def bindufy(
     config: Dict[str, Any],
-    handler: Callable[[list[dict[str, str]]], Any],
+    handler: Callable[[list[dict[str, Any]]], Any],
     run_server: bool = True,
     key_dir: str | Path | None = None,
     launch: bool = False,
@@ -721,7 +721,13 @@ def bindufy(
             - global_webhook_url: Default webhook URL for all tasks (optional)
             - global_webhook_token: Authentication token for global webhook (optional)
         handler: The handler function that processes messages and returns responses.
-                Must have signature: (messages: list[dict[str, str]]) -> Any
+                Must have signature: (messages: list[dict[str, Any]]) -> Any.
+                Each message is an A2A protocol message: {"role": "user" |
+                "agent" | "system", "kind": "message", "parts": [...]} where
+                parts are {"kind": "text", "text": ...}, {"kind": "file",
+                "file": {"bytes", "mimeType", "name"}}, or {"kind": "data",
+                "data": {...}}. Read text via the message's parts, and file
+                bytes via part["file"]["bytes"] (base64).
         run_server: If True, starts the uvicorn server (blocking). If False, returns manifest
                    immediately for testing/programmatic usage (default: True)
         key_dir: Directory for storing DID keys. If None, attempts to detect from caller's
@@ -733,8 +739,14 @@ def bindufy(
         AgentManifest: The manifest for the bindufied agent
 
     Example:
-        def my_handler(messages: list[dict[str, str]]) -> str:
-            result = agent.run(input=messages)
+        def my_handler(messages: list[dict[str, Any]]) -> str:
+            # A2A contract: message text lives in parts.
+            user_text = " ".join(
+                p.get("text", "")
+                for p in messages[-1].get("parts", [])
+                if p.get("kind") == "text"
+            )
+            result = agent.run(input=user_text)
             return result.to_dict()["content"]
 
         config = {

--- a/bindu/server/workers/base.py
+++ b/bindu/server/workers/base.py
@@ -204,17 +204,20 @@ class Worker(ABC):
 
     @abstractmethod
     def build_message_history(self, history: list[Message]) -> list[Any]:
-        """Convert A2A protocol messages to agent-specific format.
+        """Prepare A2A protocol messages for agent execution.
 
         Args:
             history: List of protocol Message objects
 
         Returns:
-            List in format suitable for agent execution (e.g., chat format for LLMs)
+            List in the format handlers consume. ManifestWorker passes A2A
+            messages through with ``parts`` intact (the handler contract);
+            chat-format flattening happens only at wire boundaries that
+            require it (e.g. the gRPC proto).
 
         Example:
-            Protocol: [{"role": "user", "parts": [{"text": "Hello"}]}]
-            Agent: [{"role": "user", "content": "Hello"}]
+            Protocol: [{"role": "user", "parts": [{"kind": "text", "text": "Hello"}]}]
+            Agent:    [{"role": "user", "parts": [{"kind": "text", "text": "Hello"}]}]
         """
         ...
 

--- a/bindu/server/workers/manifest_worker.py
+++ b/bindu/server/workers/manifest_worker.py
@@ -278,16 +278,24 @@ class ManifestWorker(Worker):
                 params["task_id"], task["context_id"], "canceled", True
             )
 
-    def build_message_history(self, history: list[Message]) -> list[dict[str, str]]:
-        """Convert A2A protocol messages to chat format for manifest execution.
+    def build_message_history(self, history: list[Message]) -> list[dict[str, Any]]:
+        """Pass A2A protocol messages through verbatim — each keeps its ``parts``.
+
+        Handlers read ``messages[-1]["parts"]`` (text / file / data parts)
+        directly; that is the A2A contract agents are written against. Do NOT
+        flatten to ``{role, content}`` here: it discards ``parts``, and the
+        file interceptor cannot represent binary (PDF/image) bytes as text,
+        so every file/vision handler receives an empty message. Chat-format
+        flattening happens only at the gRPC boundary
+        (``GrpcAgentClient._build_request``), whose proto requires it.
 
         Args:
             history: List of A2A protocol Message objects
 
         Returns:
-            List of dicts with 'role' and 'content' keys for LLM consumption
+            The same messages as plain dicts, ``parts`` intact.
         """
-        return MessageConverter.to_chat_format(history)
+        return [{**m} for m in history]
 
     def build_artifacts(self, result: Any) -> list[Artifact]:
         """Convert manifest execution result to A2A protocol artifacts.
@@ -304,7 +312,7 @@ class ManifestWorker(Worker):
         did_extension = self.manifest.did_extension
         return ArtifactBuilder.from_result(result, did_extension=did_extension)
 
-    async def _build_complete_message_history(self, task: Task) -> list[dict[str, str]]:
+    async def _build_complete_message_history(self, task: Task) -> list[dict[str, Any]]:
         """Build complete conversation history following A2A Protocol.
 
         A2A Protocol Strategy:
@@ -320,7 +328,7 @@ class ManifestWorker(Worker):
             task: Current task being executed
 
         Returns:
-            List of chat-formatted messages for agent execution
+            List of A2A protocol messages (``parts`` intact) for agent execution
         """
         # Extract referenceTaskIds from current task message
         current_message = task.get("history", [])[0] if task.get("history") else None

--- a/bindu/server/workers/manifest_worker.py
+++ b/bindu/server/workers/manifest_worker.py
@@ -62,6 +62,26 @@ INVALID_TERMINAL_STATE_ERROR = (
 )
 
 
+def _jsonable_copy(value: Any) -> Any:
+    """Structurally copy containers, stringifying UUID leaves.
+
+    Handler input must be (a) isolated — the in-memory backend's
+    list_tasks_by_context hands out live references to stored task dicts,
+    so without copying nested containers a handler mutating `parts` would
+    corrupt stored history — and (b) JSON-serializable with the same shape
+    on every storage backend (memory preserves UUID objects, Postgres loads
+    them differently). Leaf values (including large base64 payload strings)
+    are shared, not duplicated.
+    """
+    if isinstance(value, dict):
+        return {k: _jsonable_copy(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_jsonable_copy(v) for v in value]
+    if isinstance(value, UUID):
+        return str(value)
+    return value
+
+
 @dataclass
 class ManifestWorker(Worker):
     """Concrete worker implementation using AgentManifest for task execution.
@@ -167,13 +187,19 @@ class ManifestWorker(Worker):
                 self.manifest.enable_system_message
                 and app_settings.agent.enable_structured_responses
             ):
-                # Inject structured response system prompt as first message
+                # Inject structured response system prompt as first message.
+                # A2A-shaped like the rest of the history — handlers see one
+                # uniform contract (every message has `parts`), and the gRPC
+                # boundary maps role "system" through unchanged via ROLE_MAP.
                 system_prompt = app_settings.agent.structured_response_system_prompt
                 if system_prompt:
+                    system_message = {
+                        "role": "system",
+                        "kind": "message",
+                        "parts": [{"kind": "text", "text": system_prompt}],
+                    }
                     # Create new list to avoid mutating original message_history
-                    message_history = [{"role": "system", "content": system_prompt}] + (
-                        message_history or []
-                    )
+                    message_history = [system_message] + (message_history or [])
 
             # Step 3.1: Execute agent with tracing
             with tracer.start_as_current_span("agent.execute") as agent_span:
@@ -279,7 +305,7 @@ class ManifestWorker(Worker):
             )
 
     def build_message_history(self, history: list[Message]) -> list[dict[str, Any]]:
-        """Pass A2A protocol messages through verbatim — each keeps its ``parts``.
+        """Pass A2A protocol messages through — each keeps its ``parts``.
 
         Handlers read ``messages[-1]["parts"]`` (text / file / data parts)
         directly; that is the A2A contract agents are written against. Do NOT
@@ -289,13 +315,18 @@ class ManifestWorker(Worker):
         flattening happens only at the gRPC boundary
         (``GrpcAgentClient._build_request``), whose proto requires it.
 
+        Messages are structurally copied (see ``_jsonable_copy``) so handler
+        mutations cannot reach stored task history, and envelope UUIDs are
+        stringified so the input is JSON-serializable and shaped identically
+        on every storage backend. ``parts`` content is untouched.
+
         Args:
             history: List of A2A protocol Message objects
 
         Returns:
-            The same messages as plain dicts, ``parts`` intact.
+            The same messages as plain JSON-safe dicts, ``parts`` intact.
         """
-        return [{**m} for m in history]
+        return [_jsonable_copy(m) for m in history]
 
     def build_artifacts(self, result: Any) -> list[Artifact]:
         """Convert manifest execution result to A2A protocol artifacts.

--- a/bindu/utils/worker/messages.py
+++ b/bindu/utils/worker/messages.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import io
+from functools import lru_cache
 from typing import Any, Optional, Union
 from uuid import UUID, uuid4
 
@@ -67,6 +68,20 @@ class FileInterceptor:
             mime_type = file_obj.get("mimeType", "")
             base64_data = str(file_obj.get("bytes", ""))
 
+            if not base64_data:
+                # FileWithUri (or missing bytes): nothing to decode locally.
+                # Say so explicitly instead of emitting an empty "Document
+                # Uploaded" block from b64decode("").
+                ref = file_obj.get("uri") or file_obj.get("name") or "unknown"
+                logger.warning(f"File part without inline bytes skipped: {ref}")
+                processed_parts.append(
+                    {
+                        "kind": "text",
+                        "text": f"[File reference not fetched: {ref}]",
+                    }
+                )
+                continue
+
             if mime_type not in cls.SUPPORTED_MIME_TYPES:
                 logger.warning(f"Unsupported MIME type rejected: {mime_type}")
                 processed_parts.append(
@@ -78,20 +93,7 @@ class FileInterceptor:
                 continue
 
             try:
-                # Decode the Base64 payload
-                file_bytes = base64.b64decode(base64_data)
-                extracted_text = ""
-
-                # Route to specific parser based on MIME type
-                if mime_type == "application/pdf":
-                    extracted_text = cls._extract_pdf(file_bytes)
-                elif mime_type == "text/plain":
-                    extracted_text = file_bytes.decode("utf-8")
-                elif (
-                    mime_type
-                    == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-                ):
-                    extracted_text = cls._extract_docx(file_bytes)
+                extracted_text = _extract_file_text(mime_type, base64_data)
 
                 # Inject the parsed document as a formatted text prompt
                 processed_parts.append(
@@ -113,10 +115,28 @@ class FileInterceptor:
         return processed_parts
 
 
+@lru_cache(maxsize=8)
+def _extract_file_text(mime_type: str, base64_data: str) -> str:
+    """Decode and extract text from a supported file payload.
+
+    Cached because task history is append-only: on a multi-turn
+    conversation every turn re-flattens the full history, and without the
+    cache the same PDF is base64-decoded and re-parsed on every turn,
+    synchronously on the event loop. Failures are not cached (lru_cache
+    only stores successful returns).
+    """
+    file_bytes = base64.b64decode(base64_data)
+    if mime_type == "application/pdf":
+        return FileInterceptor._extract_pdf(file_bytes)
+    if mime_type == "text/plain":
+        return file_bytes.decode("utf-8")
+    return FileInterceptor._extract_docx(file_bytes)
+
+
 class MessageConverter:
     """Optimized converter for message format transformations."""
 
-    ROLE_MAP = {"agent": "assistant", "user": "user"}
+    ROLE_MAP = {"agent": "assistant", "user": "user", "system": "system"}
 
     @staticmethod
     def to_chat_format(history: list[Message]) -> list[ChatMessage]:

--- a/bindu/utils/worker/messages.py
+++ b/bindu/utils/worker/messages.py
@@ -62,8 +62,10 @@ class FileInterceptor:
                 processed_parts.append(part)
                 continue
 
-            mime_type = part.get("mimeType", "")
-            base64_data = str(part.get("data", ""))
+            # A2A FilePart shape: {"kind": "file", "file": {"bytes", "mimeType", "name"}}
+            file_obj = part.get("file") or {}
+            mime_type = file_obj.get("mimeType", "")
+            base64_data = str(file_obj.get("bytes", ""))
 
             if mime_type not in cls.SUPPORTED_MIME_TYPES:
                 logger.warning(f"Unsupported MIME type rejected: {mime_type}")

--- a/docs/FILE_HANDLING_&_UPLOADS.md
+++ b/docs/FILE_HANDLING_&_UPLOADS.md
@@ -1,44 +1,12 @@
-﻿# File Handling & Uploads
+# File Handling & Uploads
 
-Bindu provides built-in file handling at the framework layer, so agent authors do not need to implement custom upload parsing logic. Uploaded files are validated, parsed, and injected into conversation context as plain text before agent execution.
+When a client uploads a file, your handler receives the real bytes. Bindu stores the uploaded A2A file part verbatim in task history and passes it through to your handler untouched — base64 payload, MIME type, and filename intact. Your agent decides what to do with them: parse a PDF, feed an image to a vision model, or hand the bytes to a downstream tool.
 
-This design gives you:
-- Consistent parsing behavior across agents
-- Strict MIME-type validation before execution
-- Zero-configuration file support for common document workflows
-
-## How It Works
-
-```mermaid
-sequenceDiagram
-    participant Client
-    participant API as Bindu API
-    participant FH as File Handler
-    participant Worker as ManifestWorker
-    participant Agent
-
-    Client->>API: POST / (JSON-RPC message/send)\nparts: [text, file]
-    API->>FH: Detect file part (kind=file)
-    FH->>FH: Decode Base64 payload
-    FH->>FH: Validate MIME type
-    FH->>FH: Parse content (PDF/text)
-    FH-->>API: Inject extracted text into message
-    API->>Worker: Forward normalized message history
-    Worker->>Agent: Execute with parsed file content
-    Agent-->>Client: Structured response
-```
-
-## Supported Formats
-
-Bindu currently supports:
-- `application/pdf` (PDF parsing)
-- Text MIME types such as `text/plain`, `text/csv`
-
-Unsupported MIME types are rejected before task execution.
+This matters because flattening files to text destroys information. A framework cannot know whether your agent wants extracted text, raw bytes for a vision model, or the original file for re-upload — so it doesn't guess.
 
 ## Upload Request Format
 
-Files are sent using A2A JSON-RPC as Base64 data inside a `parts` item with `"kind": "file"`.
+Files travel as A2A `FilePart` entries inside `message/send`. The file payload is nested under `file` — not at the top level of the part:
 
 ```json
 {
@@ -59,8 +27,12 @@ Files are sent using A2A JSON-RPC as Base64 data inside a `parts` item with `"ki
         },
         {
           "kind": "file",
-          "mimeType": "application/pdf",
-          "data": "JVBERi0xLjQK...<base64>..."
+          "text": "report.pdf",
+          "file": {
+            "bytes": "JVBERi0xLjQK...<base64>...",
+            "mimeType": "application/pdf",
+            "name": "report.pdf"
+          }
         }
       ]
     }
@@ -68,66 +40,48 @@ Files are sent using A2A JSON-RPC as Base64 data inside a `parts` item with `"ki
 }
 ```
 
-## Processing Pipeline
+The `text` field on the file part is currently required by request validation; use the filename.
 
-### 1. Protocol Interception
+## Reading Files in a Python Handler
 
-The message conversion layer detects `"kind": "file"` parts in incoming payloads.
+Your handler receives the full A2A message history. Find file parts and decode:
 
-### 2. Extraction and Validation
+```python
+import base64
 
-The file handler decodes Base64 content, validates MIME type, and routes to the parser.
 
-### 3. Context Injection
-
-Parsed content is transformed into a text block and appended to the conversation payload.
-
-Example injected structure:
-
-```text
-[Attached Document: file.pdf]
-...extracted content...
+def handler(messages):
+    last = messages[-1]
+    for part in last.get("parts", []):
+        if part.get("kind") == "file":
+            file_obj = part["file"]
+            raw = base64.b64decode(file_obj.get("bytes", ""))
+            name = file_obj.get("name", "upload")
+            mime = file_obj.get("mimeType", "")
+            # raw is the exact uploaded content — parse, embed, or forward it.
+    ...
 ```
 
-### 4. Agent Execution
+Byte integrity is guaranteed end to end: what the client base64-encoded is exactly what `b64decode` returns in your handler.
 
-`ManifestWorker` receives normalized text content and runs the agent with file data already in message history.
+## gRPC (SDK) Agents Get Extracted Text
 
-## Developer Experience
+The gRPC wire format (`ChatMessage`) only carries `{role, content}` strings, so file parts are flattened at that boundary — and only there:
 
-### Zero Configuration for Agents
+- `application/pdf`, `text/plain`, and `.docx` payloads are decoded and their text is injected into `content` as a `--- Document Uploaded ---` block.
+- Other MIME types (images included) arrive as an `[Unsupported file type: ...]` placeholder — binary cannot cross the current proto.
+- A `FileWithUri` part without inline bytes arrives as `[File reference not fetched: <uri>]`; the core does not download URIs.
 
-Agent code does not need to handle:
-- Base64 decoding
-- Binary parsing
-- MIME validation
-
-Agents receive clean text content and can immediately summarize, classify, extract, or reason over uploaded documents.
+If your agent needs raw file bytes, write it as a Python handler for now; carrying parts over the proto is a planned protocol change (see [gRPC limitations](./grpc/limitations.md)).
 
 ## Security Considerations
 
-- Validate MIME types strictly at the API boundary
-- Reject unsupported file formats before task execution
-- Avoid passing raw binary payloads to model execution
-- Keep parser dependencies updated for security patches
-
-## Tips
-
-- Prefer text-based formats when possible for lower parsing overhead
-- Keep user prompts explicit (for example: summarize, extract entities, compare)
-- Return clear validation errors for unsupported file types
+- Treat uploaded bytes as untrusted input: cap sizes, validate MIME types against what your agent actually supports, and sandbox parsers.
+- Keep parser dependencies (pypdf, python-docx, image libraries) updated for security patches.
+- Reject unsupported formats early with a clear validation error rather than deep in your pipeline.
 
 ## Related Documentation
 
 - [Streaming](./STREAMING.md)
 - [Storage](./STORAGE.md)
 - [Authentication](./AUTHENTICATION.md)
-du abstracts file handling into a seamless pipeline:
-
-```text id="u5p9e2"
-Upload → Parse → Inject → Consume
-```
-
-👉 So you can focus on **agent logic**, not file infrastructure.
-
----

--- a/docs/GRPC_LANGUAGE_AGNOSTIC.md
+++ b/docs/GRPC_LANGUAGE_AGNOSTIC.md
@@ -654,9 +654,12 @@ Kotlin stubs are generated automatically by the Gradle protobuf plugin during `.
 from bindu.grpc.generated.agent_handler_pb2 import ChatMessage, HandleRequest
 from bindu.grpc.generated.agent_handler_pb2_grpc import AgentHandlerStub
 
-# Convert Python dicts → proto messages
-proto_msgs = [ChatMessage(role=m["role"], content=m["content"]) for m in messages]
-request = HandleRequest(messages=proto_msgs)
+# Flatten A2A messages → proto messages. The core hands manifest.run raw
+# A2A messages (with `parts`); the proto ChatMessage only carries
+# {role, content}, so text is extracted from parts and A2A roles are
+# mapped ("agent" → "assistant") here at the wire boundary — see
+# GrpcAgentClient._build_request in bindu/grpc/client.py.
+request = self._build_request(messages)
 
 # Make gRPC call using generated stub
 response = self._stub.HandleMessages(request, timeout=30.0)

--- a/docs/grpc/client.md
+++ b/docs/grpc/client.md
@@ -29,9 +29,12 @@ class GrpcAgentClient:
         self._timeout = timeout
 
     def __call__(self, messages, **kwargs):
-        # 1. Convert Python dicts to protobuf
-        proto_msgs = [ChatMessage(role=m["role"], content=m["content"]) for m in messages]
-        request = HandleRequest(messages=proto_msgs)
+        # 1. Flatten A2A messages (with `parts`) to protobuf {role, content}.
+        #    The proto ChatMessage has no parts field, so text parts collapse
+        #    to content, file parts are text-extracted, and A2A roles map to
+        #    chat roles ("agent" -> "assistant") — this is the ONE place
+        #    chat-format flattening still happens.
+        request = self._build_request(messages)
 
         # 2. Call the SDK's AgentHandler over gRPC
         response = self._stub.HandleMessages(request, timeout=self._timeout)
@@ -63,8 +66,9 @@ A user sends "What is quantum computing?" to a TypeScript agent:
 
 ```
 ManifestWorker calls manifest.run(messages)
-  → GrpcAgentClient.__call__([{"role": "user", "content": "What is quantum computing?"}])
-    → Converts to protobuf: ChatMessage(role="user", content="What is quantum computing?")
+  → GrpcAgentClient.__call__([{"role": "user", "kind": "message",
+        "parts": [{"kind": "text", "text": "What is quantum computing?"}], ...}])
+    → Flattens parts to protobuf: ChatMessage(role="user", content="What is quantum computing?")
     → gRPC call: AgentHandler.HandleMessages(HandleRequest{messages: [...]})
     → TypeScript SDK receives the call
     → Developer's handler runs: await openai.chat.completions.create(...)

--- a/docs/grpc/limitations.md
+++ b/docs/grpc/limitations.md
@@ -68,8 +68,9 @@ If you run two instances of the same TypeScript agent, each one registers separa
 | State transitions (input-required) | works | works |
 | Health checks | works | works |
 | Multi-language | Python only | any language |
+| File/binary parts | works (raw A2A parts) | **flattened to text** |
 | Latency overhead | 0ms | 1-5ms |
 | TLS | N/A (in-process) | **not implemented** |
 | Auto-reconnection | N/A (in-process) | **not implemented** |
 
-The bottom line: gRPC agents have **full feature parity** with Python agents for the core functionality (DID, auth, payments, skills, A2A protocol). The gaps are in streaming, security, and resilience — all planned for future releases.
+The bottom line: gRPC agents have **near-full feature parity** with Python agents for the core functionality (DID, auth, payments, skills). The message contract differs in one important way: Python handlers receive raw A2A messages with `parts` intact (including file bytes), while the gRPC proto `ChatMessage` only carries `{role, content}` strings — so file parts are text-extracted (PDF/txt/docx) or replaced with an `[Unsupported file type: ...]` placeholder at the wire boundary, and messages with no extractable text (e.g. data-part-only) are dropped from the gRPC request. Vision/file agents that need raw bytes must be Python handlers until the proto grows a parts field. The remaining gaps are streaming, security, and resilience — all planned for future releases.

--- a/docs/runtime/README.md
+++ b/docs/runtime/README.md
@@ -25,7 +25,13 @@ from bindu.penguin.bindufy import bindufy
 
 
 def handler(messages):
-    return [{"role": "assistant", "content": messages[-1]["content"]}]
+    # A2A contract: the message text lives in parts.
+    text = " ".join(
+        p.get("text", "")
+        for p in messages[-1].get("parts", [])
+        if p.get("kind") == "text"
+    )
+    return [{"role": "assistant", "content": text}]
 
 
 config = {

--- a/docs/runtime/quickstart.md
+++ b/docs/runtime/quickstart.md
@@ -102,10 +102,16 @@ def handler(messages):
     """Echo the latest user message back."""
     if not messages:
         return "send a message"
+    # A2A contract: the message text lives in parts.
+    text = " ".join(
+        p.get("text", "")
+        for p in messages[-1].get("parts", [])
+        if p.get("kind") == "text"
+    )
     return [
         {
             "role": "assistant",
-            "content": messages[-1].get("content", ""),
+            "content": text,
         }
     ]
 

--- a/examples/ag2_research_team/main.py
+++ b/examples/ag2_research_team/main.py
@@ -51,7 +51,14 @@ def handler(messages: list[dict[str, str]]):
     """Run the AG2 research team and return the final report."""
     if not messages:
         return [{"role": "assistant", "content": "No input provided."}]
-    user_input = messages[-1].get("content", "")
+    last = messages[-1]
+    # A2A contract: the message text lives in parts. Fall back to "content"
+    # so the example also works against older bindu releases that flattened
+    # history to chat format.
+    text = " ".join(
+        p.get("text", "") for p in last.get("parts", []) if p.get("kind") == "text"
+    )
+    user_input = text or last.get("content", "")
     if not user_input:
         return [{"role": "assistant", "content": "Empty message."}]
 

--- a/examples/agent_swarm/bindu_super_agent.py
+++ b/examples/agent_swarm/bindu_super_agent.py
@@ -29,9 +29,13 @@ def handler(messages: list[dict[str, str]]) -> str:
     if not isinstance(last_msg, dict):
         return "Invalid message structure."
 
-    user_input = last_msg.get("content")
+    user_input = " ".join(
+        part.get("text", "")
+        for part in last_msg.get("parts") or []
+        if isinstance(part, dict) and part.get("kind") == "text"
+    ).strip()
 
-    if not user_input or not isinstance(user_input, str):
+    if not user_input:
         return "Empty or invalid message content."
 
     # -------- Swarm Execution --------

--- a/examples/beginner/ag2_simple_example.py
+++ b/examples/beginner/ag2_simple_example.py
@@ -42,7 +42,11 @@ def handler(messages: list[dict[str, str]]):
     if not messages:
         return [{"role": "assistant", "content": "No input provided."}]
 
-    user_input = messages[-1].get("content", "")
+    user_input = " ".join(
+        part.get("text", "")
+        for part in messages[-1].get("parts", [])
+        if part.get("kind") == "text"
+    ).strip()
     if not user_input:
         return [{"role": "assistant", "content": "Empty message."}]
 

--- a/examples/beginner/agno_example.py
+++ b/examples/beginner/agno_example.py
@@ -18,6 +18,7 @@ Environment:
 
 import os
 from bindu.penguin.bindufy import bindufy
+from bindu.utils.worker import MessageConverter
 from agno.agent import Agent
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.models.openrouter import OpenRouter
@@ -69,7 +70,7 @@ def handler(messages: list[dict[str, str]]):
     Returns:
         Agent response result
     """
-    result = agent.run(input=messages)
+    result = agent.run(input=MessageConverter.to_chat_format(messages))
     return result
 
 

--- a/examples/beginner/agno_notion_agent.py
+++ b/examples/beginner/agno_notion_agent.py
@@ -18,6 +18,7 @@ Environment:
 import os
 from dotenv import load_dotenv
 from bindu.penguin.bindufy import bindufy
+from bindu.utils.worker import MessageConverter
 from agno.agent import Agent
 from agno.models.openrouter import OpenRouter
 from notion_client import Client
@@ -105,7 +106,7 @@ config = {
 # -----------------------------
 def handler(messages: list[dict[str, str]]):
     """Process messages and return agent response"""
-    return agent.run(input=messages)
+    return agent.run(input=MessageConverter.to_chat_format(messages))
 
 
 # -----------------------------

--- a/examples/beginner/agno_paywall_example.py
+++ b/examples/beginner/agno_paywall_example.py
@@ -17,6 +17,7 @@ Environment:
 
 import os
 from bindu.penguin.bindufy import bindufy
+from bindu.utils.worker import MessageConverter
 from agno.agent import Agent
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.models.openrouter import OpenRouter
@@ -73,7 +74,7 @@ def handler(messages: list[dict[str, str]]):
     Returns:
         Agent response result
     """
-    result = agent.run(input=messages)
+    result = agent.run(input=MessageConverter.to_chat_format(messages))
     return result
 
 

--- a/examples/beginner/agno_simple_example.py
+++ b/examples/beginner/agno_simple_example.py
@@ -17,6 +17,7 @@ Environment:
 
 import os
 from bindu.penguin.bindufy import bindufy
+from bindu.utils.worker import MessageConverter
 from agno.agent import Agent
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.models.openrouter import OpenRouter
@@ -64,7 +65,7 @@ def handler(messages: list[dict[str, str]]):
     Returns:
         Agent response result
     """
-    result = agent.run(input=messages)
+    result = agent.run(input=MessageConverter.to_chat_format(messages))
     return result
 
 

--- a/examples/beginner/beginner_zero_config_agent.py
+++ b/examples/beginner/beginner_zero_config_agent.py
@@ -18,6 +18,7 @@ Environment:
 
 import os
 from bindu.penguin.bindufy import bindufy
+from bindu.utils.worker import MessageConverter
 from agno.agent import Agent
 from agno.models.openrouter import OpenRouter
 from agno.tools.duckduckgo import DuckDuckGoTools
@@ -47,7 +48,7 @@ config = {
 }
 
 def handler(messages):
-    return agent.run(input=messages)
+    return agent.run(input=MessageConverter.to_chat_format(messages))
 
 bindufy(config, handler)
 

--- a/examples/beginner/dspy_agent.py
+++ b/examples/beginner/dspy_agent.py
@@ -43,7 +43,11 @@ def handler(messages: list[dict]) -> list[dict]:
     Returns:
         List with a single assistant response message
     """
-    last_message = messages[-1]["content"]
+    last_message = " ".join(
+        part.get("text", "")
+        for part in messages[-1].get("parts", [])
+        if part.get("kind") == "text"
+    ).strip()
     result = qa_program(question=last_message)
     return [{"role": "assistant", "content": result.answer}]
 

--- a/examples/beginner/echo_agent_behind_paywall.py
+++ b/examples/beginner/echo_agent_behind_paywall.py
@@ -28,8 +28,13 @@ def handler(messages):
     Returns:
         List containing a single assistant message with the user's content.
     """
-    # Reply with the user's latest input
-    return [{"role": "assistant", "content": messages[-1]["content"]}]
+    # Reply with the text of the user's latest input (A2A parts contract)
+    text = " ".join(
+        part.get("text", "")
+        for part in messages[-1].get("parts", [])
+        if part.get("kind") == "text"
+    )
+    return [{"role": "assistant", "content": text}]
 
 
 config = {

--- a/examples/beginner/echo_simple_agent.py
+++ b/examples/beginner/echo_simple_agent.py
@@ -28,8 +28,13 @@ def handler(messages):
     Returns:
         List containing a single assistant message with the user's content.
     """
-    # Reply with the user's latest input
-    return [{"role": "assistant", "content": messages[-1]["content"]}]
+    # Reply with the text of the user's latest input (A2A parts contract)
+    text = " ".join(
+        part.get("text", "")
+        for part in messages[-1].get("parts", [])
+        if part.get("kind") == "text"
+    )
+    return [{"role": "assistant", "content": text}]
 
 
 config = {

--- a/examples/beginner/faq_agent.py
+++ b/examples/beginner/faq_agent.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from bindu.penguin.bindufy import bindufy
+from bindu.utils.worker import MessageConverter
 from agno.agent import Agent
 from agno.models.openrouter import OpenRouter
 from agno.tools.duckduckgo import DuckDuckGoTools
@@ -52,7 +53,7 @@ def handler(messages: list[dict[str, str]]):
     Returns:
         Agent response result
     """
-    result = agent.run(input=messages)
+    result = agent.run(input=MessageConverter.to_chat_format(messages))
     return result
 # ---------------------------------------------------------------------------
 # Bindu config

--- a/examples/beginner/minimax_example.py
+++ b/examples/beginner/minimax_example.py
@@ -18,6 +18,7 @@ Environment:
 
 import os
 from bindu.penguin.bindufy import bindufy
+from bindu.utils.worker import MessageConverter
 from agno.agent import Agent
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.models.openai import OpenAILike
@@ -66,7 +67,7 @@ def handler(messages: list[dict[str, str]]):
     Returns:
         Agent response result
     """
-    result = agent.run(input=messages)
+    result = agent.run(input=MessageConverter.to_chat_format(messages))
     return result
 
 

--- a/examples/beginner/motivational_agent.py
+++ b/examples/beginner/motivational_agent.py
@@ -19,6 +19,7 @@ Environment:
 
 import os
 from bindu.penguin.bindufy import bindufy
+from bindu.utils.worker import MessageConverter
 from agno.agent import Agent
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.models.openrouter import OpenRouter
@@ -72,7 +73,7 @@ def handler(messages: list[dict[str, str]]):
     Returns:
         Agent response result
     """
-    result = agent.run(input=messages)
+    result = agent.run(input=MessageConverter.to_chat_format(messages))
     return result
 
 

--- a/examples/hermes_agent/hermes_simple_example.py
+++ b/examples/hermes_agent/hermes_simple_example.py
@@ -76,19 +76,20 @@ def _get_agent() -> AIAgent:
 
 
 def _last_user_text(messages: list[dict[str, Any]]) -> str:
-    """Extract the newest user message's text, tolerating the A2A parts shape."""
+    """Extract the newest user message's text from A2A ``parts`` (chat fallback)."""
     for m in reversed(messages):
         if m.get("role") != "user":
             continue
+        parts = m.get("parts")
+        if isinstance(parts, list):
+            return "\n".join(
+                p.get("text", "")
+                for p in parts
+                if isinstance(p, dict) and p.get("kind") == "text"
+            )
         content = m.get("content", "")
         if isinstance(content, str):
             return content
-        if isinstance(content, list):
-            return "\n".join(
-                p.get("text", "")
-                for p in content
-                if isinstance(p, dict) and p.get("kind") == "text"
-            )
     return ""
 
 

--- a/examples/langgraph_blog_writing_agent/main.py
+++ b/examples/langgraph_blog_writing_agent/main.py
@@ -15,11 +15,17 @@ def handler(messages):
 
         last_message = messages[-1]
 
-        # Support both formats:
-        # 1) [{"role": "user", "content": "..."}]
-        # 2) ["plain string"]
+        # Support all formats:
+        # 1) A2A messages: [{"role": "user", "parts": [{"kind": "text", ...}]}]
+        # 2) chat format (older bindu releases): [{"role": "user", "content": "..."}]
+        # 3) ["plain string"]
         if isinstance(last_message, dict):
-            query = last_message.get("content", "")
+            text = " ".join(
+                p.get("text", "")
+                for p in last_message.get("parts", [])
+                if p.get("kind") == "text"
+            )
+            query = text or last_message.get("content", "")
         else:
             query = str(last_message)
 

--- a/examples/medical_agent/medical_agent.py
+++ b/examples/medical_agent/medical_agent.py
@@ -84,7 +84,15 @@ def handler(messages: list[dict[str, str]]) -> str:
     latest_message = messages[-1]
 
     if isinstance(latest_message, dict):
-        user_message = latest_message.get("content", "")
+        # A2A contract: the message text lives in parts. Fall back to "content"
+        # so the example also works against older bindu releases that flattened
+        # history to chat format.
+        text = " ".join(
+            p.get("text", "")
+            for p in latest_message.get("parts", [])
+            if p.get("kind") == "text"
+        )
+        user_message = text or latest_message.get("content", "")
     else:
         user_message = latest_message
 

--- a/examples/news-summarizer/news_agent.py
+++ b/examples/news-summarizer/news_agent.py
@@ -20,6 +20,7 @@ from agno.agent import Agent
 from agno.models.ollama import Ollama
 from agno.tools.duckduckgo import DuckDuckGoTools
 from bindu.penguin.bindufy import bindufy
+from bindu.utils.worker import MessageConverter
 
 load_dotenv()
 
@@ -55,14 +56,13 @@ def handler(messages: list[dict[str, str]]):
     """Process incoming messages and return news summary.
 
     Args:
-        messages: Conversation history as list of dicts
-                  e.g. [{"role": "user", "content": "cricket news"}]
+        messages: Conversation history as raw A2A messages, e.g.
+                  [{"role": "user", "parts": [{"kind": "text", "text": "cricket news"}], ...}]
 
     Returns:
         Agent response with structured news summary
     """
-    latest_message = messages[-1]["content"]
-    result = agent.run(input=messages)
+    result = agent.run(input=MessageConverter.to_chat_format(messages))
     return result
 
 # Launch

--- a/examples/pdf_research_agent/pdf_research_agent.py
+++ b/examples/pdf_research_agent/pdf_research_agent.py
@@ -16,14 +16,17 @@ Usage
     python pdf_research_agent.py
 
 The agent will be live at http://localhost:3775
-Send it a message like:
-    {"role": "user", "content": "/path/to/paper.pdf"}
-or paste raw text directly as the message content.
+Send it an A2A message whose parts carry either an inline PDF file part:
+    {"kind": "file", "text": "paper.pdf",
+     "file": {"bytes": "<base64>", "mimeType": "application/pdf", "name": "paper.pdf"}}
+or a text part with a PDF path or raw document text.
 """
 from bindu.penguin.bindufy import bindufy
 from agno.agent import Agent
 from agno.models.openrouter import OpenRouter
 from dotenv import load_dotenv
+import base64
+import io
 import os
 
 load_dotenv()
@@ -51,6 +54,22 @@ def _read_content(source: str) -> str:
         except Exception as e:
             return f"Error reading PDF '{source.strip()}': {str(e)}"
     return source  # treat as raw document text
+
+
+def _read_pdf_bytes(data: bytes) -> str:
+    """Return plain text extracted from an in-memory PDF (inline file part)."""
+    try:
+        from pypdf import PdfReader  # optional dependency
+        reader = PdfReader(io.BytesIO(data))
+        pages = [page.extract_text() or "" for page in reader.pages]
+        text = "\n\n".join(pages)
+        if len(text.strip()) < 100:
+            return "Attached PDF appears to be empty or contains very little text."
+        return text
+    except ImportError:
+        return "[pypdf not installed — cannot read the attached PDF. Run: uv add pypdf]"
+    except Exception as e:
+        return f"Error reading attached PDF: {str(e)}"
 
 
 # ---------------------------------------------------------------------------
@@ -110,8 +129,8 @@ def handler(messages: list[dict[str, str]]):
     message, read its content (PDF or raw text), and return a summary.
 
     Args:
-        messages: Standard A2A message list, e.g.
-                  [{"role": "user", "content": "/path/to/doc.pdf"}]
+        messages: Raw A2A message list; the latest user message's parts carry
+                  an inline PDF file part, a PDF path, or raw document text.
 
     Returns:
         Agent response with the document summary.
@@ -122,11 +141,27 @@ def handler(messages: list[dict[str, str]]):
         if not user_messages:
             return "No user message found. Please send a PDF path or document text."
 
-        user_input = user_messages[-1].get("content", "").strip()
-        if not user_input:
-            return "Empty message received. Please provide a PDF path or document text."
+        parts = user_messages[-1].get("parts", [])
+        user_input = " ".join(
+            p.get("text", "") for p in parts if p.get("kind") == "text"
+        ).strip()
+        pdf_bytes = next(
+            (
+                (p.get("file") or {}).get("bytes")
+                for p in parts
+                if p.get("kind") == "file"
+                and (p.get("file") or {}).get("mimeType") == "application/pdf"
+                and (p.get("file") or {}).get("bytes")
+            ),
+            None,
+        )
 
-        document_text = _read_content(user_input)
+        if pdf_bytes:
+            document_text = _read_pdf_bytes(base64.b64decode(pdf_bytes))
+        elif user_input:
+            document_text = _read_content(user_input)
+        else:
+            return "Empty message received. Please attach a PDF or provide a path/document text."
 
         # Check if document processing failed
         if document_text.startswith("[") or document_text.startswith("Error"):

--- a/examples/private_skills_agent/acme_compliance_agent.py
+++ b/examples/private_skills_agent/acme_compliance_agent.py
@@ -37,7 +37,14 @@ from bindu.penguin.bindufy import bindufy
 def handler(messages):
     """Echo the last message back. The point of the example is the
     PAYWALL shape on /agent/private.json, not what the handler does."""
-    last = messages[-1].get("content", "") if messages else ""
+    last_msg = messages[-1] if messages else {}
+    # A2A contract: the message text lives in parts. Fall back to "content"
+    # so the example also works against older bindu releases that flattened
+    # history to chat format.
+    text = " ".join(
+        p.get("text", "") for p in last_msg.get("parts", []) if p.get("kind") == "text"
+    )
+    last = text or last_msg.get("content", "")
     return f"acme_compliance_agent: received '{last}'"
 
 

--- a/examples/runtime-boxd-agent/agent.py
+++ b/examples/runtime-boxd-agent/agent.py
@@ -37,10 +37,17 @@ def handler(messages: list[dict[str, str]]):
     """Echo the latest user message back."""
     if not messages:
         return "send a message"
+    last = messages[-1]
+    # A2A contract: the message text lives in parts. Fall back to "content"
+    # so the example also works against older bindu releases that flattened
+    # history to chat format.
+    text = " ".join(
+        p.get("text", "") for p in last.get("parts", []) if p.get("kind") == "text"
+    )
     return [
         {
             "role": "assistant",
-            "content": messages[-1].get("content", ""),
+            "content": text or last.get("content", ""),
         }
     ]
 

--- a/examples/song-meaning-agent/song_meaning_agent.py
+++ b/examples/song-meaning-agent/song_meaning_agent.py
@@ -107,6 +107,19 @@ config = {
 # 3. Handler
 # ---------------------------------------------------------------------------
 
+def _message_text(message: dict) -> str:
+    """Extract text from an A2A message.
+
+    The text lives in message parts. Falls back to "content" so the example
+    also works against older bindu releases that flattened history to chat
+    format.
+    """
+    text = " ".join(
+        p.get("text", "") for p in message.get("parts", []) if p.get("kind") == "text"
+    )
+    return text or message.get("content", "")
+
+
 def handler(messages: list[dict[str, str]]):
     """Analyze the meaning of a song based on the user's query.
 
@@ -122,11 +135,20 @@ def handler(messages: list[dict[str, str]]):
         if not user_messages:
             return "No query received. Please ask about a song, e.g. 'What does Bohemian Rhapsody mean?'"
 
-        query = user_messages[-1].get("content", "").strip()
+        query = _message_text(user_messages[-1]).strip()
         if not query:
             return "Empty query. Please name a song or paste lyrics you'd like analyzed."
 
-        result = agent.run(input=messages)
+        # Flatten the history to chat format for the agno agent.
+        chat_messages = []
+        for m in messages:
+            text = _message_text(m)
+            if not text:
+                continue
+            role = "user" if m.get("role") == "user" else "assistant"
+            chat_messages.append({"role": role, "content": text})
+
+        result = agent.run(input=chat_messages)
         return result
 
     except Exception as e:

--- a/examples/speech-to-text/speech_to_text_agent.py
+++ b/examples/speech-to-text/speech_to_text_agent.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import tempfile
 from typing import Any
 
 from agno.agent import Agent
@@ -102,10 +103,36 @@ agent = Agent(
 def handler(messages: list[dict[str, str]]) -> Any:
     """Protocol-compliant handler for processing agent messages.
 
-    Signature required by Bindu: (messages: list[dict[str, str]]) -> Any
+    Reads the A2A ``parts`` contract: text parts become the query, and an
+    attached audio file part is written to a temp file so the agent's
+    path-based ``transcribe_audio`` tool can process it.
     """
-    # Extract the user's message text
-    user_query = messages[-1].get("content", "")
+    parts = messages[-1].get("parts", [])
+    user_query = " ".join(
+        p.get("text", "") for p in parts if p.get("kind") == "text"
+    ).strip()
+
+    audio_extensions = {
+        "audio/mpeg": ".mp3",
+        "audio/wav": ".wav",
+        "audio/x-wav": ".wav",
+        "audio/ogg": ".ogg",
+        "audio/mp4": ".m4a",
+    }
+    for part in parts:
+        file_obj = (part.get("file") or {}) if part.get("kind") == "file" else {}
+        audio_b64 = file_obj.get("bytes")
+        mime_type = file_obj.get("mimeType", "")
+        if not audio_b64 or not mime_type.startswith("audio/"):
+            continue
+        suffix = audio_extensions.get(mime_type, ".wav")
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp.write(base64.b64decode(audio_b64))
+        user_query = (
+            f"{user_query or 'Transcribe this audio file.'}\n"
+            f"Audio file path: {tmp.name}"
+        )
+        break
 
     # Run the Agno agent
     result = agent.run(user_query)

--- a/examples/summarizer/summarizer_agent.py
+++ b/examples/summarizer/summarizer_agent.py
@@ -26,7 +26,12 @@ agent = Agent(
 
 def handler(messages):
     """Return a summary of the user's latest input message."""
-    user_input = messages[-1]["content"]
+    latest = messages[-1]
+    user_input = " ".join(
+        part.get("text", "")
+        for part in latest.get("parts", [])
+        if part.get("kind") == "text"
+    ).strip()
     result = agent.run(input=user_input)
     return result
 

--- a/examples/web-scraping-agent/web_scraping_agent.py
+++ b/examples/web-scraping-agent/web_scraping_agent.py
@@ -72,11 +72,17 @@ def handler(messages: list[dict[str, str]]):
         Extracted and structured data from the requested web page
     """
     if messages:
-        latest = (
-            messages[-1].get("content", "")
-            if isinstance(messages[-1], dict)
-            else str(messages[-1])
-        )
+        last = messages[-1]
+        if isinstance(last, dict):
+            # A2A contract: the message text lives in parts. Fall back to
+            # "content" for older bindu releases that flattened history to
+            # chat format.
+            text = " ".join(
+                p.get("text", "") for p in last.get("parts", []) if p.get("kind") == "text"
+            )
+            latest = text or last.get("content", "")
+        else:
+            latest = str(last)
         result = agent.run(input=latest)
         if hasattr(result, "content"):
             return result.content

--- a/tests/e2e/runtime/echo_agent.py
+++ b/tests/e2e/runtime/echo_agent.py
@@ -10,10 +10,17 @@ def handler(messages):
     """Echo the last user message back, or a placeholder when input is empty."""
     if not messages:
         return "no message"
+    last = messages[-1]
+    # A2A contract: the message text lives in parts. Fall back to "content"
+    # so the fixture also works against older bindu releases that flattened
+    # history to chat format.
+    text = " ".join(
+        p.get("text", "") for p in last.get("parts", []) if p.get("kind") == "text"
+    )
     return [
         {
             "role": "assistant",
-            "content": messages[-1].get("content", ""),
+            "content": text or last.get("content", ""),
         }
     ]
 

--- a/tests/e2e/runtime/test_boxd_e2e.py
+++ b/tests/e2e/runtime/test_boxd_e2e.py
@@ -5,7 +5,9 @@ This test creates a real VM, ships a tiny echo agent, hits the A2A endpoint,
 and destroys the VM. Slow (~30–60s), costs real boxd resources.
 """
 
+import asyncio
 import os
+import uuid
 from pathlib import Path
 
 import httpx
@@ -67,6 +69,61 @@ async def test_full_lifecycle(tmp_path):
             assert resp.status_code == 200, resp.text
             card = resp.json()
             assert card.get("name") == "boxd-e2e-echo", card
+
+            # Exercise the actual message path: without this, a history
+            # contract regression (e.g. re-flattening parts) keeps the
+            # e2e green while every deployed echo returns empty output.
+            task_id, context_id = str(uuid.uuid4()), str(uuid.uuid4())
+            resp = await client.post(
+                handle.url + "/",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": str(uuid.uuid4()),
+                    "method": "message/send",
+                    "params": {
+                        "configuration": {"accepted_output_modes": ["text"]},
+                        "message": {
+                            "role": "user",
+                            "kind": "message",
+                            "parts": [{"kind": "text", "text": "boxd echo probe"}],
+                            "messageId": str(uuid.uuid4()),
+                            "contextId": context_id,
+                            "taskId": task_id,
+                        },
+                    },
+                },
+            )
+            assert resp.status_code == 200, resp.text
+
+            # Poll until terminal, then require the echoed text — the
+            # fixture reads parts (with a content fallback for older
+            # PyPI releases inside the VM), so either code path must
+            # surface the probe text, never an empty echo.
+            reply = ""
+            for _ in range(40):
+                resp = await client.post(
+                    handle.url + "/",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": str(uuid.uuid4()),
+                        "method": "tasks/get",
+                        "params": {"taskId": task_id},
+                    },
+                )
+                task = resp.json().get("result") or {}
+                state = (task.get("status") or {}).get("state")
+                if state in ("completed", "failed", "rejected"):
+                    assert state == "completed", task
+                    chunks = [
+                        p.get("text", "")
+                        for art in task.get("artifacts") or []
+                        for p in art.get("parts") or []
+                        if p.get("kind") == "text"
+                    ]
+                    reply = " ".join(chunks)
+                    break
+                await asyncio.sleep(0.5)
+            assert "boxd echo probe" in reply, f"echo lost the message text: {reply!r}"
     finally:
         if handle is not None:
             await p.on_exit(handle, "destroy")

--- a/tests/e2e/x402_scenarios/agent.py
+++ b/tests/e2e/x402_scenarios/agent.py
@@ -20,8 +20,12 @@ from bindu.penguin.bindufy import bindufy  # noqa: E402
 
 def handler(messages):
     """Echo back the last user message wrapped in a PAID JOB DONE marker."""
-    last = messages[-1].get("content", "") if messages else ""
-    return f"PAID JOB DONE — agent received: '{last}'"
+    last = messages[-1] if messages else {}
+    # A2A contract: the message text lives in parts.
+    text = " ".join(
+        p.get("text", "") for p in last.get("parts", []) if p.get("kind") == "text"
+    )
+    return f"PAID JOB DONE — agent received: '{text}'"
 
 
 bindufy(

--- a/tests/unit/grpc/test_client.py
+++ b/tests/unit/grpc/test_client.py
@@ -130,6 +130,67 @@ class TestGrpcAgentClient:
 
     @patch("bindu.grpc.client.grpc.insecure_channel")
     @patch("bindu.grpc.client.agent_handler_pb2_grpc.AgentHandlerStub")
+    def test_a2a_messages_flattened_at_wire_boundary(
+        self, mock_stub_class, mock_channel
+    ):
+        """Raw A2A messages (with parts) flatten to {role, content} proto.
+
+        ManifestWorker now passes A2A messages through verbatim; this client
+        is the one place that still needs chat format (the proto ChatMessage
+        has no parts field). Text parts collapse to content, file parts get
+        text-extracted, and the A2A "agent" role maps to "assistant".
+        """
+        import base64
+
+        mock_stub = MagicMock()
+        mock_stub_class.return_value = mock_stub
+        mock_stub.HandleMessages.return_value = agent_handler_pb2.HandleResponse(
+            content="ok", state=""
+        )
+
+        client = GrpcAgentClient("localhost:50052")
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {
+                "role": "user",
+                "kind": "message",
+                "parts": [{"kind": "text", "text": "Read this file"}],
+            },
+            {
+                "role": "agent",
+                "kind": "message",
+                "parts": [{"kind": "text", "text": "Sure, send it over"}],
+            },
+            {
+                "role": "user",
+                "kind": "message",
+                "parts": [
+                    {
+                        "kind": "file",
+                        "file": {
+                            "bytes": base64.b64encode(b"file body").decode(),
+                            "mimeType": "text/plain",
+                            "name": "notes.txt",
+                        },
+                    }
+                ],
+            },
+        ]
+        client(messages)
+
+        request = mock_stub.HandleMessages.call_args[0][0]
+        assert len(request.messages) == 4
+        assert request.messages[0].role == "system"
+        assert request.messages[0].content == "You are helpful"
+        assert request.messages[1].role == "user"
+        assert request.messages[1].content == "Read this file"
+        assert request.messages[2].role == "assistant"
+        assert request.messages[2].content == "Sure, send it over"
+        assert request.messages[3].role == "user"
+        assert "file body" in request.messages[3].content
+
+    @patch("bindu.grpc.client.grpc.insecure_channel")
+    @patch("bindu.grpc.client.agent_handler_pb2_grpc.AgentHandlerStub")
     def test_lazy_connection(self, mock_stub_class, mock_channel):
         """Test that gRPC channel is not created until first call."""
         client = GrpcAgentClient("localhost:50052")

--- a/tests/unit/grpc/test_client.py
+++ b/tests/unit/grpc/test_client.py
@@ -191,6 +191,38 @@ class TestGrpcAgentClient:
 
     @patch("bindu.grpc.client.grpc.insecure_channel")
     @patch("bindu.grpc.client.agent_handler_pb2_grpc.AgentHandlerStub")
+    def test_a2a_system_message_keeps_system_role(self, mock_stub_class, mock_channel):
+        """The A2A-shaped injected system prompt reaches the wire as 'system'."""
+        mock_stub = MagicMock()
+        mock_stub_class.return_value = mock_stub
+        mock_stub.HandleMessages.return_value = agent_handler_pb2.HandleResponse(
+            content="ok", state=""
+        )
+
+        client = GrpcAgentClient("localhost:50052")
+        client(
+            [
+                {
+                    "role": "system",
+                    "kind": "message",
+                    "parts": [{"kind": "text", "text": "Respond in JSON."}],
+                },
+                {
+                    "role": "user",
+                    "kind": "message",
+                    "parts": [{"kind": "text", "text": "hi"}],
+                },
+            ]
+        )
+
+        request = mock_stub.HandleMessages.call_args[0][0]
+        assert len(request.messages) == 2
+        assert request.messages[0].role == "system"
+        assert request.messages[0].content == "Respond in JSON."
+        assert request.messages[1].role == "user"
+
+    @patch("bindu.grpc.client.grpc.insecure_channel")
+    @patch("bindu.grpc.client.agent_handler_pb2_grpc.AgentHandlerStub")
     def test_lazy_connection(self, mock_stub_class, mock_channel):
         """Test that gRPC channel is not created until first call."""
         client = GrpcAgentClient("localhost:50052")

--- a/tests/unit/server/workers/test_manifest_worker.py
+++ b/tests/unit/server/workers/test_manifest_worker.py
@@ -55,6 +55,47 @@ class TestManifestWorker:
         # File bytes reach the handler untouched.
         assert result[-1]["parts"][0]["file"]["bytes"] == "JVBERi0xLjQ="
 
+    def test_build_message_history_is_json_safe_and_isolated(self):
+        """Envelope UUIDs stringify; handler mutations can't reach the source.
+
+        The in-memory backend's list_tasks_by_context returns live stored
+        dicts, so the copy must be structural — and json.dumps(messages)
+        must work identically on every storage backend.
+        """
+        import json
+
+        mock_manifest = Mock()
+        mock_scheduler = Mock()
+        mock_storage = AsyncMock()
+
+        worker = ManifestWorker(
+            manifest=mock_manifest, scheduler=mock_scheduler, storage=mock_storage
+        )
+
+        message_id, task_id = uuid4(), uuid4()
+        messages = [
+            {
+                "role": "user",
+                "kind": "message",
+                "message_id": message_id,
+                "task_id": task_id,
+                "parts": [{"kind": "text", "text": "original"}],
+            }
+        ]
+
+        result = worker.build_message_history(messages)  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
+
+        # UUID envelope fields become strings — JSON-safe on any backend.
+        assert result[0]["message_id"] == str(message_id)
+        assert result[0]["task_id"] == str(task_id)
+        json.dumps(result)
+
+        # Nested containers are copies: mutating handler input must not
+        # touch the (potentially live-stored) source message.
+        result[0]["parts"][0]["text"] = "mutated"
+        result[0]["parts"].append({"kind": "text", "text": "injected"})
+        assert messages[0]["parts"] == [{"kind": "text", "text": "original"}]
+
     def test_build_artifacts(self):
         """Test building artifacts from result."""
         mock_manifest = Mock()
@@ -709,6 +750,14 @@ class TestManifestWorker:
             await worker.run_task(params)
 
         mock_manifest.run.assert_called_once()
+        # The injected system prompt must be A2A-shaped like the rest of the
+        # history — one uniform contract, every message has `parts`.
+        sent_history = mock_manifest.run.call_args[0][0]
+        assert sent_history[0] == {
+            "role": "system",
+            "kind": "message",
+            "parts": [{"kind": "text", "text": "System prompt"}],
+        }
 
     @pytest.mark.asyncio
     async def test_run_task_with_context_based_history(self):

--- a/tests/unit/server/workers/test_manifest_worker.py
+++ b/tests/unit/server/workers/test_manifest_worker.py
@@ -12,8 +12,13 @@ from bindu.server.workers.manifest_worker import ManifestWorker
 class TestManifestWorker:
     """Test ManifestWorker functionality."""
 
-    def test_build_message_history_delegates_to_converter(self):
-        """Test building message history delegates to MessageConverter."""
+    def test_build_message_history_preserves_parts(self):
+        """A2A messages pass through verbatim — ``parts`` must survive.
+
+        Handlers read ``messages[-1]["parts"]`` directly (the A2A contract).
+        Flattening to {role, content} here dropped file bytes and broke every
+        file/vision handler ("No file part found in the message").
+        """
         mock_manifest = Mock()
         mock_scheduler = Mock()
         mock_storage = AsyncMock()
@@ -23,15 +28,32 @@ class TestManifestWorker:
         )
 
         messages = [
-            {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi there"},
+            {
+                "role": "user",
+                "kind": "message",
+                "parts": [{"kind": "text", "text": "Extract this invoice"}],
+            },
+            {
+                "role": "user",
+                "kind": "message",
+                "parts": [
+                    {
+                        "kind": "file",
+                        "file": {
+                            "bytes": "JVBERi0xLjQ=",
+                            "mimeType": "application/pdf",
+                            "name": "invoice.pdf",
+                        },
+                    }
+                ],
+            },
         ]
 
-        # The method delegates to MessageConverter.to_chat_format
         result = worker.build_message_history(messages)  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
 
-        # Result type depends on MessageConverter implementation
-        assert isinstance(result, list)
+        assert result == messages
+        # File bytes reach the handler untouched.
+        assert result[-1]["parts"][0]["file"]["bytes"] == "JVBERi0xLjQ="
 
     def test_build_artifacts(self):
         """Test building artifacts from result."""

--- a/tests/unit/utils/worker/test_messages.py
+++ b/tests/unit/utils/worker/test_messages.py
@@ -131,6 +131,54 @@ class TestMessageConverter:
         assert "hello from a text file" in result[0]["content"]
         assert "Unsupported file type" not in result[0]["content"]
 
+    def test_to_chat_format_maps_system_role_through(self):
+        """A2A system messages keep role 'system' (not demoted to 'user')."""
+        messages = [
+            cast(
+                Message,
+                {
+                    "role": "system",
+                    "parts": [{"kind": "text", "text": "Respond in JSON."}],
+                },
+            )
+        ]
+
+        result = MessageConverter.to_chat_format(messages)
+
+        assert result == [{"role": "system", "content": "Respond in JSON."}]
+
+    def test_to_chat_format_flags_uri_file_without_bytes(self):
+        """FileWithUri parts aren't fetched — say so instead of emitting an
+        empty 'Document Uploaded' block from decoding zero bytes."""
+        messages = [
+            cast(
+                Message,
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "kind": "file",
+                            "file": {
+                                "uri": "https://example.com/doc.pdf",
+                                "bytes": "",
+                                "mimeType": "application/pdf",
+                                "name": "doc.pdf",
+                            },
+                        }
+                    ],
+                },
+            )
+        ]
+
+        result = MessageConverter.to_chat_format(messages)
+
+        assert len(result) == 1
+        assert (
+            "[File reference not fetched: https://example.com/doc.pdf]"
+            in result[0]["content"]
+        )
+        assert "Document Uploaded" not in result[0]["content"]
+
     def test_to_chat_format_marks_unsupported_file_types(self):
         """Unsupported MIME types report the actual type, not an empty string."""
         messages = [

--- a/tests/unit/utils/worker/test_messages.py
+++ b/tests/unit/utils/worker/test_messages.py
@@ -95,3 +95,64 @@ class TestMessageConverter:
         result = MessageConverter.to_chat_format(messages)
 
         assert result == []
+
+    def test_to_chat_format_extracts_text_from_a2a_file_part(self):
+        """File bytes live at part["file"]["bytes"] (A2A FilePart shape).
+
+        Regression: the interceptor used to read part["mimeType"] /
+        part["data"], which don't exist on A2A file parts, so every upload
+        became "[Unsupported file type: ]".
+        """
+        import base64
+
+        payload = base64.b64encode(b"hello from a text file").decode()
+        messages = [
+            cast(
+                Message,
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "kind": "file",
+                            "file": {
+                                "bytes": payload,
+                                "mimeType": "text/plain",
+                                "name": "notes.txt",
+                            },
+                        }
+                    ],
+                },
+            )
+        ]
+
+        result = MessageConverter.to_chat_format(messages)
+
+        assert len(result) == 1
+        assert "hello from a text file" in result[0]["content"]
+        assert "Unsupported file type" not in result[0]["content"]
+
+    def test_to_chat_format_marks_unsupported_file_types(self):
+        """Unsupported MIME types report the actual type, not an empty string."""
+        messages = [
+            cast(
+                Message,
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "kind": "file",
+                            "file": {
+                                "bytes": "aWdub3JlZA==",
+                                "mimeType": "image/png",
+                                "name": "photo.png",
+                            },
+                        }
+                    ],
+                },
+            )
+        ]
+
+        result = MessageConverter.to_chat_format(messages)
+
+        assert len(result) == 1
+        assert "[Unsupported file type: image/png]" in result[0]["content"]


### PR DESCRIPTION
## Problem

`ManifestWorker.build_message_history` flattened A2A protocol messages to chat `{role, content}` and dropped `parts`. Handlers read `messages[-1]["parts"]` directly — that's the A2A contract agents are written against — so every file/vision handler received a message with no parts and failed with **"No file part found in the message."** Text handlers silently lost the parts contract too. The flatten also routed uploads through `FileInterceptor`, which cannot represent binary (PDF/image) bytes as text at all.

The regression shipped in **2026.20.2** (c5ed0f86, the FileInterceptor commit) — before it, file-bearing messages kept their `parts`. Any deployment on 2026.20.x+ is affected.

## Fix (commit 1)

- **`ManifestWorker.build_message_history`** passes A2A messages through with `parts` intact.
- **`GrpcAgentClient._build_request`** takes over chat-format flattening — the one boundary that genuinely needs it (the proto `ChatMessage` only carries `{role, content}`). Roles map `agent`→`assistant`, text parts collapse to content, file parts are text-extracted, so **gRPC/TypeScript SDK agents see an unchanged wire contract**.
- **`FileInterceptor.intercept_and_parse`** reads the A2A `FilePart` shape (`part["file"]["mimeType"]` / `part["file"]["bytes"]`) instead of nonexistent top-level keys that turned every upload into `[Unsupported file type: ]`.

## Hardening from adversarial review (commit 2)

An 8-angle review (line-by-line, removed-behavior, cross-file trace, reuse, simplification, efficiency, altitude, conventions) with per-finding verification produced 10 confirmed findings; this commit fixes 9:

- **Uniform handler contract**: the injected structured-response system prompt is now an A2A message with `parts` (was a chat-shaped dict at index 0 — a `KeyError: 'parts'` trap for any handler iterating the full history under default settings). `ROLE_MAP` gains `"system"`, so the role maps through to the gRPC wire unchanged instead of demoting to `"user"`.
- **JSON-safe, isolated handler input**: `build_message_history` returns structural copies with UUID envelope fields stringified — `json.dumps(messages)` works on every storage backend, and handler mutations can no longer corrupt live stored history (the memory backend's `list_tasks_by_context` returns live references).
- **File edge cases**: `FileWithUri`/missing-bytes parts yield an explicit `[File reference not fetched: …]` placeholder instead of a misleading empty "Document Uploaded" block; extraction is `lru_cache`d so multi-turn conversations stop re-decoding and re-parsing every file in history on the event loop.
- **Observability**: `_build_request` logs when a message flattens to nothing (data-part-only turns are invisible to SDK agents — now documented in `docs/grpc/limitations.md`).
- **Contract surfaces**: `bindufy` handler type + docstring example, `Worker.build_message_history` docs, and six docs that still taught the retired flattened contract (`runtime/quickstart`, `runtime/README`, `FILE_HANDLING_&_UPLOADS`, `grpc/client`, `grpc/limitations`, `GRPC_LANGUAGE_AGNOSTIC`) all updated per the docs-in-same-PR convention.
- **Fixtures**: the x402 e2e agent reads parts; the boxd e2e now actually sends a `message/send` and asserts the echoed text (env-gated suite — not run in CI here).

## Examples migration (commit 3 — resolves review finding 10)

25 in-repo example handlers still read the retired flattened shape and were confirmed broken by the fan-out testing below (crash via `KeyError: 'content'`, or worse: **silent degradation** — agno 2.6.5 serializes parts-shaped dicts as `content=""`, so models were asked empty questions while tasks "completed"; hermes returned "Empty message." for every request). All migrated:

- **Direct readers → inline parts extraction** (standalone examples keep a `content` fallback so they also run on older releases): `summarizer`, `agent_swarm`, `hermes_agent`, `ag2_research_team`, `langgraph_blog_writing_agent`, `medical_agent`, `private_skills_agent`, `runtime-boxd-agent`, `song-meaning-agent`, `web-scraping-agent`, and `beginner/` echo ×2, dspy, ag2.
- **Agno passthrough → `MessageConverter.to_chat_format(messages)`**: `news-summarizer` + 8 `beginner/` agno files. Restores pre-regression behavior exactly (role mapping, file→text extraction, system prompt included).
- **File-upload examples get real file-part handling**: `pdf_research_agent` decodes inline `application/pdf` bytes via pypdf; `speech-to-text` bridges audio file parts to its path-based tool through a temp file.

## Verification

- Regression tests pin every contract above (system-message shape, UUID stringification + isolation, system-role wire mapping, URI placeholder, worker pass-through, FilePart keys, gRPC boundary flattening).
- **HTTP E2E**: real bindufied agent, real `message/send` with a text part + a 282-byte **non-UTF-8 binary** file part — handler received `parts` with byte-exact content (sha256-verified), with the A2A-shaped system message in history.
- **gRPC E2E**: real loopback `AgentHandler` server — received clean `{role, content}` for all messages, roles mapped, file text extracted, zero empty contents.
- **10-example parallel fan-out E2E** against this branch (isolated copies, real `message/send`/`tasks/get`, real models where keys allowed). Core contract held in all 10: PDF and audio file parts arrived byte-exact (960 and 110,900 base64 chars, length-matched at the handler), file parts survived stored history via `referenceTaskIds` (follow-up turn answered from the file alone), and a real TypeScript SDK agent recovered a marker from cross-task history through the wire-boundary flattening — with the core system prompt demonstrably reaching it. The regression string never appeared.
- **Post-migration smoke tests** (live model): echo, summarizer, agno joke agent, `pdf_research_agent` with an inline PDF part (reply quoted the probe marker), and the 5-agent `agent_swarm` chain (previously 0 LLM calls) — all completed.
- Full suite: **1124 passed, 6 skipped** (unit + integration); ruff, ruff-format, ty, bandit, pydocstyle clean (examples are excluded from lint hooks by repo config).

## Follow-ups (out of scope, tracked separately)

- `FilePart` inherits `TextPart`, so submit validation requires a `text` key on file parts — spec-shaped bare file parts are rejected at the door (pre-existing; a spec-compliance fix is in progress on a separate branch).
- Proto-level `parts` support so gRPC/SDK agents can receive binary (documented ceiling in `docs/grpc/limitations.md`).
- Stale example model ids found during testing (dead on OpenRouter): `document_analyzer.py` `arcee-ai/trinity-large-preview:free`, `speech_to_text_agent.py` `google/gemini-2.0-flash-001` ×2. Also `examples/beginner/.env` ships a revoked `OPENROUTER_API_KEY` and malformed `OLTP_HEADERS` JSON that crashes boot when sourced with telemetry enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - gRPC interactions now support A2A messages with structured text and file parts while retaining legacy chat messages.
  - Message history preserves A2A parts, including file details, for handlers.
  - File uploads are passed to handlers with their original encoded data, MIME type, and filename.
  - System messages and agent roles are preserved correctly.

- **Bug Fixes**
  - Improved file text extraction and unsupported-format feedback.
  - URI-only file references now provide clear fallback text.
  - Handler mutations no longer alter stored message history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
