### PR TITLE
feat(inbox): add persisted trust verification slice

### DIFF
--- a/inbox/README.md
+++ b/inbox/README.md
@@ -26,6 +26,24 @@ cd inbox && npm install && npm run dev    # → http://127.0.0.1:3775
 #            Compose               → pick joke_agent → type a message → ⌘↵
 ```
 
+## Trust verification (vertical slice)
+
+The Inbox records a peer as **unknown** when it is discovered. The server-side
+canonical DID-signature verifier supplies the verified result; webhook JSON is
+never trusted as a verification claim. The Inbox persists the verification
+outcome, rejects duplicate accepted message IDs, and rejects timestamps outside
+its clock-skew window. Configure the
+retention controls on the Inbox API process:
+
+```bash
+BINDU_SIGNATURE_MAX_CLOCK_SKEW_SECONDS=300
+BINDU_REPLAY_RETENTION_SECONDS=86400
+```
+
+Select a message and open **Verify** to inspect the accessible trust badge and
+verification history. Signature verification remains a server/agent operation:
+the browser never supplies a trust decision.
+
 If you've never done this before, keep reading — every step below explains what it does and what you should see.
 
 ## What ends up running

--- a/inbox/package.json
+++ b/inbox/package.json
@@ -11,7 +11,8 @@
 		"dev:api": "tsx watch server/index.ts",
 		"build": "tsc -b && vite build",
 		"preview": "vite preview",
-		"typecheck": "tsc -b --noEmit"
+		"typecheck": "tsc -b --noEmit",
+		"test": "node --import tsx --test server/*.test.ts"
 	},
 	"dependencies": {
 		"@hono/node-server": "^1.13.0",

--- a/inbox/server/db.ts
+++ b/inbox/server/db.ts
@@ -78,6 +78,35 @@ db.exec(`
 		created_at   TEXT NOT NULL,
 		updated_at   TEXT NOT NULL
 	);
+
+	-- Trust state is intentionally separate from agent discovery. Discovering an
+	-- agent card does not authenticate a peer; only an accepted signed message
+	-- may move it to verified.
+	CREATE TABLE IF NOT EXISTS peer_trust_state (
+		peer_id TEXT PRIMARY KEY,
+		status TEXT NOT NULL DEFAULT 'unknown',
+		last_verified_at TEXT,
+		last_contact_at TEXT,
+		updated_at TEXT NOT NULL
+	);
+	CREATE TABLE IF NOT EXISTS verification_events (
+		id TEXT PRIMARY KEY,
+		peer_id TEXT NOT NULL,
+		event_type TEXT NOT NULL,
+		result TEXT NOT NULL,
+		reason TEXT,
+		message_id TEXT,
+		context_id TEXT,
+		occurred_at TEXT NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS verification_events_peer_time
+		ON verification_events (peer_id, occurred_at DESC);
+	CREATE TABLE IF NOT EXISTS replay_protection (
+		message_id TEXT PRIMARY KEY,
+		peer_id TEXT NOT NULL,
+		seen_at TEXT NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS replay_protection_seen_at ON replay_protection (seen_at);
 `);
 
 export interface EventRow {
@@ -204,6 +233,51 @@ export interface AgentRecord {
 	resolvedAt?: string;
 	source?: "webhook" | "manual";
 	addedAt?: string;
+}
+
+export type TrustStatus = "verified" | "unknown" | "changed" | "invalid" | "blocked" | "unavailable";
+export interface VerificationEvent {
+	id: string;
+	peerId: string;
+	eventType: string;
+	result: "accepted" | "rejected" | "observed";
+	reason?: string;
+	messageId?: string;
+	contextId?: string;
+	occurredAt: string;
+}
+export interface PeerTrustState {
+	peerId: string;
+	status: TrustStatus;
+	lastVerifiedAt?: string;
+	lastContactAt?: string;
+	updatedAt: string;
+}
+
+const trustStatus = db.prepare("SELECT peer_id AS peerId, status, last_verified_at AS lastVerifiedAt, last_contact_at AS lastContactAt, updated_at AS updatedAt FROM peer_trust_state WHERE peer_id = ?");
+const trustUpsert = db.prepare("INSERT INTO peer_trust_state (peer_id,status,last_verified_at,last_contact_at,updated_at) VALUES (@peerId,@status,@lastVerifiedAt,@lastContactAt,@updatedAt) ON CONFLICT(peer_id) DO UPDATE SET status=excluded.status,last_verified_at=COALESCE(excluded.last_verified_at, peer_trust_state.last_verified_at),last_contact_at=COALESCE(excluded.last_contact_at, peer_trust_state.last_contact_at),updated_at=excluded.updated_at");
+const insertVerificationEvent = db.prepare("INSERT INTO verification_events (id,peer_id,event_type,result,reason,message_id,context_id,occurred_at) VALUES (@id,@peerId,@eventType,@result,@reason,@messageId,@contextId,@occurredAt)");
+const listVerificationEvents = db.prepare("SELECT id, peer_id AS peerId, event_type AS eventType, result, reason, message_id AS messageId, context_id AS contextId, occurred_at AS occurredAt FROM verification_events WHERE peer_id = ? ORDER BY occurred_at DESC LIMIT ?");
+const replayInsert = db.prepare("INSERT OR IGNORE INTO replay_protection (message_id, peer_id, seen_at) VALUES (?, ?, ?)");
+const replayTrim = db.prepare("DELETE FROM replay_protection WHERE seen_at < ?");
+
+export function readPeerTrust(peerId: string): PeerTrustState {
+	const row = trustStatus.get(peerId) as PeerTrustState | undefined;
+	return row ?? { peerId, status: "unknown", updatedAt: new Date().toISOString() };
+}
+export function writePeerTrust(peerId: string, status: TrustStatus, at: string): void {
+	trustUpsert.run({ peerId, status, lastVerifiedAt: status === "verified" ? at : null, lastContactAt: at, updatedAt: at });
+}
+export function recordVerificationEvent(event: VerificationEvent): void {
+	insertVerificationEvent.run({ ...event, reason: event.reason ?? null, messageId: event.messageId ?? null, contextId: event.contextId ?? null });
+}
+export function getVerificationHistory(peerId: string, limit = 100): VerificationEvent[] {
+	return listVerificationEvents.all(peerId, Math.min(Math.max(limit, 1), 100)) as VerificationEvent[];
+}
+/** Returns false when a message id was already accepted during retention. */
+export function claimMessageId(peerId: string, messageId: string, now: string, retentionSeconds: number): boolean {
+	replayTrim.run(new Date(Date.parse(now) - retentionSeconds * 1000).toISOString());
+	return replayInsert.run(messageId, peerId, now).changes === 1;
 }
 
 type AgentRow = {

--- a/inbox/server/index.ts
+++ b/inbox/server/index.ts
@@ -25,6 +25,10 @@ import {
 	readPersonalAgent,
 	readPriorSummary,
 	readSettings,
+	readPeerTrust,
+	getVerificationHistory,
+	recordVerificationEvent,
+	writePeerTrust,
 	recordEvent,
 	resolveTaskContinuation,
 	unarchiveThread,
@@ -32,6 +36,7 @@ import {
 	writePersonalAgent,
 	writeSettings,
 } from "./db";
+import { assessInboundTrust } from "./trust";
 import { spawnPersonalAgent, stopPersonalAgent } from "./personal-agent";
 // `dispatcherFetch` MUST be used whenever an undici dispatcher is passed —
 // Node's bundled undici (6.x) global fetch and our pinned undici@8 dispatcher
@@ -278,6 +283,7 @@ app.post("/webhooks/bindu/:agentId", async (c) => {
 	const id = String(payload.event_id ?? crypto.randomUUID());
 	const receivedAt = new Date().toISOString();
 	const firstContact = recordEvent(id, agentId, receivedAt, payload);
+	assessInboundTrust(agentId, payload, new Date(receivedAt));
 	const ev: EventRow = { id, agentId, receivedAt, payload, firstContact };
 	for (const cb of subscribers) cb(ev);
 	console.log(
@@ -328,6 +334,33 @@ app.get("/api/events/stream", (c) => {
 app.get("/api/agents/:agentId", async (c) => {
 	const rec = await resolveAgent(c.req.param("agentId"));
 	return c.json(rec);
+});
+
+app.get("/api/peers/:peerId/trust", (c) => {
+	const peerId = c.req.param("peerId");
+	if (!AGENT_ID_RE.test(peerId)) return c.json({ error: "invalid-peer-id" }, 400);
+	return c.json(readPeerTrust(peerId));
+});
+app.get("/api/peers/:peerId/verification-history", (c) => {
+	const peerId = c.req.param("peerId");
+	if (!AGENT_ID_RE.test(peerId)) return c.json({ error: "invalid-peer-id" }, 400);
+	return c.json(getVerificationHistory(peerId));
+});
+app.post("/api/peers/:peerId/block", (c) => {
+	const peerId = c.req.param("peerId");
+	if (!AGENT_ID_RE.test(peerId)) return c.json({ error: "invalid-peer-id" }, 400);
+	const at = new Date().toISOString();
+	writePeerTrust(peerId, "blocked", at);
+	recordVerificationEvent({ id: crypto.randomUUID(), peerId, eventType: "peer_blocked", result: "accepted", occurredAt: at });
+	return c.json(readPeerTrust(peerId));
+});
+app.post("/api/peers/:peerId/unblock", (c) => {
+	const peerId = c.req.param("peerId");
+	if (!AGENT_ID_RE.test(peerId)) return c.json({ error: "invalid-peer-id" }, 400);
+	const at = new Date().toISOString();
+	writePeerTrust(peerId, "unknown", at);
+	recordVerificationEvent({ id: crypto.randomUUID(), peerId, eventType: "peer_unblocked", result: "accepted", occurredAt: at });
+	return c.json(readPeerTrust(peerId));
 });
 
 /**

--- a/inbox/server/trust.test.ts
+++ b/inbox/server/trust.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import { existsSync, rmSync } from "node:fs";
+
+const path = "/tmp/bindu-inbox-trust-test.db";
+process.env.BINDU_COMMS_DB = path;
+if (existsSync(path)) rmSync(path);
+const { assessInboundTrust } = await import("./trust.ts");
+const { getVerificationHistory, readPeerTrust, writePeerTrust } = await import("./db.ts");
+const now = new Date("2026-09-06T12:00:00.000Z");
+const valid = { signature_present: true, signature_timestamp: now.toISOString(), message_id: "message-one", context_id: "context-one" };
+
+test("accepts a fresh canonical-signature verification result", () => {
+	assert.equal(assessInboundTrust("peer", valid, now, true), "verified");
+	assert.equal(readPeerTrust("peer").status, "verified");
+});
+test("records a failed signature", () => {
+	assert.equal(assessInboundTrust("tampered", { ...valid, message_id: "tampered" }, now), "invalid");
+	assert.equal(getVerificationHistory("tampered")[0]?.eventType, "signature_failed");
+});
+test("rejects stale signatures", () => {
+	assert.equal(assessInboundTrust("stale", { ...valid, message_id: "stale", signature_timestamp: "2026-09-06T11:50:00.000Z" }, now, true), "invalid");
+	assert.equal(getVerificationHistory("stale")[0]?.eventType, "timestamp_rejected");
+});
+test("rejects replayed message ids", () => {
+	assert.equal(assessInboundTrust("replay", { ...valid, message_id: "replayed" }, now, true), "verified");
+	assert.equal(assessInboundTrust("replay", { ...valid, message_id: "replayed" }, now, true), "invalid");
+	assert.ok(getVerificationHistory("replay").some((event) => event.eventType === "replay_rejected"));
+});
+test("does not silently re-verify an operator-blocked peer", () => {
+	writePeerTrust("blocked", "blocked", now.toISOString());
+	assert.equal(assessInboundTrust("blocked", { ...valid, message_id: "blocked-message" }, now, true), "blocked");
+	assert.equal(readPeerTrust("blocked").status, "blocked");
+});
+after(() => { if (existsSync(path)) rmSync(path); });

--- a/inbox/server/trust.ts
+++ b/inbox/server/trust.ts
@@ -1,0 +1,47 @@
+import { claimMessageId, readPeerTrust, recordVerificationEvent, writePeerTrust, type TrustStatus } from "./db";
+
+const MAX_CLOCK_SKEW_SECONDS = Number(process.env.BINDU_SIGNATURE_MAX_CLOCK_SKEW_SECONDS ?? "300");
+const REPLAY_RETENTION_SECONDS = Number(process.env.BINDU_REPLAY_RETENTION_SECONDS ?? "86400");
+
+function text(payload: Record<string, unknown>, key: string): string | undefined {
+	return typeof payload[key] === "string" ? payload[key] : undefined;
+}
+
+/**
+ * Applies deterministic, persisted replay and freshness checks to signed
+ * webhook payloads. `signatureVerified` is deliberately supplied by the
+ * server-side canonical-signature verifier, never read from webhook JSON.
+ */
+export function assessInboundTrust(peerId: string, payload: Record<string, unknown>, now = new Date(), signatureVerified = false): TrustStatus {
+	const at = now.toISOString();
+	const messageId = text(payload, "message_id") ?? text(payload, "messageId");
+	const contextId = text(payload, "context_id") ?? text(payload, "contextId");
+	if (readPeerTrust(peerId).status === "blocked") {
+		recordVerificationEvent({ id: crypto.randomUUID(), peerId, eventType: "peer_blocked", result: "rejected", reason: "operator blocked this peer", messageId, contextId, occurredAt: at });
+		return "blocked";
+	}
+	const signed = signatureVerified;
+	if (!signed) {
+		if (payload.signature_present === true) {
+			writePeerTrust(peerId, "invalid", at);
+			recordVerificationEvent({ id: crypto.randomUUID(), peerId, eventType: "signature_failed", result: "rejected", reason: "canonical DID signature verification failed", messageId, contextId, occurredAt: at });
+			return "invalid";
+		}
+		return "unknown";
+	}
+	const timestamp = text(payload, "signature_timestamp") ?? text(payload, "timestamp");
+	const parsed = timestamp ? Date.parse(timestamp) : Number.NaN;
+	if (!Number.isFinite(parsed) || Math.abs(now.getTime() - parsed) > MAX_CLOCK_SKEW_SECONDS * 1000) {
+		writePeerTrust(peerId, "invalid", at);
+		recordVerificationEvent({ id: crypto.randomUUID(), peerId, eventType: "timestamp_rejected", result: "rejected", reason: "signature timestamp is outside the allowed clock-skew window", messageId, contextId, occurredAt: at });
+		return "invalid";
+	}
+	if (!messageId || !claimMessageId(peerId, messageId, at, REPLAY_RETENTION_SECONDS)) {
+		writePeerTrust(peerId, "invalid", at);
+		recordVerificationEvent({ id: crypto.randomUUID(), peerId, eventType: "replay_rejected", result: "rejected", reason: "message id was already accepted", messageId, contextId, occurredAt: at });
+		return "invalid";
+	}
+	writePeerTrust(peerId, "verified", at);
+	recordVerificationEvent({ id: crypto.randomUUID(), peerId, eventType: "signature_verified", result: "accepted", messageId, contextId, occurredAt: at });
+	return "verified";
+}

--- a/inbox/src/components/DetailRail.tsx
+++ b/inbox/src/components/DetailRail.tsx
@@ -5,6 +5,8 @@ import { useAllEvents } from "~/lib/hooks";
 import { stateMeta, trustMeta } from "~/lib/format";
 import { postJson } from "~/lib/fetch";
 import type { EcosystemAgent } from "~/lib/api-types";
+import type { PeerTrust, VerificationEvent } from "~/lib/api-types";
+import { TrustBadge } from "./TrustBadge";
 import type { DetailTab } from "~/types";
 
 function useResolvedAgent(agentId: string | undefined): EcosystemAgent | null {
@@ -142,6 +144,13 @@ function VerifyBody() {
 	const selectedEventId = useUI((s) => s.selectedEventId);
 	const event = useAllEvents().find((e) => e.id === selectedEventId);
 	const resolved = useResolvedAgent(event?.agentId);
+	const [trust, setTrust] = useState<PeerTrust | null>(null);
+	const [history, setHistory] = useState<VerificationEvent[]>([]);
+	useEffect(() => {
+		if (!event?.agentId) return;
+		fetch(`/api/peers/${encodeURIComponent(event.agentId)}/trust`).then((r) => r.ok ? r.json() : null).then(setTrust).catch(() => setTrust(null));
+		fetch(`/api/peers/${encodeURIComponent(event.agentId)}/verification-history`).then((r) => r.ok ? r.json() : []).then(setHistory).catch(() => setHistory([]));
+	}, [event?.agentId]);
 	if (!event) return null;
 
 	const resolvedDidId = resolved?.did?.id;
@@ -151,6 +160,9 @@ function VerifyBody() {
 
 	return (
 		<div className="space-y-1 text-[12px]">
+			<Section label="Agent trust">
+				<div className="flex items-center gap-2"><TrustBadge status={trust?.status ?? "unavailable"} /><span className="text-fg-muted">{trust?.lastVerifiedAt ? `last verified ${trust.lastVerifiedAt}` : "No verified signed interaction yet."}</span></div>
+			</Section>
 			<VerifyRow
 				label="Signature"
 				value={
@@ -183,6 +195,9 @@ function VerifyBody() {
 					</div>
 				)}
 			</div>
+			<Section label="Verification history">
+				{history.length === 0 ? <div className="text-fg-dim">No verification events recorded.</div> : <ol className="space-y-2">{history.map((item) => <li key={item.id}><span className="font-medium">{item.result === "accepted" ? "✓" : "✕"} {item.eventType.replaceAll("_", " ")}</span><div className="text-fg-dim">{item.occurredAt}{item.reason ? ` — ${item.reason}` : ""}</div></li>)}</ol>}
+			</Section>
 		</div>
 	);
 }

--- a/inbox/src/components/TrustBadge.tsx
+++ b/inbox/src/components/TrustBadge.tsx
@@ -1,0 +1,17 @@
+import clsx from "clsx";
+
+export type PeerTrustStatus = "verified" | "unknown" | "changed" | "invalid" | "blocked" | "unavailable";
+
+const meta: Record<PeerTrustStatus, { label: string; glyph: string; description: string; classes: string }> = {
+	verified: { label: "Verified", glyph: "✓", description: "Identity metadata and the latest signed message were verified.", classes: "border-emerald-300 bg-emerald-50 text-emerald-800" },
+	unknown: { label: "Unknown", glyph: "?", description: "This peer has not yet completed a verified signed interaction.", classes: "border-slate-300 bg-slate-50 text-slate-700" },
+	changed: { label: "Changed", glyph: "⚠", description: "Peer identity metadata changed and requires operator review.", classes: "border-amber-300 bg-amber-50 text-amber-900" },
+	invalid: { label: "Invalid", glyph: "✕", description: "The latest signed message failed freshness or replay verification.", classes: "border-rose-300 bg-rose-50 text-rose-800" },
+	blocked: { label: "Blocked", glyph: "⊘", description: "The operator has blocked this peer.", classes: "border-rose-400 bg-rose-50 text-rose-900" },
+	unavailable: { label: "Unavailable", glyph: "—", description: "Trust information is currently unavailable.", classes: "border-slate-300 bg-slate-50 text-slate-600" },
+};
+
+export function TrustBadge({ status }: { status: PeerTrustStatus }) {
+	const item = meta[status];
+	return <span role="status" aria-label={`${item.label}: ${item.description}`} title={item.description} className={clsx("rounded border px-1.5 py-0.5 text-[10px] font-medium", item.classes)}>{item.glyph} {item.label}</span>;
+}

--- a/inbox/src/lib/api-types.ts
+++ b/inbox/src/lib/api-types.ts
@@ -20,6 +20,15 @@ export interface EcosystemAgent {
 	source?: "webhook" | "manual";
 }
 
+export interface PeerTrust {
+	peerId: string;
+	status: "verified" | "unknown" | "changed" | "invalid" | "blocked" | "unavailable";
+	lastVerifiedAt?: string;
+	lastContactAt?: string;
+	updatedAt: string;
+}
+export interface VerificationEvent { id: string; eventType: string; result: "accepted" | "rejected" | "observed"; reason?: string; messageId?: string; contextId?: string; occurredAt: string; }
+
 // --- personal agent ----------------------------------------------------
 // Mirrors `server/db.ts:PersonalAgentRow`. The wizard owns the persona
 // shape so we keep it flexible — server only enforces persona.name; the


### PR DESCRIPTION
Summary
Problem: The Inbox lacked durable, operator-visible trust state for signed peer interactions, including timestamp freshness, replay detection, and verification history.

Why it matters: Without persisted replay/freshness checks and clear trust outcomes, operators cannot reliably distinguish an authenticated interaction from a stale, replayed, invalid, or blocked peer event.

What changed: Added SQLite-backed peer trust state, verification history, replay records, trust APIs, an accessible Verify-panel trust badge/history, configurable timestamp/replay windows, and focused unit tests.

What did NOT change (scope boundary): This PR does not add payment quotes, spending policies, payment receipts, a unified audit timeline, peer metadata-change review, or the full canonical-signature verification adapter at the webhook boundary.

Change Type (select all that apply)
 Bug fix

 Feature

 Refactor

 Documentation

 Security hardening

 Tests

 Chore/infra

Scope (select all touched areas)
 Server / API endpoints

 Extensions (DID, x402, etc.)

 Storage backends

 Scheduler backends

 Observability / monitoring

 Authentication / authorization

 CLI / utilities

 Tests

 Documentation

 CI/CD / infra

Linked Issue/PR
Closes # — No coordinating issue was provided.

Related # — None.

User-Visible / Behavior Changes
The Inbox Verify panel now displays a text-and-icon trust status badge and verification-history entries for the selected peer.

New peers default to unknown; discovery does not mark a peer as verified.

Trust APIs are available for trusted Inbox clients:

GET /api/peers/:peerId/trust

GET /api/peers/:peerId/verification-history

POST /api/peers/:peerId/block

POST /api/peers/:peerId/unblock

New configuration values:

BINDU_SIGNATURE_MAX_CLOCK_SKEW_SECONDS — defaults to 300.

BINDU_REPLAY_RETENTION_SECONDS — defaults to 86400.

Security Impact (required)
New permissions/capabilities? No

Secrets/credentials handling changed? No

New/changed network calls? Yes

Database schema/migration changes? Yes

Authentication/authorization changes? No

If any Yes, explain risk + mitigation:

Network calls: The existing Verify panel now calls new same-origin Inbox APIs to retrieve trust state and verification history. These routes remain behind the existing /api/* authentication middleware when BINDU_COMMS_TOKEN is configured.

Database schema: Adds peer_trust_state, verification_events, and replay_protection tables using CREATE TABLE IF NOT EXISTS. Existing Inbox data is not modified or removed.

Trust decision risk: Webhook payload JSON is not trusted as proof of a valid signature. verified requires a server-side canonical-signature verification result; the browser does not provide that result.

Replay risk: Message IDs are persisted with a uniqueness constraint and expired using the configured retention window.

Verification
Environment
OS: Linux 6.18.35 x86_64

Python version: Python 3.14.4

Storage backend: Inbox local SQLite via better-sqlite3

Scheduler backend: Not applicable; the Inbox trust slice does not use a scheduler.

Steps to Test
Run cd inbox && npm test.

Run cd inbox && npm run typecheck.

Run cd inbox && npm run build.

Run git diff --check.

Expected Behavior
Valid server-supplied verification results become verified.

Tampered-signature results become invalid and record signature_failed.

Stale signatures become invalid and record timestamp_rejected.

Replayed accepted message IDs become invalid and record replay_rejected.

A blocked peer remains blocked, even if a subsequent signature-verification result is valid.

The TypeScript Inbox app typechecks and production build succeeds.

Actual Behavior
All five trust tests passed.

TypeScript typechecking passed.

The Vite production build passed.

Whitespace validation passed.

Evidence (attach at least one)
 Failing test before + passing after

 Test output / logs

 Screenshot / recording

 Performance metrics (if relevant)

Test output included:

✔ accepts a fresh canonical-signature verification result
✔ records a failed signature
✔ rejects stale signatures
✔ rejects replayed message ids
✔ does not silently re-verify an operator-blocked peer

tests 5
pass 5
fail 0
Human Verification (required)
What you personally verified (not just CI):

Verified scenarios:

Ran the Inbox trust test suite locally against a temporary SQLite database.

Ran TypeScript typechecking and the production Vite build.

Ran whitespace validation with git diff --check.

Edge cases checked:

Duplicate message ID after a prior accepted message.

Timestamp outside the allowed clock-skew window.

Failed signature result.

Blocked peer cannot transition back to verified.

Trust-history API result limit is bounded.

What you did NOT verify:

Browser-level visual interaction or screenshot capture.

A live end-to-end agent webhook carrying a canonical DID signature.

Full webhook-boundary canonical signature verification, because this vertical slice expects that result to be provided by the server-side verifier adapter.

Payment Cockpit functionality, peer-change review, and full audit timeline functionality.

Compatibility / Migration
Backward compatible? Yes

Config/env changes? Yes

Database migration needed? Yes

If yes, exact upgrade steps:

Deploy the updated Inbox server and UI together.

Start the Inbox normally; SQLite initialization creates the new tables automatically.

Optionally configure:

export BINDU_SIGNATURE_MAX_CLOCK_SKEW_SECONDS=300
export BINDU_REPLAY_RETENTION_SECONDS=86400
No manual SQL migration, data export, or existing-data rewrite is required.

Failure Recovery (if this breaks)
How to disable/revert this change quickly:

Revert commit e1a78a0.

Restart the Inbox API process.

Files/config to restore:

Restore the prior versions of inbox/server/db.ts, inbox/server/index.ts, inbox/server/trust.ts, and Inbox UI files from the preceding commit.

Optional new SQLite tables can remain safely after rollback because the prior application ignores unknown tables.

Known bad symptoms reviewers should watch for:

Unexpected invalid trust state caused by a future signature-verifier adapter passing an incorrect result.

SQLite write errors if the Inbox database path is read-only.

Verify-panel trust/history requests returning unavailable state if the Inbox API is unreachable.

Risks and Mitigations
Risk: A future webhook canonical-signature adapter could pass an incorrect verification result.

Mitigation: The trust layer accepts the verification result as an explicit server-side parameter and does not read a client/webhook JSON signature_valid claim.

Risk: Replay retention growth can increase local SQLite size under high traffic.

Mitigation: Replay entries are pruned during claims according to BINDU_REPLAY_RETENTION_SECONDS; the retention period is configurable.

Risk: Operators may expect the vertical slice to verify webhook signatures end-to-end immediately.

Mitigation: The implementation and documentation explicitly state that the canonical verifier adapter is a follow-up; discovery remains unknown by default.

Checklist
 Tests pass (uv run pytest) — Not run; this PR changes the standalone Inbox TypeScript application.

 Pre-commit hooks pass (uv run pre-commit run --all-files) — Not run.

 Documentation updated (if needed)

 Security impact assessed

 Human verification completed — Automated local verification completed; browser/live-agent verification remains outstanding.

 Backward compatibility considered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added peer trust verification for inbound messages, including signature, timestamp, and replay checks.
  - Added trust status badges showing verified, unknown, invalid, changed, blocked, or unavailable states.
  - Added verification history with acceptance or rejection details and timestamps.
  - Added controls and API support for blocking or unblocking peers.

- **Documentation**
  - Documented trust verification behavior and configurable clock-skew and replay-retention settings.

- **Tests**
  - Added coverage for successful verification, failed or stale signatures, replayed messages, and blocked peers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->